### PR TITLE
[DABOM-377] DB Redis 정합성 배치 2차 구현(개인 월 사용량 키 삭제 step, 리스너, 테스트)

### DIFF
--- a/src/main/java/com/template/worker/jobs/common/reader/ActiveFamilyCursorReader.java
+++ b/src/main/java/com/template/worker/jobs/common/reader/ActiveFamilyCursorReader.java
@@ -12,6 +12,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 public class ActiveFamilyCursorReader implements ItemReader<Long>, StepExecutionListener {
 
+    private static final String COLUMN_ID = "id";
     private static final String READ_ACTIVE_FAMILY_SQL =
             """
             SELECT id
@@ -47,7 +48,7 @@ public class ActiveFamilyCursorReader implements ItemReader<Long>, StepExecution
             List<Long> familyIds =
                     jdbcTemplate.query(
                             READ_ACTIVE_FAMILY_SQL,
-                            (resultSet, rowNum) -> resultSet.getLong("id"),
+                            (resultSet, rowNum) -> resultSet.getLong(COLUMN_ID),
                             lastFamilyId,
                             dbFetchSizeSupplier.getAsInt());
 

--- a/src/main/java/com/template/worker/jobs/common/reader/ActiveFamilyMemberCursorReader.java
+++ b/src/main/java/com/template/worker/jobs/common/reader/ActiveFamilyMemberCursorReader.java
@@ -13,6 +13,10 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 public class ActiveFamilyMemberCursorReader<T> implements ItemReader<T>, StepExecutionListener {
 
+    private static final String COLUMN_ID = "id";
+    private static final String COLUMN_FAMILY_ID = "family_id";
+    private static final String COLUMN_CUSTOMER_ID = "customer_id";
+
     private static final String READ_ACTIVE_FAMILY_MEMBER_SQL =
             """
             SELECT id, family_id, customer_id
@@ -55,9 +59,9 @@ public class ActiveFamilyMemberCursorReader<T> implements ItemReader<T>, StepExe
                             READ_ACTIVE_FAMILY_MEMBER_SQL,
                             (resultSet, rowNum) ->
                                     new FamilyMemberRow(
-                                            resultSet.getLong("id"),
-                                            resultSet.getLong("family_id"),
-                                            resultSet.getLong("customer_id")),
+                                            resultSet.getLong(COLUMN_ID),
+                                            resultSet.getLong(COLUMN_FAMILY_ID),
+                                            resultSet.getLong(COLUMN_CUSTOMER_ID)),
                             lastFamilyMemberId,
                             dbFetchSizeSupplier.getAsInt());
 

--- a/src/main/java/com/template/worker/jobs/common/reader/ActiveFamilyMemberCursorReader.java
+++ b/src/main/java/com/template/worker/jobs/common/reader/ActiveFamilyMemberCursorReader.java
@@ -1,0 +1,81 @@
+package com.template.worker.jobs.common.reader;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.IntSupplier;
+
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class ActiveFamilyMemberCursorReader<T> implements ItemReader<T>, StepExecutionListener {
+
+    private static final String READ_ACTIVE_FAMILY_MEMBER_SQL =
+            """
+            SELECT id, family_id, customer_id
+            FROM family_member
+            WHERE deleted_at IS NULL
+              AND id > ?
+            ORDER BY id ASC
+            LIMIT ?
+            """;
+
+    private final JdbcTemplate jdbcTemplate;
+    private final IntSupplier dbFetchSizeSupplier;
+    private final BiFunction<Long, Long, T> targetFactory;
+
+    private Iterator<T> currentBatch = Collections.emptyIterator();
+    private long lastFamilyMemberId = 0L;
+
+    public ActiveFamilyMemberCursorReader(
+            JdbcTemplate jdbcTemplate,
+            IntSupplier dbFetchSizeSupplier,
+            BiFunction<Long, Long, T> targetFactory) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.dbFetchSizeSupplier = dbFetchSizeSupplier;
+        this.targetFactory = targetFactory;
+    }
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        // Step 재실행 시 상태 누수를 막기 위해 커서를 초기화함
+        currentBatch = Collections.emptyIterator();
+        lastFamilyMemberId = 0L;
+    }
+
+    @Override
+    public T read() {
+        while (!currentBatch.hasNext()) {
+            // PK 커서 기반으로 활성 구성원 목록을 배치 단위 조회함
+            List<FamilyMemberRow> familyMembers =
+                    jdbcTemplate.query(
+                            READ_ACTIVE_FAMILY_MEMBER_SQL,
+                            (resultSet, rowNum) ->
+                                    new FamilyMemberRow(
+                                            resultSet.getLong("id"),
+                                            resultSet.getLong("family_id"),
+                                            resultSet.getLong("customer_id")),
+                            lastFamilyMemberId,
+                            dbFetchSizeSupplier.getAsInt());
+
+            // 더 이상 데이터가 없으면 null을 반환해 Chunk 처리를 종료함
+            if (familyMembers.isEmpty()) {
+                return null;
+            }
+
+            lastFamilyMemberId = familyMembers.get(familyMembers.size() - 1).id();
+            currentBatch =
+                    familyMembers.stream()
+                            .map(row -> targetFactory.apply(row.familyId(), row.customerId()))
+                            .toList()
+                            .iterator();
+        }
+
+        return currentBatch.next();
+    }
+
+    private record FamilyMemberRow(Long id, Long familyId, Long customerId) {}
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/job/DbRedisReconciliationJobConfig.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/job/DbRedisReconciliationJobConfig.java
@@ -7,7 +7,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.template.worker.global.listener.JobResultListener;
+import com.template.worker.jobs.reconciliation.listener.DbRedisReconciliationJobListener;
 import com.template.worker.jobs.reconciliation.step.AcquireReconciliationLockStepConfig;
+import com.template.worker.jobs.reconciliation.step.InvalidateCustomerMonthlyUsageStepConfig;
 import com.template.worker.jobs.reconciliation.step.InvalidateFamilyInfoAndRemainingStepConfig;
 import com.template.worker.jobs.reconciliation.step.ReleaseReconciliationLockStepConfig;
 import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
@@ -20,15 +22,18 @@ public class DbRedisReconciliationJobConfig {
 
     private final JobRepository jobRepository;
     private final JobResultListener jobResultListener;
+    private final DbRedisReconciliationJobListener dbRedisReconciliationJobListener;
     private final AcquireReconciliationLockStepConfig acquireReconciliationLockStepConfig;
     private final InvalidateFamilyInfoAndRemainingStepConfig
             invalidateFamilyInfoAndRemainingStepConfig;
+    private final InvalidateCustomerMonthlyUsageStepConfig invalidateCustomerMonthlyUsageStepConfig;
     private final ReleaseReconciliationLockStepConfig releaseReconciliationLockStepConfig;
 
     @Bean
     public Job dbRedisReconciliationJob() {
         return new JobBuilder(DbRedisReconciliationJobConstants.JOB_NAME, jobRepository)
                 .listener(jobResultListener)
+                .listener(dbRedisReconciliationJobListener)
                 .start(acquireReconciliationLockStepConfig.acquireReconciliationLockStep())
                 // 락 미획득이면 정상 종료해 중복 실행을 방지함
                 .on(DbRedisReconciliationJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED)
@@ -42,6 +47,7 @@ public class DbRedisReconciliationJobConfig {
                 .to(
                         invalidateFamilyInfoAndRemainingStepConfig
                                 .invalidateFamilyInfoAndRemainingStep())
+                .next(invalidateCustomerMonthlyUsageStepConfig.invalidateCustomerMonthlyUsageStep())
                 .next(releaseReconciliationLockStepConfig.releaseReconciliationLockStep())
                 .end()
                 .build();

--- a/src/main/java/com/template/worker/jobs/reconciliation/listener/DbRedisReconciliationJobListener.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/listener/DbRedisReconciliationJobListener.java
@@ -22,7 +22,9 @@ public class DbRedisReconciliationJobListener implements JobExecutionListener {
     private final DbRedisReconciliationLockManager lockManager;
 
     @Override
-    public void beforeJob(JobExecution jobExecution) {}
+    public void beforeJob(JobExecution jobExecution) {
+        // 이 리스너는 잡 시작 전 선행 작업이 없고 종료 후 요약/락 정리만 담당함
+    }
 
     @Override
     public void afterJob(JobExecution jobExecution) {

--- a/src/main/java/com/template/worker/jobs/reconciliation/listener/DbRedisReconciliationJobListener.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/listener/DbRedisReconciliationJobListener.java
@@ -35,7 +35,7 @@ public class DbRedisReconciliationJobListener implements JobExecutionListener {
                         jobExecution
                                 .getJobParameters()
                                 .getString(DbRedisReconciliationJobConstants.PARAM_TARGET_MONTH),
-                        "default");
+                        DbRedisReconciliationJobConstants.JOB_CONTEXT_TARGET_MONTH_DEFAULT);
         String targetMonth =
                 jobContext.getString(
                         DbRedisReconciliationJobConstants.JOB_CONTEXT_TARGET_MONTH,

--- a/src/main/java/com/template/worker/jobs/reconciliation/listener/DbRedisReconciliationJobListener.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/listener/DbRedisReconciliationJobListener.java
@@ -1,0 +1,109 @@
+package com.template.worker.jobs.reconciliation.listener;
+
+import java.util.Objects;
+
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationLockManager;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DbRedisReconciliationJobListener implements JobExecutionListener {
+
+    private final DbRedisReconciliationLockManager lockManager;
+
+    @Override
+    public void beforeJob(JobExecution jobExecution) {}
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        // JobExecutionContext와 StepExecutionContext에서 요약 지표를 수집함
+        ExecutionContext jobContext = jobExecution.getExecutionContext();
+        String targetMonthFromParam =
+                Objects.requireNonNullElse(
+                        jobExecution
+                                .getJobParameters()
+                                .getString(DbRedisReconciliationJobConstants.PARAM_TARGET_MONTH),
+                        "default");
+        String targetMonth =
+                jobContext.getString(
+                        DbRedisReconciliationJobConstants.JOB_CONTEXT_TARGET_MONTH,
+                        targetMonthFromParam);
+        String lockStatus =
+                jobContext.getString(
+                        DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_STATUS,
+                        DbRedisReconciliationJobConstants.LOCK_STATUS_NOT_ACQUIRED);
+
+        long deletedFamilyInfoCount =
+                findStepContextLong(
+                        jobExecution,
+                        DbRedisReconciliationJobConstants.STEP_INVALIDATE_FAMILY_INFO_AND_REMAINING,
+                        DbRedisReconciliationJobConstants.STEP_CONTEXT_DELETED_FAMILY_INFO_COUNT);
+        long deletedFamilyRemainingCount =
+                findStepContextLong(
+                        jobExecution,
+                        DbRedisReconciliationJobConstants.STEP_INVALIDATE_FAMILY_INFO_AND_REMAINING,
+                        DbRedisReconciliationJobConstants
+                                .STEP_CONTEXT_DELETED_FAMILY_REMAINING_COUNT);
+        long deletedCustomerMonthlyUsageCount =
+                findStepContextLong(
+                        jobExecution,
+                        DbRedisReconciliationJobConstants.STEP_INVALIDATE_CUSTOMER_MONTHLY_USAGE,
+                        DbRedisReconciliationJobConstants
+                                .STEP_CONTEXT_DELETED_CUSTOMER_MONTHLY_USAGE_COUNT);
+
+        int failureCount = jobExecution.getAllFailureExceptions().size();
+        log.info(
+                "DB-Redis reconciliation summary. targetMonth={}, deletedFamilyInfoCount={}, "
+                        + "deletedFamilyRemainingCount={}, deletedCustomerMonthlyUsageCount={}, "
+                        + "failureCount={}, lockStatus={}, status={}, jobExecutionId={}",
+                targetMonth,
+                deletedFamilyInfoCount,
+                deletedFamilyRemainingCount,
+                deletedCustomerMonthlyUsageCount,
+                failureCount,
+                lockStatus,
+                jobExecution.getStatus(),
+                jobExecution.getId());
+
+        // 예외 경로 누수 방지를 위해 최종 락 정리를 한 번 더 수행함
+        String lockKey =
+                jobContext.getString(DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_KEY, null);
+        String lockOwner =
+                jobContext.getString(
+                        DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_OWNER, null);
+        boolean released = lockManager.releaseIfOwner(lockKey, lockOwner);
+        if (released) {
+            jobContext.putString(
+                    DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_RELEASED,
+                    String.valueOf(true));
+        }
+
+        if (lockKey != null) {
+            log.info(
+                    "DB-Redis reconciliation final lock cleanup. lockKey={}, released={}",
+                    lockKey,
+                    released);
+        }
+    }
+
+    private long findStepContextLong(
+            JobExecution jobExecution, String stepName, String executionContextKey) {
+        // 대상 step의 execution context 값을 조회해 처리 건수 집계에 사용함
+        for (StepExecution stepExecution : jobExecution.getStepExecutions()) {
+            if (stepExecution.getStepName().equals(stepName)) {
+                return stepExecution.getExecutionContext().getLong(executionContextKey, 0L);
+            }
+        }
+        return 0L;
+    }
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/model/FamilyMemberReconciliationTarget.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/model/FamilyMemberReconciliationTarget.java
@@ -1,0 +1,4 @@
+package com.template.worker.jobs.reconciliation.model;
+
+// customer monthly usage 키 삭제에 필요한 최소 식별자만 보관함
+public record FamilyMemberReconciliationTarget(Long familyId, Long customerId) {}

--- a/src/main/java/com/template/worker/jobs/reconciliation/reader/ReconciliationFamilyMemberReader.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/reader/ReconciliationFamilyMemberReader.java
@@ -1,0 +1,18 @@
+package com.template.worker.jobs.reconciliation.reader;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.common.reader.ActiveFamilyMemberCursorReader;
+import com.template.worker.jobs.reconciliation.model.FamilyMemberReconciliationTarget;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationProperties;
+
+@Component
+public class ReconciliationFamilyMemberReader
+        extends ActiveFamilyMemberCursorReader<FamilyMemberReconciliationTarget> {
+
+    public ReconciliationFamilyMemberReader(
+            JdbcTemplate jdbcTemplate, DbRedisReconciliationProperties properties) {
+        super(jdbcTemplate, properties::getDbFetchSize, FamilyMemberReconciliationTarget::new);
+    }
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/step/InvalidateCustomerMonthlyUsageStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/step/InvalidateCustomerMonthlyUsageStepConfig.java
@@ -1,0 +1,40 @@
+package com.template.worker.jobs.reconciliation.step;
+
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.template.worker.jobs.reconciliation.model.FamilyMemberReconciliationTarget;
+import com.template.worker.jobs.reconciliation.reader.ReconciliationFamilyMemberReader;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationProperties;
+import com.template.worker.jobs.reconciliation.writer.ReconciliationCustomerMonthlyUsageInvalidationWriter;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class InvalidateCustomerMonthlyUsageStepConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final ReconciliationFamilyMemberReader reader;
+    private final ReconciliationCustomerMonthlyUsageInvalidationWriter writer;
+    private final DbRedisReconciliationProperties properties;
+
+    @Bean
+    public Step invalidateCustomerMonthlyUsageStep() {
+        // family_member reader + monthly usage invalidation writer의 Chunk Step 구성
+        return new StepBuilder(
+                        DbRedisReconciliationJobConstants.STEP_INVALIDATE_CUSTOMER_MONTHLY_USAGE,
+                        jobRepository)
+                .<FamilyMemberReconciliationTarget, FamilyMemberReconciliationTarget>chunk(
+                        properties.getRedisChunkSize(), transactionManager)
+                .reader(reader)
+                .writer(writer)
+                .build();
+    }
+}

--- a/src/main/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationJobConstants.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationJobConstants.java
@@ -22,6 +22,7 @@ public final class DbRedisReconciliationJobConstants {
     public static final String EXIT_STATUS_LOCK_NOT_ACQUIRED = "LOCK_NOT_ACQUIRED";
 
     public static final String JOB_CONTEXT_TARGET_MONTH = "targetMonth";
+    public static final String JOB_CONTEXT_TARGET_MONTH_DEFAULT = "default";
     public static final String JOB_CONTEXT_LOCK_KEY = "lockKey";
     public static final String JOB_CONTEXT_LOCK_OWNER = "lockOwner";
     public static final String JOB_CONTEXT_LOCK_STATUS = "lockStatus";

--- a/src/main/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationJobConstants.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationJobConstants.java
@@ -14,6 +14,8 @@ public final class DbRedisReconciliationJobConstants {
             "acquire-reconciliation-lock-step";
     public static final String STEP_INVALIDATE_FAMILY_INFO_AND_REMAINING =
             "invalidate-family-info-and-remaining-step";
+    public static final String STEP_INVALIDATE_CUSTOMER_MONTHLY_USAGE =
+            "invalidate-customer-monthly-usage-step";
     public static final String STEP_RELEASE_RECONCILIATION_LOCK =
             "release-reconciliation-lock-step";
 
@@ -32,6 +34,8 @@ public final class DbRedisReconciliationJobConstants {
     public static final String STEP_CONTEXT_DELETED_FAMILY_INFO_COUNT = "deletedFamilyInfoCount";
     public static final String STEP_CONTEXT_DELETED_FAMILY_REMAINING_COUNT =
             "deletedFamilyRemainingCount";
+    public static final String STEP_CONTEXT_DELETED_CUSTOMER_MONTHLY_USAGE_COUNT =
+            "deletedCustomerMonthlyUsageCount";
 
     private DbRedisReconciliationJobConstants() {}
 }

--- a/src/main/java/com/template/worker/jobs/reconciliation/writer/ReconciliationCustomerMonthlyUsageInvalidationWriter.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/writer/ReconciliationCustomerMonthlyUsageInvalidationWriter.java
@@ -1,0 +1,89 @@
+package com.template.worker.jobs.reconciliation.writer;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.global.util.RedisKeyGenerator;
+import com.template.worker.jobs.reconciliation.model.FamilyMemberReconciliationTarget;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobParameterSupport;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ReconciliationCustomerMonthlyUsageInvalidationWriter
+        implements ItemWriter<FamilyMemberReconciliationTarget>, StepExecutionListener {
+
+    private final StringRedisTemplate redisTemplate;
+    private final RedisKeyGenerator keyGenerator;
+    private final DbRedisReconciliationJobParameterSupport parameterSupport;
+
+    private LocalDate targetMonth;
+    private long deletedCustomerMonthlyUsageCount;
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        // targetMonth suffix 키 삭제를 위해 파라미터를 선계산하고 카운터를 초기화함
+        targetMonth = parameterSupport.resolveTargetMonth(stepExecution.getJobParameters());
+        deletedCustomerMonthlyUsageCount = 0L;
+    }
+
+    @Override
+    public void write(Chunk<? extends FamilyMemberReconciliationTarget> chunk) {
+        if (chunk.isEmpty()) {
+            return;
+        }
+
+        // Redis 파이프라인으로 대상 월 monthly usage 키만 일괄 삭제함
+        List<Object> results =
+                redisTemplate.executePipelined(
+                        (RedisCallback<Object>)
+                                connection -> {
+                                    StringRedisConnection redisConnection =
+                                            (StringRedisConnection) connection;
+                                    for (FamilyMemberReconciliationTarget target : chunk) {
+                                        String monthlyUsageKey =
+                                                keyGenerator.customerMonthlyUsageKey(
+                                                        target.familyId(),
+                                                        target.customerId(),
+                                                        targetMonth);
+                                        redisConnection.del(monthlyUsageKey);
+                                    }
+                                    return null;
+                                });
+
+        for (Object result : results) {
+            deletedCustomerMonthlyUsageCount += resolveDeletedCount(result);
+        }
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        // afterJob 요약 로그에서 사용할 수 있도록 StepExecutionContext에 누적값을 기록함
+        stepExecution
+                .getExecutionContext()
+                .putLong(
+                        DbRedisReconciliationJobConstants
+                                .STEP_CONTEXT_DELETED_CUSTOMER_MONTHLY_USAGE_COUNT,
+                        deletedCustomerMonthlyUsageCount);
+        return null;
+    }
+
+    private long resolveDeletedCount(Object rawResult) {
+        if (rawResult instanceof Number number) {
+            return number.longValue();
+        }
+        return 0L;
+    }
+}

--- a/src/main/java/com/template/worker/jobs/usagereset/listener/MonthlyUsageResetJobListener.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/listener/MonthlyUsageResetJobListener.java
@@ -22,7 +22,9 @@ public class MonthlyUsageResetJobListener implements JobExecutionListener {
     private final MonthlyResetLockManager monthlyResetLockManager;
 
     @Override
-    public void beforeJob(JobExecution jobExecution) {}
+    public void beforeJob(JobExecution jobExecution) {
+        // 이 리스너는 잡 시작 전 선행 작업이 없고 종료 후 요약/락 정리만 담당함
+    }
 
     @Override
     public void afterJob(JobExecution jobExecution) {

--- a/src/main/java/com/template/worker/jobs/usagereset/listener/MonthlyUsageResetJobListener.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/listener/MonthlyUsageResetJobListener.java
@@ -36,11 +36,11 @@ public class MonthlyUsageResetJobListener implements JobExecutionListener {
                         jobExecution
                                 .getJobParameters()
                                 .getString(MonthlyUsageResetJobConstants.PARAM_TARGET_MONTH),
-                        "default");
+                        MonthlyUsageResetJobConstants.JOB_CONTEXT_TARGET_MONTH_DEFAULT);
         String targetMonth =
                 jobContext.getString(
                         MonthlyUsageResetJobConstants.JOB_CONTEXT_TARGET_MONTH,
-                        MonthlyUsageResetJobConstants.JOB_CONTEXT_TARGET_MONTH_DEFAULT);
+                        targetMonthFromParam);
 
         long dbUpdatedCount =
                 jobContext.getLong(

--- a/src/main/java/com/template/worker/jobs/usagereset/listener/MonthlyUsageResetJobListener.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/listener/MonthlyUsageResetJobListener.java
@@ -40,7 +40,7 @@ public class MonthlyUsageResetJobListener implements JobExecutionListener {
         String targetMonth =
                 jobContext.getString(
                         MonthlyUsageResetJobConstants.JOB_CONTEXT_TARGET_MONTH,
-                        targetMonthFromParam);
+                        MonthlyUsageResetJobConstants.JOB_CONTEXT_TARGET_MONTH_DEFAULT);
 
         long dbUpdatedCount =
                 jobContext.getLong(

--- a/src/main/java/com/template/worker/jobs/usagereset/reader/ActiveFamilyMemberReader.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/reader/ActiveFamilyMemberReader.java
@@ -1,84 +1,18 @@
 package com.template.worker.jobs.usagereset.reader;
 
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
-import org.springframework.batch.core.StepExecution;
-import org.springframework.batch.core.StepExecutionListener;
-import org.springframework.batch.item.ItemReader;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.jobs.common.reader.ActiveFamilyMemberCursorReader;
 import com.template.worker.jobs.usagereset.model.FamilyMemberUsageResetTarget;
 import com.template.worker.jobs.usagereset.support.MonthlyUsageResetProperties;
 
-import lombok.RequiredArgsConstructor;
-
 @Component
-@RequiredArgsConstructor
 public class ActiveFamilyMemberReader
-        implements ItemReader<FamilyMemberUsageResetTarget>, StepExecutionListener {
+        extends ActiveFamilyMemberCursorReader<FamilyMemberUsageResetTarget> {
 
-    private static final String READ_ACTIVE_FAMILY_MEMBER_SQL =
-            """
-            SELECT id, family_id, customer_id
-            FROM family_member
-            WHERE deleted_at IS NULL
-              AND id > ?
-            ORDER BY id ASC
-            LIMIT ?
-            """;
-
-    private final JdbcTemplate jdbcTemplate;
-    private final MonthlyUsageResetProperties properties;
-
-    private Iterator<FamilyMemberUsageResetTarget> currentBatch = Collections.emptyIterator();
-    private long lastFamilyMemberId = 0L;
-
-    @Override
-    public void beforeStep(StepExecution stepExecution) {
-        // Step 재실행 시 상태 누수를 막기 위해 커서를 초기화함
-        currentBatch = Collections.emptyIterator();
-        lastFamilyMemberId = 0L;
+    public ActiveFamilyMemberReader(
+            JdbcTemplate jdbcTemplate, MonthlyUsageResetProperties properties) {
+        super(jdbcTemplate, properties::getDbFetchSize, FamilyMemberUsageResetTarget::new);
     }
-
-    @Override
-    public FamilyMemberUsageResetTarget read() {
-        while (!currentBatch.hasNext()) {
-            // PK 커서 기반으로 활성 구성원 목록을 배치 단위 조회함
-            List<FamilyMemberRow> familyMembers =
-                    jdbcTemplate.query(
-                            READ_ACTIVE_FAMILY_MEMBER_SQL,
-                            (resultSet, rowNum) ->
-                                    new FamilyMemberRow(
-                                            resultSet.getLong("id"),
-                                            resultSet.getLong("family_id"),
-                                            resultSet.getLong("customer_id")),
-                            lastFamilyMemberId,
-                            properties.getDbFetchSize());
-
-            // 더 이상 데이터가 없으면 null을 반환해 Chunk 처리를 종료함
-            if (familyMembers.isEmpty()) {
-                return null;
-            }
-
-            lastFamilyMemberId = familyMembers.get(familyMembers.size() - 1).id();
-
-            // Reader 책임을 유지하기 위해 writer 입력 DTO로만 변환함
-            List<FamilyMemberUsageResetTarget> targets =
-                    familyMembers.stream()
-                            .map(
-                                    row ->
-                                            new FamilyMemberUsageResetTarget(
-                                                    row.familyId(), row.customerId()))
-                            .toList();
-
-            currentBatch = targets.iterator();
-        }
-
-        return currentBatch.next();
-    }
-
-    private record FamilyMemberRow(Long id, Long familyId, Long customerId) {}
 }

--- a/src/main/java/com/template/worker/jobs/usagereset/support/MonthlyUsageResetJobConstants.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/support/MonthlyUsageResetJobConstants.java
@@ -21,6 +21,7 @@ public final class MonthlyUsageResetJobConstants {
     public static final String EXIT_STATUS_LOCK_NOT_ACQUIRED = "LOCK_NOT_ACQUIRED";
 
     public static final String JOB_CONTEXT_TARGET_MONTH = "targetMonth";
+    public static final String JOB_CONTEXT_TARGET_MONTH_DEFAULT = "default";
     public static final String JOB_CONTEXT_LOCK_KEY = "lockKey";
     public static final String JOB_CONTEXT_LOCK_OWNER = "lockOwner";
     public static final String JOB_CONTEXT_DB_UPDATED_FAMILY_COUNT = "dbUpdatedFamilyCount";

--- a/src/test/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationJobParameterSupportTest.java
+++ b/src/test/java/com/template/worker/jobs/reconciliation/support/DbRedisReconciliationJobParameterSupportTest.java
@@ -1,0 +1,53 @@
+package com.template.worker.jobs.reconciliation.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+
+import com.template.worker.jobs.common.support.TargetMonthParameterSupport;
+
+class DbRedisReconciliationJobParameterSupportTest {
+
+    private final DbRedisReconciliationJobParameterSupport support =
+            new DbRedisReconciliationJobParameterSupport(new TargetMonthParameterSupport());
+
+    @Test
+    @DisplayName("resolveTargetMonth - targetMonth 파라미터가 있으면 해당 값을 반환한다")
+    void resolveTargetMonth_withParam_returnsParsedValue() {
+        JobParameters parameters =
+                new JobParametersBuilder().addString("targetMonth", "2026-03-01").toJobParameters();
+
+        LocalDate targetMonth = support.resolveTargetMonth(parameters);
+
+        assertThat(targetMonth).isEqualTo(LocalDate.of(2026, 3, 1));
+    }
+
+    @Test
+    @DisplayName("resolveTargetMonth - 파라미터가 없으면 현재 월 1일을 반환한다")
+    void resolveTargetMonth_withoutParam_returnsCurrentMonthStart() {
+        JobParameters parameters = new JobParametersBuilder().toJobParameters();
+
+        LocalDate targetMonth = support.resolveTargetMonth(parameters);
+
+        LocalDate expected =
+                ZonedDateTime.now(DbRedisReconciliationJobConstants.KST_ZONE_ID)
+                        .toLocalDate()
+                        .withDayOfMonth(1);
+        assertThat(targetMonth).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("resolveTargetMonth - day가 1이 아니면 예외가 발생한다")
+    void resolveTargetMonth_withInvalidDay_throwsException() {
+        assertThatThrownBy(() -> support.resolveTargetMonth("2026-03-05"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("targetMonth must be first day of month");
+    }
+}

--- a/src/test/java/com/template/worker/jobs/reconciliation/tasklet/ReconciliationLockTaskletTest.java
+++ b/src/test/java/com/template/worker/jobs/reconciliation/tasklet/ReconciliationLockTaskletTest.java
@@ -41,7 +41,7 @@ class ReconciliationLockTaskletTest {
 
     @Test
     @DisplayName("execute - 락 미획득 시 LOCK_NOT_ACQUIRED로 종료한다")
-    void execute_lockNotAcquired_setsLockNotAcquiredExitStatus() throws Exception {
+    void execute_lockNotAcquired_setsLockNotAcquiredExitStatus() {
         JobParameters jobParameters =
                 new JobParametersBuilder().addString("targetMonth", "2026-03-01").toJobParameters();
         JobInstance jobInstance = new JobInstance(1L, "dbRedisReconciliationJob");
@@ -81,7 +81,7 @@ class ReconciliationLockTaskletTest {
 
     @Test
     @DisplayName("execute - 락 획득 시 다음 스텝으로 진행한다")
-    void execute_lockAcquired_setsAcquiredStatus() throws Exception {
+    void execute_lockAcquired_setsAcquiredStatus() {
         JobParameters jobParameters =
                 new JobParametersBuilder().addString("targetMonth", "2026-03-01").toJobParameters();
         JobInstance jobInstance = new JobInstance(2L, "dbRedisReconciliationJob");

--- a/src/test/java/com/template/worker/jobs/reconciliation/tasklet/ReconciliationLockTaskletTest.java
+++ b/src/test/java/com/template/worker/jobs/reconciliation/tasklet/ReconciliationLockTaskletTest.java
@@ -1,0 +1,115 @@
+package com.template.worker.jobs.reconciliation.tasklet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.scope.context.StepContext;
+
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobParameterSupport;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationLockKeyGenerator;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationLockManager;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationProperties;
+
+@ExtendWith(MockitoExtension.class)
+class ReconciliationLockTaskletTest {
+
+    @Mock private DbRedisReconciliationLockManager lockManager;
+    @Mock private DbRedisReconciliationJobParameterSupport parameterSupport;
+    @Mock private DbRedisReconciliationProperties properties;
+    @Mock private DbRedisReconciliationLockKeyGenerator lockKeyGenerator;
+
+    @InjectMocks private ReconciliationLockTasklet tasklet;
+
+    @Test
+    @DisplayName("execute - 락 미획득 시 LOCK_NOT_ACQUIRED로 종료한다")
+    void execute_lockNotAcquired_setsLockNotAcquiredExitStatus() throws Exception {
+        JobParameters jobParameters =
+                new JobParametersBuilder().addString("targetMonth", "2026-03-01").toJobParameters();
+        JobInstance jobInstance = new JobInstance(1L, "dbRedisReconciliationJob");
+        JobExecution jobExecution = new JobExecution(jobInstance, jobParameters);
+        StepExecution stepExecution = new StepExecution("acquire-lock-step", jobExecution);
+
+        LocalDate targetMonth = LocalDate.of(2026, 3, 1);
+        when(parameterSupport.resolveTargetMonth(any(JobParameters.class))).thenReturn(targetMonth);
+        when(lockKeyGenerator.reconciliationLockKey(targetMonth))
+                .thenReturn("batch:lock:reconciliation:2026-03-01");
+        when(properties.getLockTtl()).thenReturn(Duration.ofHours(1));
+        when(lockManager.tryAcquire(anyString(), anyString(), any(Duration.class)))
+                .thenReturn(false);
+
+        tasklet.beforeStep(stepExecution);
+
+        StepContribution contribution = new StepContribution(stepExecution);
+        ChunkContext chunkContext = new ChunkContext(new StepContext(stepExecution));
+
+        tasklet.execute(contribution, chunkContext);
+
+        assertThat(contribution.getExitStatus().getExitCode())
+                .isEqualTo(DbRedisReconciliationJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED);
+        assertThat(
+                        jobExecution
+                                .getExecutionContext()
+                                .getString(
+                                        DbRedisReconciliationJobConstants.JOB_CONTEXT_TARGET_MONTH))
+                .isEqualTo("2026-03-01");
+        assertThat(
+                        jobExecution
+                                .getExecutionContext()
+                                .getString(
+                                        DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_STATUS))
+                .isEqualTo(DbRedisReconciliationJobConstants.LOCK_STATUS_NOT_ACQUIRED);
+    }
+
+    @Test
+    @DisplayName("execute - 락 획득 시 다음 스텝으로 진행한다")
+    void execute_lockAcquired_setsAcquiredStatus() throws Exception {
+        JobParameters jobParameters =
+                new JobParametersBuilder().addString("targetMonth", "2026-03-01").toJobParameters();
+        JobInstance jobInstance = new JobInstance(2L, "dbRedisReconciliationJob");
+        JobExecution jobExecution = new JobExecution(jobInstance, jobParameters);
+        StepExecution stepExecution = new StepExecution("acquire-lock-step", jobExecution);
+
+        LocalDate targetMonth = LocalDate.of(2026, 3, 1);
+        when(parameterSupport.resolveTargetMonth(any(JobParameters.class))).thenReturn(targetMonth);
+        when(lockKeyGenerator.reconciliationLockKey(targetMonth))
+                .thenReturn("batch:lock:reconciliation:2026-03-01");
+        when(properties.getLockTtl()).thenReturn(Duration.ofHours(1));
+        when(lockManager.tryAcquire(anyString(), anyString(), any(Duration.class)))
+                .thenReturn(true);
+
+        tasklet.beforeStep(stepExecution);
+
+        StepContribution contribution = new StepContribution(stepExecution);
+        ChunkContext chunkContext = new ChunkContext(new StepContext(stepExecution));
+
+        tasklet.execute(contribution, chunkContext);
+
+        assertThat(
+                        jobExecution
+                                .getExecutionContext()
+                                .getString(
+                                        DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_STATUS))
+                .isEqualTo(DbRedisReconciliationJobConstants.LOCK_STATUS_ACQUIRED);
+        assertThat(contribution.getExitStatus().getExitCode())
+                .isNotEqualTo(DbRedisReconciliationJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED);
+    }
+}

--- a/src/test/java/com/template/worker/jobs/reconciliation/writer/ReconciliationCustomerMonthlyUsageInvalidationWriterTest.java
+++ b/src/test/java/com/template/worker/jobs/reconciliation/writer/ReconciliationCustomerMonthlyUsageInvalidationWriterTest.java
@@ -3,7 +3,6 @@ package com.template.worker.jobs.reconciliation.writer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -90,6 +89,6 @@ class ReconciliationCustomerMonthlyUsageInvalidationWriterTest {
         verify(keyGenerator, never()).customerMonthlyUsageKey(anyLong(), anyLong());
         verify(keyGenerator, never()).familyInfoKey(anyLong());
         verify(keyGenerator, never()).familyRemainingKey(anyLong());
-        verify(parameterSupport).resolveTargetMonth(eq(jobParameters));
+        verify(parameterSupport).resolveTargetMonth(jobParameters);
     }
 }

--- a/src/test/java/com/template/worker/jobs/reconciliation/writer/ReconciliationCustomerMonthlyUsageInvalidationWriterTest.java
+++ b/src/test/java/com/template/worker/jobs/reconciliation/writer/ReconciliationCustomerMonthlyUsageInvalidationWriterTest.java
@@ -1,0 +1,95 @@
+package com.template.worker.jobs.reconciliation.writer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.Chunk;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import com.template.worker.global.util.RedisKeyGenerator;
+import com.template.worker.jobs.reconciliation.model.FamilyMemberReconciliationTarget;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobParameterSupport;
+
+@ExtendWith(MockitoExtension.class)
+class ReconciliationCustomerMonthlyUsageInvalidationWriterTest {
+
+    @Mock private StringRedisTemplate redisTemplate;
+    @Mock private RedisKeyGenerator keyGenerator;
+    @Mock private DbRedisReconciliationJobParameterSupport parameterSupport;
+
+    @InjectMocks private ReconciliationCustomerMonthlyUsageInvalidationWriter writer;
+
+    @Test
+    @DisplayName("write - targetMonth suffix monthly usage 키만 삭제하고 삭제 건수를 기록한다")
+    void write_deletesOnlyTargetMonthlyUsageKeys_andStoresCountsInContext() {
+        JobParameters jobParameters =
+                new JobParametersBuilder().addString("targetMonth", "2026-03-01").toJobParameters();
+        JobInstance jobInstance = new JobInstance(1L, "dbRedisReconciliationJob");
+        JobExecution jobExecution = new JobExecution(jobInstance, jobParameters);
+        StepExecution stepExecution = new StepExecution("invalidate-customer-step", jobExecution);
+
+        LocalDate targetMonth = LocalDate.of(2026, 3, 1);
+        when(parameterSupport.resolveTargetMonth(any(JobParameters.class))).thenReturn(targetMonth);
+        when(keyGenerator.customerMonthlyUsageKey(10L, 100L, targetMonth))
+                .thenReturn("family:10:customer:100:usage:monthly:202603");
+        when(keyGenerator.customerMonthlyUsageKey(10L, 101L, targetMonth))
+                .thenReturn("family:10:customer:101:usage:monthly:202603");
+
+        when(redisTemplate.executePipelined(any(RedisCallback.class)))
+                .thenAnswer(
+                        invocation -> {
+                            @SuppressWarnings("unchecked")
+                            RedisCallback<Object> callback = invocation.getArgument(0);
+                            StringRedisConnection connection = mock(StringRedisConnection.class);
+                            callback.doInRedis(connection);
+
+                            verify(connection).del("family:10:customer:100:usage:monthly:202603");
+                            verify(connection).del("family:10:customer:101:usage:monthly:202603");
+                            return List.of(1L, 0L);
+                        });
+
+        writer.beforeStep(stepExecution);
+        writer.write(
+                new Chunk<>(
+                        List.of(
+                                new FamilyMemberReconciliationTarget(10L, 100L),
+                                new FamilyMemberReconciliationTarget(10L, 101L))));
+        writer.afterStep(stepExecution);
+
+        assertThat(
+                        stepExecution
+                                .getExecutionContext()
+                                .getLong(
+                                        DbRedisReconciliationJobConstants
+                                                .STEP_CONTEXT_DELETED_CUSTOMER_MONTHLY_USAGE_COUNT))
+                .isEqualTo(1L);
+
+        verify(keyGenerator, never()).customerMonthlyUsageKey(anyLong(), anyLong());
+        verify(keyGenerator, never()).familyInfoKey(anyLong());
+        verify(keyGenerator, never()).familyRemainingKey(anyLong());
+        verify(parameterSupport).resolveTargetMonth(eq(jobParameters));
+    }
+}

--- a/src/test/java/com/template/worker/jobs/reconciliation/writer/ReconciliationFamilyKeyInvalidationWriterTest.java
+++ b/src/test/java/com/template/worker/jobs/reconciliation/writer/ReconciliationFamilyKeyInvalidationWriterTest.java
@@ -1,0 +1,91 @@
+package com.template.worker.jobs.reconciliation.writer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.Chunk;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import com.template.worker.global.util.RedisKeyGenerator;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
+
+@ExtendWith(MockitoExtension.class)
+class ReconciliationFamilyKeyInvalidationWriterTest {
+
+    @Mock private StringRedisTemplate redisTemplate;
+    @Mock private RedisKeyGenerator keyGenerator;
+
+    @InjectMocks private ReconciliationFamilyKeyInvalidationWriter writer;
+
+    @Test
+    @DisplayName("write - family info/remaining 키만 삭제하고 step context에 삭제 건수를 기록한다")
+    void write_deletesOnlyTargetFamilyKeys_andStoresCountsInContext() {
+        JobInstance jobInstance = new JobInstance(1L, "dbRedisReconciliationJob");
+        JobExecution jobExecution =
+                new JobExecution(jobInstance, new JobParametersBuilder().toJobParameters());
+        StepExecution stepExecution = new StepExecution("invalidate-family-step", jobExecution);
+
+        when(keyGenerator.familyInfoKey(10L)).thenReturn("family:10:info");
+        when(keyGenerator.familyRemainingKey(10L)).thenReturn("family:10:remaining");
+        when(keyGenerator.familyInfoKey(11L)).thenReturn("family:11:info");
+        when(keyGenerator.familyRemainingKey(11L)).thenReturn("family:11:remaining");
+
+        when(redisTemplate.executePipelined(any(RedisCallback.class)))
+                .thenAnswer(
+                        invocation -> {
+                            @SuppressWarnings("unchecked")
+                            RedisCallback<Object> callback = invocation.getArgument(0);
+                            StringRedisConnection connection = mock(StringRedisConnection.class);
+                            callback.doInRedis(connection);
+
+                            verify(connection).del("family:10:info");
+                            verify(connection).del("family:10:remaining");
+                            verify(connection).del("family:11:info");
+                            verify(connection).del("family:11:remaining");
+
+                            return List.of(1L, 1L, 0L, 1L);
+                        });
+
+        writer.beforeStep(stepExecution);
+        writer.write(new Chunk<>(List.of(10L, 11L)));
+        writer.afterStep(stepExecution);
+
+        assertThat(
+                        stepExecution
+                                .getExecutionContext()
+                                .getLong(
+                                        DbRedisReconciliationJobConstants
+                                                .STEP_CONTEXT_DELETED_FAMILY_INFO_COUNT))
+                .isEqualTo(1L);
+        assertThat(
+                        stepExecution
+                                .getExecutionContext()
+                                .getLong(
+                                        DbRedisReconciliationJobConstants
+                                                .STEP_CONTEXT_DELETED_FAMILY_REMAINING_COUNT))
+                .isEqualTo(2L);
+
+        verify(keyGenerator, never()).familyAlertThresholdKey(anyLong(), anyInt());
+        verify(keyGenerator, never()).customerMonthlyUsageKey(anyLong(), anyLong());
+    }
+}

--- a/src/test/java/com/template/worker/jobs/usagereset/tasklet/MonthlyResetLockTaskletTest.java
+++ b/src/test/java/com/template/worker/jobs/usagereset/tasklet/MonthlyResetLockTaskletTest.java
@@ -41,7 +41,7 @@ class MonthlyResetLockTaskletTest {
 
     @Test
     @DisplayName("execute - 락 미획득 시 LOCK_NOT_ACQUIRED로 종료한다")
-    void execute_lockNotAcquired_setsLockNotAcquiredExitStatus() throws Exception {
+    void execute_lockNotAcquired_setsLockNotAcquiredExitStatus() {
         // given
         JobParameters jobParameters =
                 new JobParametersBuilder().addString("targetMonth", "2026-03-01").toJobParameters();


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #5 
- jira: DABOM-377

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
`dabom-batch-core`에서 `db-redis-reconciliation-job` 1차 구현 범위에 개인 월사용량 키 무효화 step, afterJob 요약/락 cleanup listener, family_member cursor reader 공통화, 단위 테스트를 추가해 정합성 배치의 2차 구현 범위를 완성한다.

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->

- `ActiveFamilyMemberCursorReader<T>`를 추가해 `family_member` cursor reader 로직을 공통화
- `ActiveFamilyMemberReader`가 `MonthlyUsageResetProperties`를 사용하도록 정리
- `FamilyMemberReconciliationTarget` 추가
- `ReconciliationFamilyMemberReader` 구현
- `ReconciliationCustomerMonthlyUsageInvalidationWriter` 구현
- `InvalidateCustomerMonthlyUsageStepConfig` 추가
- `DbRedisReconciliationJobConstants`에 customer monthly usage step/context 상수 추가
- `DbRedisReconciliationJobConfig`에 step4와 `DbRedisReconciliationJobListener` 연결
- `DbRedisReconciliationJobListener` 추가: step별 삭제 건수 요약 로그 + afterJob 최종 락 cleanup 수행
- `DbRedisReconciliationJobParameterSupportTest` 추가
- `ReconciliationLockTaskletTest` 추가
- `ReconciliationFamilyKeyInvalidationWriterTest` 추가
- `ReconciliationCustomerMonthlyUsageInvalidationWriterTest` 추가

## 📂 변경 범위

<!-- 변경된 레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| Job | api (controller/service/dto) | job config | step config | reader | processor | writer | global (config/launcher/listener) |
| :-: | :--------------------------: | :--------: | :---------: | :----: | :-------: | :----: | :-------------------------------: |
| dbRedisReconciliationJob |  | [x] | [x] | [x] |  | [x] | [x] |
| monthly-usage-reset-job (reader commonization) |  |  |  | [x] |  |  |  |
---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```java
return new JobBuilder(DbRedisReconciliationJobConstants.JOB_NAME, jobRepository)
        .listener(jobResultListener)
        .listener(dbRedisReconciliationJobListener)
        .start(acquireReconciliationLockStepConfig.acquireReconciliationLockStep())
        .on(DbRedisReconciliationJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED)
        .end()
        .from(acquireReconciliationLockStepConfig.acquireReconciliationLockStep())
        .on("FAILED")
        .fail()
        .from(acquireReconciliationLockStepConfig.acquireReconciliationLockStep())
        .on("*")
        .to(invalidateFamilyInfoAndRemainingStepConfig.invalidateFamilyInfoAndRemainingStep())
        .next(invalidateCustomerMonthlyUsageStepConfig.invalidateCustomerMonthlyUsageStep())
        .next(releaseReconciliationLockStepConfig.releaseReconciliationLockStep())
        .end()
        .build();
```

- 1차 구현의 family info/remaining invalidation 뒤에 `invalidate-customer-monthly-usage-step`을 연결해 정합성 배치의 Redis 무효화 범위를 완성함
- `DbRedisReconciliationJobListener`에서 step context 집계값을 수집해 `deletedFamilyInfoCount`, `deletedFamilyRemainingCount`, `deletedCustomerMonthlyUsageCount`를 한 번에 로그로 남김
- `ActiveFamilyMemberCursorReader<T>` 공통화로 `usagereset`/`reconciliation`이 동일한 cursor 로직을 공유하면서도 각자 DTO와 properties를 사용하도록 정리함


## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- step4는 `targetMonth` suffix의 monthly usage key만 삭제하도록 제한했습니다. 다른 월 키나 family info/remaining 키 범위로 삭제가 퍼지지 않는지 중심으로 봐주시면 좋겠습니다.
- `family_member` cursor reader 공통화가 함께 들어가 있어 `usagereset` 쪽에서 `MonthlyUsageResetProperties`를 사용하도록 분리된 점도 같이 확인 부탁드립니다.
---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [ ] 전체 변경사항이 500줄을 넘지 않는가?

**배치 코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → BatchJobLauncher → Job → Step → Reader/Processor/Writer`)
- [x] 모든 Job에 `JobResultListener`를 등록했는가?
- [x] Reader/Processor/Writer가 각각 단일 책임만 수행하는가?
- [x] Job/Step 이름이 kebab-case인가?
- [x] 하나의 Config 파일에 하나의 Job/Step만 정의했는가?

**테스트**
- [x] 신규 배치 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
