### PR TITLE
[DABOM-341] DB Redis 정합 배치 로직 개발(락, info/remaining 키 제거 step)

### DIFF
--- a/src/main/java/com/template/worker/global/util/RedisKeyGenerator.java
+++ b/src/main/java/com/template/worker/global/util/RedisKeyGenerator.java
@@ -13,6 +13,7 @@ public class RedisKeyGenerator {
     private static final String ALERT_KEY = "alert";
     private static final String THRESHOLD_KEY = "THRESHOLD";
     private static final String REMAINING_KEY = "remaining";
+    private static final String INFO_KEY = "info";
     private static final String USAGE_KEY = "usage";
     private static final String MONTHLY_KEY = "monthly";
     private static final DateTimeFormatter MONTH_SUFFIX_FORMATTER =
@@ -20,6 +21,10 @@ public class RedisKeyGenerator {
 
     public String familyRemainingKey(Long familyId) {
         return FAMILY_PREFIX + KEY_SEPARATOR + familyId + KEY_SEPARATOR + REMAINING_KEY;
+    }
+
+    public String familyInfoKey(Long familyId) {
+        return FAMILY_PREFIX + KEY_SEPARATOR + familyId + KEY_SEPARATOR + INFO_KEY;
     }
 
     public String familyAlertThresholdKey(Long familyId, int threshold) {

--- a/src/main/java/com/template/worker/jobs/common/reader/ActiveFamilyCursorReader.java
+++ b/src/main/java/com/template/worker/jobs/common/reader/ActiveFamilyCursorReader.java
@@ -1,0 +1,65 @@
+package com.template.worker.jobs.common.reader;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.IntSupplier;
+
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class ActiveFamilyCursorReader implements ItemReader<Long>, StepExecutionListener {
+
+    private static final String READ_ACTIVE_FAMILY_SQL =
+            """
+            SELECT id
+            FROM family
+            WHERE deleted_at IS NULL
+              AND id > ?
+            ORDER BY id ASC
+            LIMIT ?
+            """;
+
+    private final JdbcTemplate jdbcTemplate;
+    private final IntSupplier dbFetchSizeSupplier;
+
+    private Iterator<Long> currentBatch = Collections.emptyIterator();
+    private long lastFamilyId = 0L;
+
+    public ActiveFamilyCursorReader(JdbcTemplate jdbcTemplate, IntSupplier dbFetchSizeSupplier) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.dbFetchSizeSupplier = dbFetchSizeSupplier;
+    }
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        // Step 재실행 시 상태 누수를 막기 위해 커서를 초기화함
+        currentBatch = Collections.emptyIterator();
+        lastFamilyId = 0L;
+    }
+
+    @Override
+    public Long read() {
+        while (!currentBatch.hasNext()) {
+            // PK 커서 기반으로 배치 단위 조회를 수행함
+            List<Long> familyIds =
+                    jdbcTemplate.query(
+                            READ_ACTIVE_FAMILY_SQL,
+                            (resultSet, rowNum) -> resultSet.getLong("id"),
+                            lastFamilyId,
+                            dbFetchSizeSupplier.getAsInt());
+
+            // 더 이상 데이터가 없으면 null을 반환해 Chunk 처리를 종료함
+            if (familyIds.isEmpty()) {
+                return null;
+            }
+
+            lastFamilyId = familyIds.get(familyIds.size() - 1);
+            currentBatch = familyIds.iterator();
+        }
+
+        return currentBatch.next();
+    }
+}

--- a/src/main/java/com/template/worker/jobs/common/support/BatchLockManager.java
+++ b/src/main/java/com/template/worker/jobs/common/support/BatchLockManager.java
@@ -1,0 +1,48 @@
+package com.template.worker.jobs.common.support;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class BatchLockManager {
+
+    private static final DefaultRedisScript<Long> LOCK_RELEASE_SCRIPT = buildLockReleaseScript();
+
+    private final StringRedisTemplate redisTemplate;
+
+    public boolean tryAcquire(String lockKey, String lockOwner, Duration ttl) {
+        // SET NX EX 동작으로 단일 실행 락을 획득함
+        Boolean acquired = redisTemplate.opsForValue().setIfAbsent(lockKey, lockOwner, ttl);
+        return Boolean.TRUE.equals(acquired);
+    }
+
+    public boolean releaseIfOwner(String lockKey, String lockOwner) {
+        if (lockKey == null || lockOwner == null) {
+            return false;
+        }
+
+        // Lua로 소유자 확인 후 삭제해 안전하게 락을 해제함
+        Long released =
+                redisTemplate.execute(
+                        LOCK_RELEASE_SCRIPT, Collections.singletonList(lockKey), lockOwner);
+        return released != null && released > 0;
+    }
+
+    private static DefaultRedisScript<Long> buildLockReleaseScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setResultType(Long.class);
+        // 락 해제 원자성을 보장하기 위해 GET+DEL을 Lua로 묶음
+        // 내가 잡은 락이면 지우고 아니면 지우지 않기
+        script.setScriptText(
+                "if redis.call('GET', KEYS[1]) == ARGV[1] "
+                        + "then return redis.call('DEL', KEYS[1]) else return 0 end");
+        return script;
+    }
+}

--- a/src/main/java/com/template/worker/jobs/common/support/TargetMonthLockKeyGenerator.java
+++ b/src/main/java/com/template/worker/jobs/common/support/TargetMonthLockKeyGenerator.java
@@ -1,0 +1,14 @@
+package com.template.worker.jobs.common.support;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class TargetMonthLockKeyGenerator {
+
+    public String targetMonthLockKey(String lockPrefix, LocalDate targetMonth) {
+        // 월별 단일 실행 보장을 위해 targetMonth를 락 키에 포함함
+        return lockPrefix + ":" + targetMonth;
+    }
+}

--- a/src/main/java/com/template/worker/jobs/common/support/TargetMonthParameterSupport.java
+++ b/src/main/java/com/template/worker/jobs/common/support/TargetMonthParameterSupport.java
@@ -1,0 +1,50 @@
+package com.template.worker.jobs.common.support;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Objects;
+
+import org.springframework.batch.core.JobParameters;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TargetMonthParameterSupport {
+
+    public LocalDate resolveTargetMonth(
+            JobParameters jobParameters, String parameterName, ZoneId zoneId) {
+        // 파라미터 객체가 없으면 해당 타임존의 현재 월 1일을 기본값으로 사용함
+        if (jobParameters == null) {
+            return defaultTargetMonth(zoneId);
+        }
+
+        String targetMonth = jobParameters.getString(parameterName);
+        return resolveTargetMonth(targetMonth, zoneId);
+    }
+
+    public LocalDate resolveTargetMonth(String targetMonth, ZoneId zoneId) {
+        // targetMonth 미지정 시 해당 타임존의 현재 월 1일을 기본값으로 사용함
+        if (targetMonth == null || targetMonth.isBlank()) {
+            return defaultTargetMonth(zoneId);
+        }
+
+        try {
+            // yyyy-MM-01 형식을 강제해 운영 파라미터 오류를 조기 차단함
+            LocalDate parsedTargetMonth = LocalDate.parse(targetMonth);
+            if (parsedTargetMonth.getDayOfMonth() != 1) {
+                throw new IllegalArgumentException(
+                        "targetMonth must be first day of month. expected yyyy-MM-01");
+            }
+            return parsedTargetMonth;
+        } catch (DateTimeParseException exception) {
+            throw new IllegalArgumentException(
+                    "Invalid targetMonth format. expected yyyy-MM-01", exception);
+        }
+    }
+
+    private LocalDate defaultTargetMonth(ZoneId zoneId) {
+        ZoneId targetZone = Objects.requireNonNull(zoneId);
+        return ZonedDateTime.now(targetZone).toLocalDate().withDayOfMonth(1);
+    }
+}

--- a/src/main/java/com/template/worker/jobs/common/tasklet/AbstractLockReleaseTasklet.java
+++ b/src/main/java/com/template/worker/jobs/common/tasklet/AbstractLockReleaseTasklet.java
@@ -1,0 +1,46 @@
+package com.template.worker.jobs.common.tasklet;
+
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.repeat.RepeatStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class AbstractLockReleaseTasklet implements Tasklet, StepExecutionListener {
+
+    private String lockKey;
+    private String lockOwner;
+    private ExecutionContext jobContext;
+
+    @Override
+    public final void beforeStep(StepExecution stepExecution) {
+        // 락 해제 스텝에서 사용할 키와 소유자를 컨텍스트에서 복원함
+        jobContext = stepExecution.getJobExecution().getExecutionContext();
+        lockKey = jobContext.getString(lockKeyContextName(), null);
+        lockOwner = jobContext.getString(lockOwnerContextName(), null);
+    }
+
+    @Override
+    public final RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        // 소유자 일치 시에만 락을 삭제해 타 인스턴스 락 손상을 방지함
+        boolean released = releaseIfOwner(lockKey, lockOwner);
+        onLockReleased(jobContext, released);
+        log.info("Release {} lock. lockKey={}, released={}", lockLogName(), lockKey, released);
+        return RepeatStatus.FINISHED;
+    }
+
+    protected abstract boolean releaseIfOwner(String lockKey, String lockOwner);
+
+    protected abstract String lockLogName();
+
+    protected abstract String lockKeyContextName();
+
+    protected abstract String lockOwnerContextName();
+
+    protected void onLockReleased(ExecutionContext jobContext, boolean released) {}
+}

--- a/src/main/java/com/template/worker/jobs/common/tasklet/AbstractTargetMonthLockTasklet.java
+++ b/src/main/java/com/template/worker/jobs/common/tasklet/AbstractTargetMonthLockTasklet.java
@@ -1,0 +1,83 @@
+package com.template.worker.jobs.common.tasklet;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.repeat.RepeatStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class AbstractTargetMonthLockTasklet implements Tasklet, StepExecutionListener {
+
+    private String lockKey;
+    private String lockOwner;
+    private LocalDate targetMonth;
+    private ExecutionContext jobContext;
+
+    @Override
+    public final void beforeStep(StepExecution stepExecution) {
+        // targetMonth 기준으로 락 키와 소유자 값을 준비함
+        targetMonth = resolveTargetMonth(stepExecution.getJobParameters());
+        lockKey = generateLockKey(targetMonth);
+        lockOwner = UUID.randomUUID().toString();
+
+        // 후속 스텝/리스너에서 재사용할 값을 JobExecutionContext에 저장함
+        jobContext = stepExecution.getJobExecution().getExecutionContext();
+        initializeJobContext(jobContext, targetMonth, lockKey, lockOwner);
+    }
+
+    @Override
+    public final RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        boolean lockAcquired = tryAcquire(lockKey, lockOwner, lockTtl());
+
+        // 락 미획득 시 중복 실행을 피하기 위해 별도 종료 코드를 설정함
+        if (!lockAcquired) {
+            contribution.setExitStatus(new ExitStatus(lockNotAcquiredExitStatus()));
+            onLockNotAcquired(jobContext);
+            log.info(
+                    "Skip {} job execution because lock is already held. lockKey={}, targetMonth={}",
+                    lockLogName(),
+                    lockKey,
+                    targetMonth);
+            return RepeatStatus.FINISHED;
+        }
+
+        // 락 획득 성공 시 다음 스텝 진행을 허용함
+        onLockAcquired(jobContext);
+        log.info(
+                "Acquired {} lock. lockKey={}, targetMonth={}",
+                lockLogName(),
+                lockKey,
+                targetMonth);
+        return RepeatStatus.FINISHED;
+    }
+
+    protected abstract LocalDate resolveTargetMonth(JobParameters jobParameters);
+
+    protected abstract String generateLockKey(LocalDate targetMonth);
+
+    protected abstract boolean tryAcquire(String lockKey, String lockOwner, Duration ttl);
+
+    protected abstract Duration lockTtl();
+
+    protected abstract String lockNotAcquiredExitStatus();
+
+    protected abstract String lockLogName();
+
+    protected abstract void initializeJobContext(
+            ExecutionContext jobContext, LocalDate targetMonth, String lockKey, String lockOwner);
+
+    protected void onLockAcquired(ExecutionContext jobContext) {}
+
+    protected void onLockNotAcquired(ExecutionContext jobContext) {}
+}

--- a/src/main/java/com/template/worker/jobs/common/tasklet/AbstractTargetMonthLockTasklet.java
+++ b/src/main/java/com/template/worker/jobs/common/tasklet/AbstractTargetMonthLockTasklet.java
@@ -45,7 +45,8 @@ public abstract class AbstractTargetMonthLockTasklet implements Tasklet, StepExe
             contribution.setExitStatus(new ExitStatus(lockNotAcquiredExitStatus()));
             onLockNotAcquired(jobContext);
             log.info(
-                    "Skip {} job execution because lock is already held. lockKey={}, targetMonth={}",
+                    "Skip {} job execution because lock is already held. lockKey={},"
+                            + " targetMonth={}",
                     lockLogName(),
                     lockKey,
                     targetMonth);

--- a/src/main/java/com/template/worker/jobs/reconciliation/job/DbRedisReconciliationJobConfig.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/job/DbRedisReconciliationJobConfig.java
@@ -1,0 +1,49 @@
+package com.template.worker.jobs.reconciliation.job;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.template.worker.global.listener.JobResultListener;
+import com.template.worker.jobs.reconciliation.step.AcquireReconciliationLockStepConfig;
+import com.template.worker.jobs.reconciliation.step.InvalidateFamilyInfoAndRemainingStepConfig;
+import com.template.worker.jobs.reconciliation.step.ReleaseReconciliationLockStepConfig;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class DbRedisReconciliationJobConfig {
+
+    private final JobRepository jobRepository;
+    private final JobResultListener jobResultListener;
+    private final AcquireReconciliationLockStepConfig acquireReconciliationLockStepConfig;
+    private final InvalidateFamilyInfoAndRemainingStepConfig
+            invalidateFamilyInfoAndRemainingStepConfig;
+    private final ReleaseReconciliationLockStepConfig releaseReconciliationLockStepConfig;
+
+    @Bean
+    public Job dbRedisReconciliationJob() {
+        return new JobBuilder(DbRedisReconciliationJobConstants.JOB_NAME, jobRepository)
+                .listener(jobResultListener)
+                .start(acquireReconciliationLockStepConfig.acquireReconciliationLockStep())
+                // 락 미획득이면 정상 종료해 중복 실행을 방지함
+                .on(DbRedisReconciliationJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED)
+                .end()
+                .from(acquireReconciliationLockStepConfig.acquireReconciliationLockStep())
+                .on("FAILED")
+                .fail()
+                .from(acquireReconciliationLockStepConfig.acquireReconciliationLockStep())
+                // 락 획득 이후에만 Redis 키 무효화 스텝 체인을 수행함
+                .on("*")
+                .to(
+                        invalidateFamilyInfoAndRemainingStepConfig
+                                .invalidateFamilyInfoAndRemainingStep())
+                .next(releaseReconciliationLockStepConfig.releaseReconciliationLockStep())
+                .end()
+                .build();
+    }
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/reader/ReconciliationFamilyReader.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/reader/ReconciliationFamilyReader.java
@@ -1,0 +1,66 @@
+package com.template.worker.jobs.reconciliation.reader;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationProperties;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReconciliationFamilyReader implements ItemReader<Long>, StepExecutionListener {
+
+    private static final String READ_ACTIVE_FAMILY_SQL =
+            """
+            SELECT id
+            FROM family
+            WHERE deleted_at IS NULL
+              AND id > ?
+            ORDER BY id ASC
+            LIMIT ?
+            """;
+
+    private final JdbcTemplate jdbcTemplate;
+    private final DbRedisReconciliationProperties properties;
+
+    private Iterator<Long> currentBatch = Collections.emptyIterator();
+    private long lastFamilyId = 0L;
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        // Step 재실행 시 상태 누수를 막기 위해 커서를 초기화함
+        currentBatch = Collections.emptyIterator();
+        lastFamilyId = 0L;
+    }
+
+    @Override
+    public Long read() {
+        while (!currentBatch.hasNext()) {
+            // PK 커서 기반으로 배치 단위 조회를 수행함
+            List<Long> familyIds =
+                    jdbcTemplate.query(
+                            READ_ACTIVE_FAMILY_SQL,
+                            (resultSet, rowNum) -> resultSet.getLong("id"),
+                            lastFamilyId,
+                            properties.getDbFetchSize());
+
+            // 더 이상 데이터가 없으면 null을 반환해 Chunk 처리를 종료함
+            if (familyIds.isEmpty()) {
+                return null;
+            }
+
+            lastFamilyId = familyIds.get(familyIds.size() - 1);
+            currentBatch = familyIds.iterator();
+        }
+
+        return currentBatch.next();
+    }
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/reader/ReconciliationFamilyReader.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/reader/ReconciliationFamilyReader.java
@@ -1,66 +1,16 @@
 package com.template.worker.jobs.reconciliation.reader;
 
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.core.StepExecutionListener;
-import org.springframework.batch.item.ItemReader;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.jobs.common.reader.ActiveFamilyCursorReader;
 import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationProperties;
 
-import lombok.RequiredArgsConstructor;
-
 @Component
-@RequiredArgsConstructor
-public class ReconciliationFamilyReader implements ItemReader<Long>, StepExecutionListener {
+public class ReconciliationFamilyReader extends ActiveFamilyCursorReader {
 
-    private static final String READ_ACTIVE_FAMILY_SQL =
-            """
-            SELECT id
-            FROM family
-            WHERE deleted_at IS NULL
-              AND id > ?
-            ORDER BY id ASC
-            LIMIT ?
-            """;
-
-    private final JdbcTemplate jdbcTemplate;
-    private final DbRedisReconciliationProperties properties;
-
-    private Iterator<Long> currentBatch = Collections.emptyIterator();
-    private long lastFamilyId = 0L;
-
-    @Override
-    public void beforeStep(StepExecution stepExecution) {
-        // Step 재실행 시 상태 누수를 막기 위해 커서를 초기화함
-        currentBatch = Collections.emptyIterator();
-        lastFamilyId = 0L;
-    }
-
-    @Override
-    public Long read() {
-        while (!currentBatch.hasNext()) {
-            // PK 커서 기반으로 배치 단위 조회를 수행함
-            List<Long> familyIds =
-                    jdbcTemplate.query(
-                            READ_ACTIVE_FAMILY_SQL,
-                            (resultSet, rowNum) -> resultSet.getLong("id"),
-                            lastFamilyId,
-                            properties.getDbFetchSize());
-
-            // 더 이상 데이터가 없으면 null을 반환해 Chunk 처리를 종료함
-            if (familyIds.isEmpty()) {
-                return null;
-            }
-
-            lastFamilyId = familyIds.get(familyIds.size() - 1);
-            currentBatch = familyIds.iterator();
-        }
-
-        return currentBatch.next();
+    public ReconciliationFamilyReader(
+            JdbcTemplate jdbcTemplate, DbRedisReconciliationProperties properties) {
+        super(jdbcTemplate, properties::getDbFetchSize);
     }
 }

--- a/src/main/java/com/template/worker/jobs/reconciliation/scheduler/DbRedisReconciliationScheduler.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/scheduler/DbRedisReconciliationScheduler.java
@@ -1,0 +1,51 @@
+package com.template.worker.jobs.reconciliation.scheduler;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.global.launcher.BatchJobLauncher;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "batch.schedules.db-redis-reconciliation.enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+public class DbRedisReconciliationScheduler {
+
+    private final BatchJobLauncher launcher;
+
+    @Scheduled(
+            cron = "${batch.schedules.db-redis-reconciliation.cron:0 0 3 * * *}",
+            zone = DbRedisReconciliationJobConstants.KST_ZONE_ID_NAME)
+    public void runDbRedisReconciliationJob() {
+        Map<String, String> params = new HashMap<>();
+        // 스케줄 실행 시점의 KST 월 시작일을 targetMonth로 전달
+        String targetMonth =
+                ZonedDateTime.now(DbRedisReconciliationJobConstants.KST_ZONE_ID)
+                        .toLocalDate()
+                        .withDayOfMonth(1)
+                        .toString();
+        params.put(DbRedisReconciliationJobConstants.PARAM_TARGET_MONTH, targetMonth);
+
+        try {
+            launcher.run(DbRedisReconciliationJobConstants.JOB_NAME, params);
+        } catch (Exception exception) {
+            // 스케줄 실패가 다음 실행을 막지 않도록 예외를 로그로만 처리
+            log.error(
+                    "Failed to run DB-Redis reconciliation job by scheduler. targetMonth={}",
+                    targetMonth,
+                    exception);
+        }
+    }
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/step/AcquireReconciliationLockStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/step/AcquireReconciliationLockStepConfig.java
@@ -1,0 +1,32 @@
+package com.template.worker.jobs.reconciliation.step;
+
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
+import com.template.worker.jobs.reconciliation.tasklet.ReconciliationLockTasklet;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class AcquireReconciliationLockStepConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final ReconciliationLockTasklet tasklet;
+
+    @Bean
+    public Step acquireReconciliationLockStep() {
+        // 락 획득 Tasklet을 Step으로 연결
+        return new StepBuilder(
+                        DbRedisReconciliationJobConstants.STEP_ACQUIRE_RECONCILIATION_LOCK,
+                        jobRepository)
+                .tasklet(tasklet, transactionManager)
+                .build();
+    }
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/step/InvalidateFamilyInfoAndRemainingStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/step/InvalidateFamilyInfoAndRemainingStepConfig.java
@@ -1,0 +1,38 @@
+package com.template.worker.jobs.reconciliation.step;
+
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.template.worker.jobs.reconciliation.reader.ReconciliationFamilyReader;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationProperties;
+import com.template.worker.jobs.reconciliation.writer.ReconciliationFamilyKeyInvalidationWriter;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class InvalidateFamilyInfoAndRemainingStepConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final ReconciliationFamilyReader reader;
+    private final ReconciliationFamilyKeyInvalidationWriter writer;
+    private final DbRedisReconciliationProperties properties;
+
+    @Bean
+    public Step invalidateFamilyInfoAndRemainingStep() {
+        // family id reader + info/remaining invalidation writer의 Chunk Step 구성
+        return new StepBuilder(
+                        DbRedisReconciliationJobConstants.STEP_INVALIDATE_FAMILY_INFO_AND_REMAINING,
+                        jobRepository)
+                .<Long, Long>chunk(properties.getRedisChunkSize(), transactionManager)
+                .reader(reader)
+                .writer(writer)
+                .build();
+    }
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/step/ReleaseReconciliationLockStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/step/ReleaseReconciliationLockStepConfig.java
@@ -1,0 +1,32 @@
+package com.template.worker.jobs.reconciliation.step;
+
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
+import com.template.worker.jobs.reconciliation.tasklet.ReconciliationLockReleaseTasklet;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class ReleaseReconciliationLockStepConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final ReconciliationLockReleaseTasklet tasklet;
+
+    @Bean
+    public Step releaseReconciliationLockStep() {
+        // 마지막 락 해제 Tasklet Step 정의
+        return new StepBuilder(
+                        DbRedisReconciliationJobConstants.STEP_RELEASE_RECONCILIATION_LOCK,
+                        jobRepository)
+                .tasklet(tasklet, transactionManager)
+                .build();
+    }
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationJobConstants.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationJobConstants.java
@@ -1,0 +1,37 @@
+package com.template.worker.jobs.reconciliation.support;
+
+import java.time.ZoneId;
+
+public final class DbRedisReconciliationJobConstants {
+
+    public static final String KST_ZONE_ID_NAME = "Asia/Seoul";
+    public static final ZoneId KST_ZONE_ID = ZoneId.of(KST_ZONE_ID_NAME);
+
+    public static final String JOB_NAME = "db-redis-reconciliation-job";
+    public static final String PARAM_TARGET_MONTH = "targetMonth";
+
+    public static final String STEP_ACQUIRE_RECONCILIATION_LOCK =
+            "acquire-reconciliation-lock-step";
+    public static final String STEP_INVALIDATE_FAMILY_INFO_AND_REMAINING =
+            "invalidate-family-info-and-remaining-step";
+    public static final String STEP_RELEASE_RECONCILIATION_LOCK =
+            "release-reconciliation-lock-step";
+
+    public static final String EXIT_STATUS_LOCK_NOT_ACQUIRED = "LOCK_NOT_ACQUIRED";
+
+    public static final String JOB_CONTEXT_TARGET_MONTH = "targetMonth";
+    public static final String JOB_CONTEXT_LOCK_KEY = "lockKey";
+    public static final String JOB_CONTEXT_LOCK_OWNER = "lockOwner";
+    public static final String JOB_CONTEXT_LOCK_STATUS = "lockStatus";
+    public static final String JOB_CONTEXT_LOCK_RELEASED = "lockReleased";
+
+    public static final String LOCK_STATUS_ACQUIRED = "ACQUIRED";
+    public static final String LOCK_STATUS_NOT_ACQUIRED = "NOT_ACQUIRED";
+
+    // StepExecutionContext 요약 집계 키
+    public static final String STEP_CONTEXT_DELETED_FAMILY_INFO_COUNT = "deletedFamilyInfoCount";
+    public static final String STEP_CONTEXT_DELETED_FAMILY_REMAINING_COUNT =
+            "deletedFamilyRemainingCount";
+
+    private DbRedisReconciliationJobConstants() {}
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationJobParameterSupport.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationJobParameterSupport.java
@@ -1,0 +1,29 @@
+package com.template.worker.jobs.reconciliation.support;
+
+import java.time.LocalDate;
+
+import org.springframework.batch.core.JobParameters;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.common.support.TargetMonthParameterSupport;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DbRedisReconciliationJobParameterSupport {
+
+    private final TargetMonthParameterSupport targetMonthParameterSupport;
+
+    public LocalDate resolveTargetMonth(JobParameters jobParameters) {
+        return targetMonthParameterSupport.resolveTargetMonth(
+                jobParameters,
+                DbRedisReconciliationJobConstants.PARAM_TARGET_MONTH,
+                DbRedisReconciliationJobConstants.KST_ZONE_ID);
+    }
+
+    public LocalDate resolveTargetMonth(String targetMonth) {
+        return targetMonthParameterSupport.resolveTargetMonth(
+                targetMonth, DbRedisReconciliationJobConstants.KST_ZONE_ID);
+    }
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationLockKeyGenerator.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationLockKeyGenerator.java
@@ -1,0 +1,21 @@
+package com.template.worker.jobs.reconciliation.support;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.common.support.TargetMonthLockKeyGenerator;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DbRedisReconciliationLockKeyGenerator {
+
+    private static final String BATCH_LOCK_PREFIX = "batch:lock:reconciliation";
+    private final TargetMonthLockKeyGenerator targetMonthLockKeyGenerator;
+
+    public String reconciliationLockKey(LocalDate targetMonth) {
+        return targetMonthLockKeyGenerator.targetMonthLockKey(BATCH_LOCK_PREFIX, targetMonth);
+    }
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationLockManager.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationLockManager.java
@@ -1,0 +1,24 @@
+package com.template.worker.jobs.reconciliation.support;
+
+import java.time.Duration;
+
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.common.support.BatchLockManager;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DbRedisReconciliationLockManager {
+
+    private final BatchLockManager batchLockManager;
+
+    public boolean tryAcquire(String lockKey, String lockOwner, Duration ttl) {
+        return batchLockManager.tryAcquire(lockKey, lockOwner, ttl);
+    }
+
+    public boolean releaseIfOwner(String lockKey, String lockOwner) {
+        return batchLockManager.releaseIfOwner(lockKey, lockOwner);
+    }
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationProperties.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationProperties.java
@@ -1,0 +1,31 @@
+package com.template.worker.jobs.reconciliation.support;
+
+import java.time.Duration;
+
+import jakarta.validation.constraints.Min;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Validated
+@Component
+@ConfigurationProperties(prefix = "batch.jobs.db-redis-reconciliation")
+public class DbRedisReconciliationProperties {
+
+    // 분산 락 TTL. 스텝 체인 최대 수행 시간을 고려해 설정함
+    private Duration lockTtl = Duration.ofHours(1);
+
+    // Redis DEL pipeline chunk 크기
+    @Min(1)
+    private int redisChunkSize = 2000;
+
+    // PK cursor reader 조회 배치 크기
+    @Min(1)
+    private int dbFetchSize = 4000;
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/tasklet/ReconciliationLockReleaseTasklet.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/tasklet/ReconciliationLockReleaseTasklet.java
@@ -1,0 +1,50 @@
+package com.template.worker.jobs.reconciliation.tasklet;
+
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationLockManager;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReconciliationLockReleaseTasklet implements Tasklet, StepExecutionListener {
+
+    private final DbRedisReconciliationLockManager lockManager;
+
+    private String lockKey;
+    private String lockOwner;
+    private ExecutionContext jobContext;
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        // 락 해제 스텝에서 사용할 키와 소유자를 컨텍스트에서 복원함
+        jobContext = stepExecution.getJobExecution().getExecutionContext();
+        lockKey =
+                jobContext.getString(DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_KEY, null);
+        lockOwner =
+                jobContext.getString(
+                        DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_OWNER, null);
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        // 소유자 일치 시에만 락을 삭제해 타 인스턴스 락 손상을 방지함
+        boolean released = lockManager.releaseIfOwner(lockKey, lockOwner);
+        jobContext.putString(
+                DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_RELEASED,
+                String.valueOf(released));
+        log.info("Release reconciliation lock. lockKey={}, released={}", lockKey, released);
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/tasklet/ReconciliationLockReleaseTasklet.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/tasklet/ReconciliationLockReleaseTasklet.java
@@ -1,50 +1,44 @@
 package com.template.worker.jobs.reconciliation.tasklet;
 
-import org.springframework.batch.core.StepContribution;
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.core.StepExecutionListener;
-import org.springframework.batch.core.scope.context.ChunkContext;
-import org.springframework.batch.core.step.tasklet.Tasklet;
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.jobs.common.tasklet.AbstractLockReleaseTasklet;
 import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
 import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationLockManager;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
-public class ReconciliationLockReleaseTasklet implements Tasklet, StepExecutionListener {
+public class ReconciliationLockReleaseTasklet extends AbstractLockReleaseTasklet {
 
     private final DbRedisReconciliationLockManager lockManager;
 
-    private String lockKey;
-    private String lockOwner;
-    private ExecutionContext jobContext;
-
     @Override
-    public void beforeStep(StepExecution stepExecution) {
-        // 락 해제 스텝에서 사용할 키와 소유자를 컨텍스트에서 복원함
-        jobContext = stepExecution.getJobExecution().getExecutionContext();
-        lockKey =
-                jobContext.getString(DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_KEY, null);
-        lockOwner =
-                jobContext.getString(
-                        DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_OWNER, null);
+    protected boolean releaseIfOwner(String lockKey, String lockOwner) {
+        return lockManager.releaseIfOwner(lockKey, lockOwner);
     }
 
     @Override
-    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
-        // 소유자 일치 시에만 락을 삭제해 타 인스턴스 락 손상을 방지함
-        boolean released = lockManager.releaseIfOwner(lockKey, lockOwner);
+    protected String lockLogName() {
+        return "reconciliation";
+    }
+
+    @Override
+    protected String lockKeyContextName() {
+        return DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_KEY;
+    }
+
+    @Override
+    protected String lockOwnerContextName() {
+        return DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_OWNER;
+    }
+
+    @Override
+    protected void onLockReleased(ExecutionContext jobContext, boolean released) {
         jobContext.putString(
                 DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_RELEASED,
                 String.valueOf(released));
-        log.info("Release reconciliation lock. lockKey={}, released={}", lockKey, released);
-        return RepeatStatus.FINISHED;
     }
 }

--- a/src/main/java/com/template/worker/jobs/reconciliation/tasklet/ReconciliationLockTasklet.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/tasklet/ReconciliationLockTasklet.java
@@ -1,0 +1,82 @@
+package com.template.worker.jobs.reconciliation.tasklet;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobParameterSupport;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationLockKeyGenerator;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationLockManager;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationProperties;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReconciliationLockTasklet implements Tasklet, StepExecutionListener {
+
+    private final DbRedisReconciliationLockManager lockManager;
+    private final DbRedisReconciliationJobParameterSupport parameterSupport;
+    private final DbRedisReconciliationProperties properties;
+    private final DbRedisReconciliationLockKeyGenerator lockKeyGenerator;
+
+    private String lockKey;
+    private String lockOwner;
+    private LocalDate targetMonth;
+    private ExecutionContext jobContext;
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        // targetMonth 기준으로 락 키와 소유자 값을 준비함
+        targetMonth = parameterSupport.resolveTargetMonth(stepExecution.getJobParameters());
+        lockKey = lockKeyGenerator.reconciliationLockKey(targetMonth);
+        lockOwner = UUID.randomUUID().toString();
+
+        // 후속 스텝/리스너에서 재사용할 값을 JobExecutionContext에 저장함
+        jobContext = stepExecution.getJobExecution().getExecutionContext();
+        jobContext.putString(
+                DbRedisReconciliationJobConstants.JOB_CONTEXT_TARGET_MONTH, targetMonth.toString());
+        jobContext.putString(DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_KEY, lockKey);
+        jobContext.putString(DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_OWNER, lockOwner);
+        jobContext.putString(
+                DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_STATUS,
+                DbRedisReconciliationJobConstants.LOCK_STATUS_NOT_ACQUIRED);
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        boolean lockAcquired = lockManager.tryAcquire(lockKey, lockOwner, properties.getLockTtl());
+
+        // 락 미획득 시 중복 실행을 피하기 위해 별도 종료 코드를 설정함
+        if (!lockAcquired) {
+            contribution.setExitStatus(
+                    new ExitStatus(
+                            DbRedisReconciliationJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED));
+            log.info(
+                    "Skip reconciliation job execution because lock is already held. lockKey={},"
+                            + " targetMonth={}",
+                    lockKey,
+                    targetMonth);
+            return RepeatStatus.FINISHED;
+        }
+
+        // 락 획득 성공 시 다음 스텝 진행을 허용함
+        jobContext.putString(
+                DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_STATUS,
+                DbRedisReconciliationJobConstants.LOCK_STATUS_ACQUIRED);
+        log.info("Acquired reconciliation lock. lockKey={}, targetMonth={}", lockKey, targetMonth);
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/tasklet/ReconciliationLockTasklet.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/tasklet/ReconciliationLockTasklet.java
@@ -1,18 +1,13 @@
 package com.template.worker.jobs.reconciliation.tasklet;
 
+import java.time.Duration;
 import java.time.LocalDate;
-import java.util.UUID;
 
-import org.springframework.batch.core.ExitStatus;
-import org.springframework.batch.core.StepContribution;
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.core.StepExecutionListener;
-import org.springframework.batch.core.scope.context.ChunkContext;
-import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.jobs.common.tasklet.AbstractTargetMonthLockTasklet;
 import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
 import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobParameterSupport;
 import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationLockKeyGenerator;
@@ -20,32 +15,49 @@ import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationLock
 import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationProperties;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
-public class ReconciliationLockTasklet implements Tasklet, StepExecutionListener {
+public class ReconciliationLockTasklet extends AbstractTargetMonthLockTasklet {
 
     private final DbRedisReconciliationLockManager lockManager;
     private final DbRedisReconciliationJobParameterSupport parameterSupport;
     private final DbRedisReconciliationProperties properties;
     private final DbRedisReconciliationLockKeyGenerator lockKeyGenerator;
 
-    private String lockKey;
-    private String lockOwner;
-    private LocalDate targetMonth;
-    private ExecutionContext jobContext;
+    @Override
+    protected LocalDate resolveTargetMonth(JobParameters jobParameters) {
+        return parameterSupport.resolveTargetMonth(jobParameters);
+    }
 
     @Override
-    public void beforeStep(StepExecution stepExecution) {
-        // targetMonth 기준으로 락 키와 소유자 값을 준비함
-        targetMonth = parameterSupport.resolveTargetMonth(stepExecution.getJobParameters());
-        lockKey = lockKeyGenerator.reconciliationLockKey(targetMonth);
-        lockOwner = UUID.randomUUID().toString();
+    protected String generateLockKey(LocalDate targetMonth) {
+        return lockKeyGenerator.reconciliationLockKey(targetMonth);
+    }
 
-        // 후속 스텝/리스너에서 재사용할 값을 JobExecutionContext에 저장함
-        jobContext = stepExecution.getJobExecution().getExecutionContext();
+    @Override
+    protected boolean tryAcquire(String lockKey, String lockOwner, Duration ttl) {
+        return lockManager.tryAcquire(lockKey, lockOwner, ttl);
+    }
+
+    @Override
+    protected Duration lockTtl() {
+        return properties.getLockTtl();
+    }
+
+    @Override
+    protected String lockNotAcquiredExitStatus() {
+        return DbRedisReconciliationJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED;
+    }
+
+    @Override
+    protected String lockLogName() {
+        return "reconciliation";
+    }
+
+    @Override
+    protected void initializeJobContext(
+            ExecutionContext jobContext, LocalDate targetMonth, String lockKey, String lockOwner) {
         jobContext.putString(
                 DbRedisReconciliationJobConstants.JOB_CONTEXT_TARGET_MONTH, targetMonth.toString());
         jobContext.putString(DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_KEY, lockKey);
@@ -56,27 +68,9 @@ public class ReconciliationLockTasklet implements Tasklet, StepExecutionListener
     }
 
     @Override
-    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
-        boolean lockAcquired = lockManager.tryAcquire(lockKey, lockOwner, properties.getLockTtl());
-
-        // 락 미획득 시 중복 실행을 피하기 위해 별도 종료 코드를 설정함
-        if (!lockAcquired) {
-            contribution.setExitStatus(
-                    new ExitStatus(
-                            DbRedisReconciliationJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED));
-            log.info(
-                    "Skip reconciliation job execution because lock is already held. lockKey={},"
-                            + " targetMonth={}",
-                    lockKey,
-                    targetMonth);
-            return RepeatStatus.FINISHED;
-        }
-
-        // 락 획득 성공 시 다음 스텝 진행을 허용함
+    protected void onLockAcquired(ExecutionContext jobContext) {
         jobContext.putString(
                 DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_STATUS,
                 DbRedisReconciliationJobConstants.LOCK_STATUS_ACQUIRED);
-        log.info("Acquired reconciliation lock. lockKey={}, targetMonth={}", lockKey, targetMonth);
-        return RepeatStatus.FINISHED;
     }
 }

--- a/src/main/java/com/template/worker/jobs/reconciliation/writer/ReconciliationFamilyKeyInvalidationWriter.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/writer/ReconciliationFamilyKeyInvalidationWriter.java
@@ -1,0 +1,93 @@
+package com.template.worker.jobs.reconciliation.writer;
+
+import java.util.List;
+
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.global.util.RedisKeyGenerator;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReconciliationFamilyKeyInvalidationWriter
+        implements ItemWriter<Long>, StepExecutionListener {
+
+    private final StringRedisTemplate redisTemplate;
+    private final RedisKeyGenerator keyGenerator;
+
+    private long deletedFamilyInfoCount;
+    private long deletedFamilyRemainingCount;
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        // Step 단위 집계를 위해 삭제 카운터를 초기화함
+        deletedFamilyInfoCount = 0L;
+        deletedFamilyRemainingCount = 0L;
+    }
+
+    @Override
+    public void write(Chunk<? extends Long> chunk) {
+        if (chunk.isEmpty()) {
+            return;
+        }
+
+        // Redis 라운드트립을 줄이기 위해 파이프라인으로 일괄 삭제함
+        List<Object> results =
+                redisTemplate.executePipelined(
+                        (RedisCallback<Object>)
+                                connection -> {
+                                    StringRedisConnection redisConnection =
+                                            (StringRedisConnection) connection;
+                                    for (Long familyId : chunk) {
+                                        redisConnection.del(keyGenerator.familyInfoKey(familyId));
+                                        redisConnection.del(
+                                                keyGenerator.familyRemainingKey(familyId));
+                                    }
+                                    return null;
+                                });
+
+        for (int index = 0; index < results.size(); index++) {
+            long deletedCount = resolveDeletedCount(results.get(index));
+            // 파이프라인 결과 순서(info -> remaining)에 맞춰 삭제 건수를 분리 집계함
+            if (index % 2 == 0) {
+                deletedFamilyInfoCount += deletedCount;
+            } else {
+                deletedFamilyRemainingCount += deletedCount;
+            }
+        }
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        // afterJob 요약 로그에서 사용할 수 있도록 StepExecutionContext에 누적값을 기록함
+        stepExecution
+                .getExecutionContext()
+                .putLong(
+                        DbRedisReconciliationJobConstants.STEP_CONTEXT_DELETED_FAMILY_INFO_COUNT,
+                        deletedFamilyInfoCount);
+        stepExecution
+                .getExecutionContext()
+                .putLong(
+                        DbRedisReconciliationJobConstants
+                                .STEP_CONTEXT_DELETED_FAMILY_REMAINING_COUNT,
+                        deletedFamilyRemainingCount);
+        return null;
+    }
+
+    private long resolveDeletedCount(Object rawResult) {
+        if (rawResult instanceof Number number) {
+            return number.longValue();
+        }
+        return 0L;
+    }
+}

--- a/src/main/java/com/template/worker/jobs/usagereset/reader/ActiveFamilyReader.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/reader/ActiveFamilyReader.java
@@ -1,66 +1,15 @@
 package com.template.worker.jobs.usagereset.reader;
 
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.core.StepExecutionListener;
-import org.springframework.batch.item.ItemReader;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.jobs.common.reader.ActiveFamilyCursorReader;
 import com.template.worker.jobs.usagereset.support.MonthlyUsageResetProperties;
 
-import lombok.RequiredArgsConstructor;
-
 @Component
-@RequiredArgsConstructor
-public class ActiveFamilyReader implements ItemReader<Long>, StepExecutionListener {
+public class ActiveFamilyReader extends ActiveFamilyCursorReader {
 
-    private static final String READ_ACTIVE_FAMILY_SQL =
-            """
-            SELECT id
-            FROM family
-            WHERE deleted_at IS NULL
-              AND id > ?
-            ORDER BY id ASC
-            LIMIT ?
-            """;
-
-    private final JdbcTemplate jdbcTemplate;
-    private final MonthlyUsageResetProperties properties;
-
-    private Iterator<Long> currentBatch = Collections.emptyIterator();
-    private long lastFamilyId = 0L;
-
-    @Override
-    public void beforeStep(StepExecution stepExecution) {
-        // Step 재실행 시 상태 누수를 막기 위해 커서를 초기화함
-        currentBatch = Collections.emptyIterator();
-        lastFamilyId = 0L;
-    }
-
-    @Override
-    public Long read() {
-        while (!currentBatch.hasNext()) {
-            // PK 커서 기반으로 배치 단위 조회를 수행함
-            List<Long> familyIds =
-                    jdbcTemplate.query(
-                            READ_ACTIVE_FAMILY_SQL,
-                            (resultSet, rowNum) -> resultSet.getLong("id"),
-                            lastFamilyId,
-                            properties.getDbFetchSize());
-
-            // 더 이상 데이터가 없으면 null을 반환해 Chunk 처리를 종료함
-            if (familyIds.isEmpty()) {
-                return null;
-            }
-
-            lastFamilyId = familyIds.get(familyIds.size() - 1);
-            currentBatch = familyIds.iterator();
-        }
-
-        return currentBatch.next();
+    public ActiveFamilyReader(JdbcTemplate jdbcTemplate, MonthlyUsageResetProperties properties) {
+        super(jdbcTemplate, properties::getDbFetchSize);
     }
 }

--- a/src/main/java/com/template/worker/jobs/usagereset/support/MonthlyResetLockManager.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/support/MonthlyResetLockManager.java
@@ -1,11 +1,10 @@
 package com.template.worker.jobs.usagereset.support;
 
 import java.time.Duration;
-import java.util.Collections;
 
-import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.common.support.BatchLockManager;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,36 +12,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MonthlyResetLockManager {
 
-    private static final DefaultRedisScript<Long> LOCK_RELEASE_SCRIPT = buildLockReleaseScript();
-
-    private final StringRedisTemplate redisTemplate;
+    private final BatchLockManager batchLockManager;
 
     public boolean tryAcquire(String lockKey, String lockOwner, Duration ttl) {
-        // SET NX EX 동작으로 단일 실행 락을 획득함
-        Boolean acquired = redisTemplate.opsForValue().setIfAbsent(lockKey, lockOwner, ttl);
-        return Boolean.TRUE.equals(acquired);
+        return batchLockManager.tryAcquire(lockKey, lockOwner, ttl);
     }
 
     public boolean releaseIfOwner(String lockKey, String lockOwner) {
-        if (lockKey == null || lockOwner == null) {
-            return false;
-        }
-
-        // Lua로 소유자 확인 후 삭제해 안전하게 락을 해제함
-        Long released =
-                redisTemplate.execute(
-                        LOCK_RELEASE_SCRIPT, Collections.singletonList(lockKey), lockOwner);
-        return released != null && released > 0;
-    }
-
-    private static DefaultRedisScript<Long> buildLockReleaseScript() {
-        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
-        script.setResultType(Long.class);
-        // 락 해제 원자성을 보장하기 위해 GET+DEL을 Lua로 묶음
-        // 내가 잡은 락이면 지우고 아니면 지우지 않기
-        script.setScriptText(
-                "if redis.call('GET', KEYS[1]) == ARGV[1] "
-                        + "then return redis.call('DEL', KEYS[1]) else return 0 end");
-        return script;
+        return batchLockManager.releaseIfOwner(lockKey, lockOwner);
     }
 }

--- a/src/main/java/com/template/worker/jobs/usagereset/support/MonthlyUsageResetJobParameterSupport.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/support/MonthlyUsageResetJobParameterSupport.java
@@ -1,44 +1,30 @@
 package com.template.worker.jobs.usagereset.support;
 
 import java.time.LocalDate;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeParseException;
 
 import org.springframework.batch.core.JobParameters;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.jobs.common.support.TargetMonthParameterSupport;
+
+import lombok.RequiredArgsConstructor;
+
 @Component
+@RequiredArgsConstructor
 public class MonthlyUsageResetJobParameterSupport {
 
-    public LocalDate resolveTargetMonth(JobParameters jobParameters) {
-        // 파라미터 객체가 없으면 KST 현재 월 1일을 기본값으로 사용함
-        if (jobParameters == null) {
-            return defaultTargetMonth();
-        }
+    private final TargetMonthParameterSupport targetMonthParameterSupport;
 
-        String targetMonth =
-                jobParameters.getString(MonthlyUsageResetJobConstants.PARAM_TARGET_MONTH);
-        return resolveTargetMonth(targetMonth);
+    public LocalDate resolveTargetMonth(JobParameters jobParameters) {
+        return targetMonthParameterSupport.resolveTargetMonth(
+                jobParameters,
+                MonthlyUsageResetJobConstants.PARAM_TARGET_MONTH,
+                MonthlyUsageResetJobConstants.KST_ZONE_ID);
     }
 
     public LocalDate resolveTargetMonth(String targetMonth) {
-        // targetMonth 미지정 시 KST 현재 월 1일을 기본값으로 사용함
-        if (targetMonth == null || targetMonth.isBlank()) {
-            return defaultTargetMonth();
-        }
-
-        try {
-            // yyyy-MM-01 형식을 강제해 운영 파라미터 오류를 조기 차단함
-            LocalDate parsedTargetMonth = LocalDate.parse(targetMonth);
-            if (parsedTargetMonth.getDayOfMonth() != 1) {
-                throw new IllegalArgumentException(
-                        "targetMonth must be first day of month. expected yyyy-MM-01");
-            }
-            return parsedTargetMonth;
-        } catch (DateTimeParseException exception) {
-            throw new IllegalArgumentException(
-                    "Invalid targetMonth format. expected yyyy-MM-01", exception);
-        }
+        return targetMonthParameterSupport.resolveTargetMonth(
+                targetMonth, MonthlyUsageResetJobConstants.KST_ZONE_ID);
     }
 
     public long resolveNextMonthStartEpochSecond(LocalDate targetMonth) {
@@ -47,11 +33,5 @@ public class MonthlyUsageResetJobParameterSupport {
                 .plusMonths(1)
                 .atStartOfDay(MonthlyUsageResetJobConstants.KST_ZONE_ID)
                 .toEpochSecond();
-    }
-
-    private LocalDate defaultTargetMonth() {
-        return ZonedDateTime.now(MonthlyUsageResetJobConstants.KST_ZONE_ID)
-                .toLocalDate()
-                .withDayOfMonth(1);
     }
 }

--- a/src/main/java/com/template/worker/jobs/usagereset/support/MonthlyUsageResetLockKeyGenerator.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/support/MonthlyUsageResetLockKeyGenerator.java
@@ -4,12 +4,18 @@ import java.time.LocalDate;
 
 import org.springframework.stereotype.Component;
 
+import com.template.worker.jobs.common.support.TargetMonthLockKeyGenerator;
+
+import lombok.RequiredArgsConstructor;
+
 @Component
+@RequiredArgsConstructor
 public class MonthlyUsageResetLockKeyGenerator {
 
     private static final String BATCH_LOCK_PREFIX = "batch:lock:monthly-usage-reset";
+    private final TargetMonthLockKeyGenerator targetMonthLockKeyGenerator;
 
     public String monthlyResetLockKey(LocalDate targetMonth) {
-        return BATCH_LOCK_PREFIX + ":" + targetMonth;
+        return targetMonthLockKeyGenerator.targetMonthLockKey(BATCH_LOCK_PREFIX, targetMonth);
     }
 }

--- a/src/main/java/com/template/worker/jobs/usagereset/tasklet/MonthlyResetLockReleaseTasklet.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/tasklet/MonthlyResetLockReleaseTasklet.java
@@ -1,49 +1,36 @@
 package com.template.worker.jobs.usagereset.tasklet;
 
-import org.springframework.batch.core.StepContribution;
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.core.StepExecutionListener;
-import org.springframework.batch.core.scope.context.ChunkContext;
-import org.springframework.batch.core.step.tasklet.Tasklet;
-import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.jobs.common.tasklet.AbstractLockReleaseTasklet;
 import com.template.worker.jobs.usagereset.support.MonthlyResetLockManager;
 import com.template.worker.jobs.usagereset.support.MonthlyUsageResetJobConstants;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
-public class MonthlyResetLockReleaseTasklet implements Tasklet, StepExecutionListener {
+public class MonthlyResetLockReleaseTasklet extends AbstractLockReleaseTasklet {
 
     private final MonthlyResetLockManager monthlyResetLockManager;
 
-    private String lockKey;
-    private String lockOwner;
-
     @Override
-    public void beforeStep(StepExecution stepExecution) {
-        // 락 해제 스텝에서 사용할 키와 소유자를 컨텍스트에서 복원함
-        lockKey =
-                stepExecution
-                        .getJobExecution()
-                        .getExecutionContext()
-                        .getString(MonthlyUsageResetJobConstants.JOB_CONTEXT_LOCK_KEY, null);
-        lockOwner =
-                stepExecution
-                        .getJobExecution()
-                        .getExecutionContext()
-                        .getString(MonthlyUsageResetJobConstants.JOB_CONTEXT_LOCK_OWNER, null);
+    protected boolean releaseIfOwner(String lockKey, String lockOwner) {
+        return monthlyResetLockManager.releaseIfOwner(lockKey, lockOwner);
     }
 
     @Override
-    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
-        // 소유자 일치 시에만 락을 삭제해 타 인스턴스 락 손상을 방지함
-        boolean released = monthlyResetLockManager.releaseIfOwner(lockKey, lockOwner);
-        log.info("Release monthly usage reset lock. lockKey={}, released={}", lockKey, released);
-        return RepeatStatus.FINISHED;
+    protected String lockLogName() {
+        return "monthly usage reset";
+    }
+
+    @Override
+    protected String lockKeyContextName() {
+        return MonthlyUsageResetJobConstants.JOB_CONTEXT_LOCK_KEY;
+    }
+
+    @Override
+    protected String lockOwnerContextName() {
+        return MonthlyUsageResetJobConstants.JOB_CONTEXT_LOCK_OWNER;
     }
 }

--- a/src/main/java/com/template/worker/jobs/usagereset/tasklet/MonthlyResetLockTasklet.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/tasklet/MonthlyResetLockTasklet.java
@@ -1,18 +1,13 @@
 package com.template.worker.jobs.usagereset.tasklet;
 
+import java.time.Duration;
 import java.time.LocalDate;
-import java.util.UUID;
 
-import org.springframework.batch.core.ExitStatus;
-import org.springframework.batch.core.StepContribution;
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.core.StepExecutionListener;
-import org.springframework.batch.core.scope.context.ChunkContext;
-import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.item.ExecutionContext;
-import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.jobs.common.tasklet.AbstractTargetMonthLockTasklet;
 import com.template.worker.jobs.usagereset.support.MonthlyResetLockManager;
 import com.template.worker.jobs.usagereset.support.MonthlyUsageResetJobConstants;
 import com.template.worker.jobs.usagereset.support.MonthlyUsageResetJobParameterSupport;
@@ -20,58 +15,52 @@ import com.template.worker.jobs.usagereset.support.MonthlyUsageResetLockKeyGener
 import com.template.worker.jobs.usagereset.support.MonthlyUsageResetProperties;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
-public class MonthlyResetLockTasklet implements Tasklet, StepExecutionListener {
+public class MonthlyResetLockTasklet extends AbstractTargetMonthLockTasklet {
 
     private final MonthlyResetLockManager monthlyResetLockManager;
     private final MonthlyUsageResetJobParameterSupport parameterSupport;
     private final MonthlyUsageResetProperties properties;
     private final MonthlyUsageResetLockKeyGenerator lockKeyGenerator;
 
-    private String lockKey;
-    private String lockOwner;
-    private LocalDate targetMonth;
+    @Override
+    protected LocalDate resolveTargetMonth(JobParameters jobParameters) {
+        return parameterSupport.resolveTargetMonth(jobParameters);
+    }
 
     @Override
-    public void beforeStep(StepExecution stepExecution) {
-        // targetMonth 기준으로 락 키와 소유자 값을 준비함
-        targetMonth = parameterSupport.resolveTargetMonth(stepExecution.getJobParameters());
-        lockKey = lockKeyGenerator.monthlyResetLockKey(targetMonth);
-        lockOwner = UUID.randomUUID().toString();
+    protected String generateLockKey(LocalDate targetMonth) {
+        return lockKeyGenerator.monthlyResetLockKey(targetMonth);
+    }
 
-        // 후속 스텝과 리스너에서 재사용할 값을 JobExecutionContext에 저장함
-        ExecutionContext jobContext = stepExecution.getJobExecution().getExecutionContext();
+    @Override
+    protected boolean tryAcquire(String lockKey, String lockOwner, Duration ttl) {
+        return monthlyResetLockManager.tryAcquire(lockKey, lockOwner, ttl);
+    }
+
+    @Override
+    protected Duration lockTtl() {
+        return properties.getLockTtl();
+    }
+
+    @Override
+    protected String lockNotAcquiredExitStatus() {
+        return MonthlyUsageResetJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED;
+    }
+
+    @Override
+    protected String lockLogName() {
+        return "monthly usage reset";
+    }
+
+    @Override
+    protected void initializeJobContext(
+            ExecutionContext jobContext, LocalDate targetMonth, String lockKey, String lockOwner) {
         jobContext.putString(
                 MonthlyUsageResetJobConstants.JOB_CONTEXT_TARGET_MONTH, targetMonth.toString());
         jobContext.putString(MonthlyUsageResetJobConstants.JOB_CONTEXT_LOCK_KEY, lockKey);
         jobContext.putString(MonthlyUsageResetJobConstants.JOB_CONTEXT_LOCK_OWNER, lockOwner);
-    }
-
-    @Override
-    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
-        boolean lockAcquired =
-                monthlyResetLockManager.tryAcquire(lockKey, lockOwner, properties.getLockTtl());
-
-        // 락 미획득 시 중복 실행을 피하기 위해 별도 종료 코드를 설정함
-        if (!lockAcquired) {
-            contribution.setExitStatus(
-                    new ExitStatus(MonthlyUsageResetJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED));
-            log.info(
-                    "Skip job execution because lock is already held. lockKey={}, targetMonth={}",
-                    lockKey,
-                    targetMonth);
-            return RepeatStatus.FINISHED;
-        }
-
-        // 락 획득 성공 시 다음 스텝 진행을 허용함
-        log.info(
-                "Acquired monthly usage reset lock. lockKey={}, targetMonth={}",
-                lockKey,
-                targetMonth);
-        return RepeatStatus.FINISHED;
     }
 }

--- a/src/main/resources/batch.yml
+++ b/src/main/resources/batch.yml
@@ -11,8 +11,15 @@ batch:
     monthly-usage-reset:
       enabled: ${BATCH_MONTHLY_USAGE_RESET_ENABLED:false}
       cron: ${BATCH_MONTHLY_USAGE_RESET_CRON:0 1 0 1 * *}
+    db-redis-reconciliation:
+      enabled: ${BATCH_DB_REDIS_RECONCILIATION_ENABLED:false}
+      cron: ${BATCH_DB_REDIS_RECONCILIATION_CRON:0 0 3 * * *}
   jobs:
     monthly-usage-reset:
       lock-ttl: ${BATCH_MONTHLY_USAGE_RESET_LOCK_TTL:PT1H}
       redis-chunk-size: ${BATCH_MONTHLY_USAGE_RESET_REDIS_CHUNK_SIZE:2000}
       db-fetch-size: ${BATCH_MONTHLY_USAGE_RESET_DB_FETCH_SIZE:4000}
+    db-redis-reconciliation:
+      lock-ttl: ${BATCH_DB_REDIS_RECONCILIATION_LOCK_TTL:PT1H}
+      redis-chunk-size: ${BATCH_DB_REDIS_RECONCILIATION_REDIS_CHUNK_SIZE:2000}
+      db-fetch-size: ${BATCH_DB_REDIS_RECONCILIATION_DB_FETCH_SIZE:4000}

--- a/src/test/java/com/template/worker/jobs/usagereset/support/MonthlyUsageResetJobParameterSupportTest.java
+++ b/src/test/java/com/template/worker/jobs/usagereset/support/MonthlyUsageResetJobParameterSupportTest.java
@@ -11,10 +11,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 
+import com.template.worker.jobs.common.support.TargetMonthParameterSupport;
+
 class MonthlyUsageResetJobParameterSupportTest {
 
     private final MonthlyUsageResetJobParameterSupport support =
-            new MonthlyUsageResetJobParameterSupport();
+            new MonthlyUsageResetJobParameterSupport(new TargetMonthParameterSupport());
 
     @Test
     @DisplayName("resolveTargetMonth - targetMonth 파라미터가 있으면 해당 값을 반환한다")


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #3 
- jira: DABOM-341

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
`dabom-batch-core`에서 DB/Redis 정합성 배치의 1차 완료 범위만 반영해, 운영에서 안전하게 실행 가능한 기본 플로우(락 획득 → family 키 무효화 → 락 해제)를 구축한다.

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->

- `jobs/common` 공통 모듈 추가
  - `BatchLockManager` 추가 (SET NX EX + owner 검증 해제 공통화)
  - `TargetMonthParameterSupport` 추가 (`targetMonth` 파싱/기본값 공통화)
  - `TargetMonthLockKeyGenerator` 추가 (월 기준 락 키 생성 공통화)
  - `usagereset` support를 `jobs/common` 기반으로 리팩토링
  - 가족 `reader`, 락 획득/해제 `tasklet` 공통화
- `dbRedisReconciliationJob` 1차 구현
- `acquireReconciliationLockStep` / `invalidateFamilyInfoAndRemainingStep` / `releaseReconciliationLockStep` 구성
- `ReconciliationFamilyReader` 및 `ReconciliationFamilyKeyInvalidationWriter` 구현
- `DbRedisReconciliationScheduler` 추가 (기본 cron: 매일 03:00 KST, enabled는 환경변수로 제어)
- `batch.yml`에 reconciliation 스케줄/잡 프로퍼티 추가
- `RedisKeyGenerator`에 `familyInfoKey` 추가

## 📂 변경 범위

<!-- 변경된 레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

|                    Job                     | api (controller/service/dto) | job config | step config | reader | processor | writer | global(config/launcher/listener) |
| :----------------------------------------: | :--------------------------: | :--------: | :---------: | :----: | :-------: | :----: | :------------------------------: |
|          dbRedisReconciliationJob          |                              |    [x]     |     [x]     |  [x]   |           |  [x]   |               [x]                |
| monthly-usage-reset-job (support refactor) |                              |            |             |        |           |        |               [x]                |
---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```java
return new JobBuilder(DbRedisReconciliationJobConstants.JOB_NAME, jobRepository)
        .listener(jobResultListener)
        .start(acquireReconciliationLockStepConfig.acquireReconciliationLockStep())
        .on(DbRedisReconciliationJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED)
        .end()
        .from(acquireReconciliationLockStepConfig.acquireReconciliationLockStep())
        .on("*")
        .to(invalidateFamilyInfoAndRemainingStepConfig.invalidateFamilyInfoAndRemainingStep())
        .next(releaseReconciliationLockStepConfig.releaseReconciliationLockStep())
        .end()
        .build();
```

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- customer monthly usage invalidation, afterJob summary listener, reconciliation 테스트는 후속 PR에서 완성 예정입니다.
---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [ ] 전체 변경사항이 500줄을 넘지 않는가?

**배치 코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → BatchJobLauncher → Job → Step → Reader/Processor/Writer`)
- [x] 모든 Job에 `JobResultListener`를 등록했는가?
- [x] Reader/Processor/Writer가 각각 단일 책임만 수행하는가?
- [x] Job/Step 이름이 kebab-case인가?
- [x] 하나의 Config 파일에 하나의 Job/Step만 정의했는가?

**테스트**
- [ ] 신규 배치 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
