### PR TITLE
[DABOM-385] 월간 리캡 집계 잡 구현

### DIFF
--- a/src/main/java/com/template/worker/jobs/recap/monthly/job/MonthlyFamilyRecapJobConfig.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/job/MonthlyFamilyRecapJobConfig.java
@@ -1,0 +1,50 @@
+package com.template.worker.jobs.recap.monthly.job;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.template.worker.global.listener.JobResultListener;
+import com.template.worker.jobs.recap.monthly.listener.MonthlyFamilyRecapJobListener;
+import com.template.worker.jobs.recap.monthly.step.AcquireMonthlyFamilyRecapLockStepConfig;
+import com.template.worker.jobs.recap.monthly.step.ProcessMonthlyFamilyRecapStepConfig;
+import com.template.worker.jobs.recap.monthly.step.ReleaseMonthlyFamilyRecapLockStepConfig;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobConstants;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class MonthlyFamilyRecapJobConfig {
+
+    private final JobRepository jobRepository;
+    private final JobResultListener jobResultListener;
+    private final MonthlyFamilyRecapJobListener monthlyFamilyRecapJobListener;
+    private final AcquireMonthlyFamilyRecapLockStepConfig acquireMonthlyFamilyRecapLockStepConfig;
+    private final ProcessMonthlyFamilyRecapStepConfig processMonthlyFamilyRecapStepConfig;
+    private final ReleaseMonthlyFamilyRecapLockStepConfig releaseMonthlyFamilyRecapLockStepConfig;
+
+    @Bean
+    public Job monthlyFamilyRecapJob() {
+        // 락 획득 실패면 정상 종료하고 락 획득 성공 시 집계 체인을 실행
+        return new JobBuilder(MonthlyFamilyRecapJobConstants.JOB_NAME, jobRepository)
+                .listener(jobResultListener)
+                .listener(monthlyFamilyRecapJobListener)
+                .start(acquireMonthlyFamilyRecapLockStepConfig.acquireMonthlyFamilyRecapLockStep())
+                .on(MonthlyFamilyRecapJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED)
+                .end()
+                .from(acquireMonthlyFamilyRecapLockStepConfig.acquireMonthlyFamilyRecapLockStep())
+                // 락 스텝 실패는 잡 실패로 명확히 전파
+                .on("FAILED")
+                .fail()
+                .from(acquireMonthlyFamilyRecapLockStepConfig.acquireMonthlyFamilyRecapLockStep())
+                // 락 획득 성공 경로에서만 집계/업서트를 수행
+                .on("*")
+                .to(processMonthlyFamilyRecapStepConfig.processMonthlyFamilyRecapStep())
+                .next(releaseMonthlyFamilyRecapLockStepConfig.releaseMonthlyFamilyRecapLockStep())
+                .end()
+                .build();
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/listener/MonthlyFamilyRecapJobListener.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/listener/MonthlyFamilyRecapJobListener.java
@@ -1,0 +1,81 @@
+package com.template.worker.jobs.recap.monthly.listener;
+
+import java.util.Objects;
+
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobConstants;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapLockManager;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MonthlyFamilyRecapJobListener implements JobExecutionListener {
+
+    private final MonthlyFamilyRecapLockManager lockManager;
+
+    @Override
+    public void beforeJob(JobExecution jobExecution) {
+        // 사전 처리 없음
+    }
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        // 실행 컨텍스트와 파라미터에서 요약 로그 기준값 수집
+        ExecutionContext jobContext = jobExecution.getExecutionContext();
+
+        String targetMonthFromParam =
+                Objects.requireNonNullElse(
+                        jobExecution
+                                .getJobParameters()
+                                .getString(MonthlyFamilyRecapJobConstants.PARAM_TARGET_MONTH),
+                        MonthlyFamilyRecapJobConstants.JOB_CONTEXT_TARGET_MONTH_DEFAULT);
+
+        String targetMonth =
+                jobContext.getString(
+                        MonthlyFamilyRecapJobConstants.JOB_CONTEXT_TARGET_MONTH,
+                        targetMonthFromParam);
+
+        long upsertedCount =
+                findStepWriteCount(
+                        jobExecution, MonthlyFamilyRecapJobConstants.STEP_PROCESS_MONTHLY_RECAP);
+
+        int failureCount = jobExecution.getAllFailureExceptions().size();
+        log.info(
+                "Monthly family recap summary. targetMonth={}, upsertedCount={}, failureCount={},"
+                        + " status={}",
+                targetMonth,
+                upsertedCount,
+                failureCount,
+                jobExecution.getStatus());
+
+        // 예외 경로에서도 락 누수를 막기 위해 마지막에 한 번 더 정리
+        String lockKey =
+                jobContext.getString(MonthlyFamilyRecapJobConstants.JOB_CONTEXT_LOCK_KEY, null);
+        String lockOwner =
+                jobContext.getString(MonthlyFamilyRecapJobConstants.JOB_CONTEXT_LOCK_OWNER, null);
+        boolean released = lockManager.releaseIfOwner(lockKey, lockOwner);
+        if (lockKey != null) {
+            log.info(
+                    "Monthly family recap final lock cleanup. lockKey={}, released={}",
+                    lockKey,
+                    released);
+        }
+    }
+
+    private long findStepWriteCount(JobExecution jobExecution, String stepName) {
+        // 집계 스텝 writeCount를 조회해 처리 건수로 사용
+        return jobExecution.getStepExecutions().stream()
+                .filter(step -> step.getStepName().equals(stepName))
+                .findFirst()
+                .map(StepExecution::getWriteCount)
+                .orElse(0L);
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyFamilyRecapRow.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyFamilyRecapRow.java
@@ -1,0 +1,18 @@
+package com.template.worker.jobs.recap.monthly.model;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+// family_recap_monthly 업서트 대상 모델
+public record MonthlyFamilyRecapRow(
+        Long familyId,
+        LocalDate reportMonth,
+        long totalUsedBytes,
+        long totalQuotaBytes,
+        BigDecimal usageRatePercent,
+        String usageByWeekdayJson,
+        String peakUsageJson,
+        String missionSummaryJson,
+        String appealSummaryJson,
+        String appealHighlightsJson,
+        BigDecimal communicationScore) {}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyFamilyRecapSourceMetrics.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyFamilyRecapSourceMetrics.java
@@ -1,0 +1,11 @@
+package com.template.worker.jobs.recap.monthly.model;
+
+import java.util.List;
+
+// 리포지토리 집계 원본 값을 담는 모델
+public record MonthlyFamilyRecapSourceMetrics(
+        List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots,
+        long totalQuotaBytes,
+        int totalAppeals,
+        int approvedAppeals,
+        int rejectedAppeals) {}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyPeakUsage.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyPeakUsage.java
@@ -1,0 +1,4 @@
+package com.template.worker.jobs.recap.monthly.model;
+
+// 월간 피크 사용 구간 모델
+public record MonthlyPeakUsage(int startHour, int endHour, String mostUsedWeekday) {}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyWeeklyRecapSnapshot.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyWeeklyRecapSnapshot.java
@@ -12,4 +12,6 @@ public record MonthlyWeeklyRecapSnapshot(
         int missionCreatedCount,
         int missionCompletedCount,
         int missionRejectedCount,
-        int appealCount) {}
+        int totalAppealCount,
+        int approvedAppealCount,
+        int rejectedAppealCount) {}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyWeeklyRecapSnapshot.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyWeeklyRecapSnapshot.java
@@ -1,0 +1,15 @@
+package com.template.worker.jobs.recap.monthly.model;
+
+import java.time.LocalDate;
+
+// 월간 집계 시 사용하는 주간 리캡 스냅샷
+public record MonthlyWeeklyRecapSnapshot(
+        LocalDate weekStartDate,
+        long totalUsedBytes,
+        long totalQuotaBytes,
+        String usageByWeekdayJson,
+        String peakUsageJson,
+        int missionCreatedCount,
+        int missionCompletedCount,
+        int missionRejectedCount,
+        int appealCount) {}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
@@ -1,0 +1,432 @@
+package com.template.worker.jobs.recap.monthly.processor;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapRow;
+import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapSourceMetrics;
+import com.template.worker.jobs.recap.monthly.model.MonthlyPeakUsage;
+import com.template.worker.jobs.recap.monthly.model.MonthlyWeeklyRecapSnapshot;
+import com.template.worker.jobs.recap.monthly.query.MonthlyFamilyRecapAggregationRepository;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobParameterSupport;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MonthlyFamilyRecapProcessor
+        implements ItemProcessor<Long, MonthlyFamilyRecapRow>, StepExecutionListener {
+
+    private static final List<String> WEEKDAY_KEYS =
+            List.of("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday");
+
+    private final MonthlyFamilyRecapAggregationRepository aggregationRepository;
+    private final MonthlyFamilyRecapJobParameterSupport parameterSupport;
+    private final ObjectMapper objectMapper;
+
+    private LocalDate targetMonth;
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        // 스텝 시작 시 월간 기준일을 고정
+        targetMonth = parameterSupport.resolveTargetMonth(stepExecution.getJobParameters());
+    }
+
+    @Override
+    public MonthlyFamilyRecapRow process(Long familyId) {
+        // 가족별 원본 집계값 조회
+        MonthlyFamilyRecapSourceMetrics sourceMetrics =
+                aggregationRepository.aggregate(familyId, targetMonth);
+
+        // writer 진입 전에 집계값 검증
+        validateSourceMetrics(familyId, sourceMetrics);
+
+        List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots = sourceMetrics.fullWeekSnapshots();
+
+        // 이번 이슈 범위에서는 full week 합산값만 월간 사용량에 반영
+        long totalUsedBytes =
+                fullWeekSnapshots.stream()
+                        .mapToLong(MonthlyWeeklyRecapSnapshot::totalUsedBytes)
+                        .sum();
+        long totalQuotaBytes = sourceMetrics.totalQuotaBytes();
+        BigDecimal usageRatePercent = calculatePercent(totalUsedBytes, totalQuotaBytes);
+
+        // 주간 퍼센트 평균이 아니라 주간 사용량 가중합으로 월간 요일 비율 계산
+        Map<String, BigDecimal> usageByWeekday =
+                aggregateUsageByWeekday(familyId, fullWeekSnapshots);
+        String usageByWeekdayJson = toJson(familyId, usageByWeekday, "usageByWeekday");
+
+        String mostUsedWeekday = resolveMostUsedWeekday(usageByWeekday);
+        MonthlyPeakUsage peakUsage =
+                aggregatePeakUsage(familyId, fullWeekSnapshots, mostUsedWeekday);
+        String peakUsageJson = toJson(familyId, peakUsage, "peakUsage");
+
+        int totalMissionCount =
+                fullWeekSnapshots.stream()
+                        .mapToInt(MonthlyWeeklyRecapSnapshot::missionCreatedCount)
+                        .sum();
+        int completedMissionCount =
+                fullWeekSnapshots.stream()
+                        .mapToInt(MonthlyWeeklyRecapSnapshot::missionCompletedCount)
+                        .sum();
+        int rejectedRequestCount =
+                fullWeekSnapshots.stream()
+                        .mapToInt(MonthlyWeeklyRecapSnapshot::missionRejectedCount)
+                        .sum();
+
+        String missionSummaryJson =
+                buildMissionSummaryJson(
+                        familyId, totalMissionCount, completedMissionCount, rejectedRequestCount);
+
+        String appealSummaryJson =
+                buildAppealSummaryJson(
+                        familyId,
+                        sourceMetrics.totalAppeals(),
+                        sourceMetrics.approvedAppeals(),
+                        sourceMetrics.rejectedAppeals());
+
+        String appealHighlightsJson = buildDefaultAppealHighlightsJson(familyId);
+
+        BigDecimal communicationScore =
+                calculateCommunicationScore(
+                        sourceMetrics.approvedAppeals(),
+                        sourceMetrics.rejectedAppeals(),
+                        sourceMetrics.totalAppeals(),
+                        totalMissionCount,
+                        completedMissionCount);
+
+        // 업서트 모델로 변환
+        return new MonthlyFamilyRecapRow(
+                familyId,
+                targetMonth,
+                totalUsedBytes,
+                totalQuotaBytes,
+                usageRatePercent,
+                usageByWeekdayJson,
+                peakUsageJson,
+                missionSummaryJson,
+                appealSummaryJson,
+                appealHighlightsJson,
+                communicationScore);
+    }
+
+    private void validateSourceMetrics(
+            Long familyId, MonthlyFamilyRecapSourceMetrics sourceMetrics) {
+        if (targetMonth.getDayOfMonth() != 1) {
+            throw new IllegalStateException(
+                    "targetMonth must be first day of month. familyId=" + familyId);
+        }
+        if (sourceMetrics.totalQuotaBytes() < 0) {
+            throw new IllegalStateException(
+                    "Quota snapshot cannot be negative. familyId=" + familyId);
+        }
+        if (sourceMetrics.totalAppeals() < 0
+                || sourceMetrics.approvedAppeals() < 0
+                || sourceMetrics.rejectedAppeals() < 0) {
+            throw new IllegalStateException(
+                    "Appeal aggregate cannot be negative. familyId=" + familyId);
+        }
+
+        for (MonthlyWeeklyRecapSnapshot snapshot : sourceMetrics.fullWeekSnapshots()) {
+            if (snapshot.totalUsedBytes() < 0 || snapshot.totalQuotaBytes() < 0) {
+                throw new IllegalStateException(
+                        "Weekly usage aggregate cannot be negative. familyId=" + familyId);
+            }
+            if (snapshot.missionCreatedCount() < 0
+                    || snapshot.missionCompletedCount() < 0
+                    || snapshot.missionRejectedCount() < 0
+                    || snapshot.appealCount() < 0) {
+                throw new IllegalStateException(
+                        "Weekly count aggregate cannot be negative. familyId=" + familyId);
+            }
+        }
+    }
+
+    private Map<String, BigDecimal> aggregateUsageByWeekday(
+            Long familyId, List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots) {
+        Map<String, BigDecimal> weekdayUsedBytes = initWeekdayDecimalMap();
+
+        for (MonthlyWeeklyRecapSnapshot snapshot : fullWeekSnapshots) {
+            Map<String, BigDecimal> weeklyUsageByWeekday =
+                    parseUsageByWeekdayJson(
+                            familyId, snapshot.weekStartDate(), snapshot.usageByWeekdayJson());
+
+            for (String weekday : WEEKDAY_KEYS) {
+                BigDecimal usagePercent =
+                        weeklyUsageByWeekday.getOrDefault(weekday, BigDecimal.ZERO);
+                // 주간 퍼센트를 주간 totalUsedBytes에 환산해 월간 누적 바이트로 변환
+                BigDecimal weightedBytes =
+                        BigDecimal.valueOf(snapshot.totalUsedBytes())
+                                .multiply(usagePercent)
+                                .divide(BigDecimal.valueOf(100), 6, RoundingMode.HALF_UP);
+
+                weekdayUsedBytes.put(weekday, weekdayUsedBytes.get(weekday).add(weightedBytes));
+            }
+        }
+
+        long totalUsedBytes =
+                fullWeekSnapshots.stream()
+                        .mapToLong(MonthlyWeeklyRecapSnapshot::totalUsedBytes)
+                        .sum();
+
+        // 누적 바이트를 월 totalUsedBytes 대비 퍼센트로 재계산
+        Map<String, BigDecimal> monthlyUsageByWeekday = new LinkedHashMap<>();
+        for (String weekday : WEEKDAY_KEYS) {
+            BigDecimal weekdayUsed = weekdayUsedBytes.getOrDefault(weekday, BigDecimal.ZERO);
+            monthlyUsageByWeekday.put(weekday, calculatePercent(weekdayUsed, totalUsedBytes));
+        }
+
+        return monthlyUsageByWeekday;
+    }
+
+    private MonthlyPeakUsage aggregatePeakUsage(
+            Long familyId,
+            List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots,
+            String mostUsedWeekday) {
+        // peakBytes 우선, 동률이면 더 이른 시간대를 우선 선택
+        WeeklyPeakUsageCandidate selected = new WeeklyPeakUsageCandidate(0, 1, 0L);
+
+        for (MonthlyWeeklyRecapSnapshot snapshot : fullWeekSnapshots) {
+            WeeklyPeakUsageCandidate candidate =
+                    parsePeakUsageJson(
+                            familyId, snapshot.weekStartDate(), snapshot.peakUsageJson());
+
+            if (candidate.isBetterThan(selected)) {
+                selected = candidate;
+            }
+        }
+
+        return new MonthlyPeakUsage(selected.startHour(), selected.endHour(), mostUsedWeekday);
+    }
+
+    private String buildMissionSummaryJson(
+            Long familyId,
+            int totalMissionCount,
+            int completedMissionCount,
+            int rejectedRequestCount) {
+        Map<String, Integer> missionSummary = new LinkedHashMap<>();
+        missionSummary.put("totalMissionCount", totalMissionCount);
+        missionSummary.put("completedMissionCount", completedMissionCount);
+        missionSummary.put("rejectedRequestCount", rejectedRequestCount);
+
+        return toJson(familyId, missionSummary, "missionSummary");
+    }
+
+    private String buildAppealSummaryJson(
+            Long familyId, int totalAppeals, int approvedAppeals, int rejectedAppeals) {
+        Map<String, Integer> appealSummary = new LinkedHashMap<>();
+        appealSummary.put("totalAppeals", totalAppeals);
+        appealSummary.put("approvedAppeals", approvedAppeals);
+        appealSummary.put("rejectedAppeals", rejectedAppeals);
+
+        return toJson(familyId, appealSummary, "appealSummary");
+    }
+
+    private String buildDefaultAppealHighlightsJson(Long familyId) {
+        Map<String, Object> topSuccessfulRequester = new LinkedHashMap<>();
+        topSuccessfulRequester.put("requesterId", null);
+        topSuccessfulRequester.put("requesterName", null);
+        topSuccessfulRequester.put("approvedAppealCount", 0);
+        topSuccessfulRequester.put("recentApprovedAppeals", List.of());
+
+        Map<String, Object> topAcceptedApprover = new LinkedHashMap<>();
+        topAcceptedApprover.put("approverId", null);
+        topAcceptedApprover.put("approverName", null);
+        topAcceptedApprover.put("approvedAppealCount", 0);
+        topAcceptedApprover.put("recentAcceptedAppeals", List.of());
+
+        Map<String, Object> highlights = new LinkedHashMap<>();
+        highlights.put("topSuccessfulRequester", topSuccessfulRequester);
+        highlights.put("topAcceptedApprover", topAcceptedApprover);
+
+        return toJson(familyId, highlights, "appealHighlights");
+    }
+
+    private Map<String, BigDecimal> parseUsageByWeekdayJson(
+            Long familyId, LocalDate weekStartDate, String usageByWeekdayJson) {
+        Map<String, BigDecimal> usageByWeekday = initWeekdayDecimalMap();
+
+        if (usageByWeekdayJson == null || usageByWeekdayJson.isBlank()) {
+            return usageByWeekday;
+        }
+
+        try {
+            JsonNode root = objectMapper.readTree(usageByWeekdayJson);
+            for (String weekday : WEEKDAY_KEYS) {
+                JsonNode valueNode = root.get(weekday);
+                usageByWeekday.put(weekday, parseBigDecimal(valueNode));
+            }
+            return usageByWeekday;
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException(
+                    "Failed to parse weekly usageByWeekday JSON. familyId="
+                            + familyId
+                            + ", weekStartDate="
+                            + weekStartDate,
+                    exception);
+        }
+    }
+
+    private WeeklyPeakUsageCandidate parsePeakUsageJson(
+            Long familyId, LocalDate weekStartDate, String peakUsageJson) {
+        if (peakUsageJson == null || peakUsageJson.isBlank()) {
+            return new WeeklyPeakUsageCandidate(0, 1, 0L);
+        }
+
+        try {
+            JsonNode root = objectMapper.readTree(peakUsageJson);
+            int startHour = root.path("startHour").asInt(0);
+            int endHour = root.path("endHour").asInt(startHour + 1);
+            long peakBytes = root.path("peakBytes").asLong(0L);
+            return new WeeklyPeakUsageCandidate(startHour, endHour, peakBytes);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException(
+                    "Failed to parse weekly peakUsage JSON. familyId="
+                            + familyId
+                            + ", weekStartDate="
+                            + weekStartDate,
+                    exception);
+        }
+    }
+
+    private String resolveMostUsedWeekday(Map<String, BigDecimal> usageByWeekday) {
+        String mostUsedWeekday = WEEKDAY_KEYS.get(0);
+        BigDecimal mostUsedValue = usageByWeekday.getOrDefault(mostUsedWeekday, BigDecimal.ZERO);
+
+        for (String weekday : WEEKDAY_KEYS) {
+            BigDecimal current = usageByWeekday.getOrDefault(weekday, BigDecimal.ZERO);
+            if (current.compareTo(mostUsedValue) > 0) {
+                mostUsedWeekday = weekday;
+                mostUsedValue = current;
+            }
+        }
+
+        return mostUsedWeekday;
+    }
+
+    private BigDecimal calculateCommunicationScore(
+            int approvedAppeals,
+            int rejectedAppeals,
+            int totalAppeals,
+            int totalMissionCount,
+            int completedMissionCount) {
+        if (totalAppeals > 0) {
+            // NORMAL 이의제기가 1건 이상이면 가이드 수식(A/B/C)으로 계산
+            int respondedAppeals = approvedAppeals + rejectedAppeals;
+
+            BigDecimal factorA =
+                    respondedAppeals == 0
+                            ? BigDecimal.ZERO
+                            : divide(approvedAppeals, respondedAppeals);
+            BigDecimal factorB = divide(respondedAppeals, totalAppeals);
+            BigDecimal factorC =
+                    approvedAppeals == 0
+                            ? BigDecimal.ZERO
+                            : divide(completedMissionCount, approvedAppeals).min(BigDecimal.ONE);
+
+            return factorA.multiply(BigDecimal.valueOf(0.5))
+                    .add(factorB.multiply(BigDecimal.valueOf(0.3)))
+                    .add(factorC.multiply(BigDecimal.valueOf(0.2)))
+                    .multiply(BigDecimal.valueOf(100))
+                    .setScale(2, RoundingMode.HALF_UP);
+        }
+
+        if (totalMissionCount > 0) {
+            // 이의제기 0건이면 미션 완료율 fallback 점수를 사용
+            return calculatePercent(completedMissionCount, totalMissionCount);
+        }
+
+        // 이의제기/미션 모두 없으면 점수 미산정(null)
+        return null;
+    }
+
+    private Map<String, BigDecimal> initWeekdayDecimalMap() {
+        Map<String, BigDecimal> map = new LinkedHashMap<>();
+        for (String weekday : WEEKDAY_KEYS) {
+            map.put(weekday, BigDecimal.ZERO);
+        }
+        return map;
+    }
+
+    private BigDecimal parseBigDecimal(JsonNode valueNode) {
+        if (valueNode == null || valueNode.isNull()) {
+            return BigDecimal.ZERO;
+        }
+
+        try {
+            return new BigDecimal(valueNode.asText("0"));
+        } catch (NumberFormatException exception) {
+            return BigDecimal.ZERO;
+        }
+    }
+
+    private String toJson(Long familyId, Object target, String targetName) {
+        try {
+            return objectMapper.writeValueAsString(target);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException(
+                    "Failed to serialize " + targetName + " to JSON. familyId=" + familyId,
+                    exception);
+        }
+    }
+
+    private BigDecimal calculatePercent(long numerator, long denominator) {
+        if (denominator <= 0) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+
+        return BigDecimal.valueOf(numerator)
+                .multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(denominator), 2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal calculatePercent(BigDecimal numerator, long denominator) {
+        if (denominator <= 0) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+        }
+
+        return numerator
+                .multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(denominator), 2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal divide(int numerator, int denominator) {
+        if (denominator <= 0) {
+            return BigDecimal.ZERO;
+        }
+
+        return BigDecimal.valueOf(numerator)
+                .divide(BigDecimal.valueOf(denominator), 6, RoundingMode.HALF_UP);
+    }
+
+    private record WeeklyPeakUsageCandidate(int startHour, int endHour, long peakBytes) {
+
+        private boolean isBetterThan(WeeklyPeakUsageCandidate current) {
+            if (peakBytes > current.peakBytes) {
+                return true;
+            }
+            if (peakBytes < current.peakBytes) {
+                return false;
+            }
+            if (startHour < current.startHour) {
+                return true;
+            }
+            if (startHour > current.startHour) {
+                return false;
+            }
+            return endHour < current.endHour;
+        }
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
@@ -90,6 +90,7 @@ public class MonthlyFamilyRecapProcessor
                 buildMissionSummaryJson(
                         familyId, totalMissionCount, completedMissionCount, rejectedRequestCount);
 
+        // full week snapshot에서 합산한 이의제기 요약을 월간 JSON으로 변환
         String appealSummaryJson =
                 buildAppealSummaryJson(
                         familyId,
@@ -143,7 +144,9 @@ public class MonthlyFamilyRecapProcessor
             if (snapshot.missionCreatedCount() < 0
                     || snapshot.missionCompletedCount() < 0
                     || snapshot.missionRejectedCount() < 0
-                    || snapshot.appealCount() < 0) {
+                    || snapshot.totalAppealCount() < 0
+                    || snapshot.approvedAppealCount() < 0
+                    || snapshot.rejectedAppealCount() < 0) {
                 throw new IllegalStateException(
                         "Weekly count aggregate cannot be negative. familyId=" + familyId);
             }

--- a/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
@@ -124,10 +124,6 @@ public class MonthlyFamilyRecapProcessor
 
     private void validateSourceMetrics(
             Long familyId, MonthlyFamilyRecapSourceMetrics sourceMetrics) {
-        if (targetMonth.getDayOfMonth() != 1) {
-            throw new IllegalStateException(
-                    "targetMonth must be first day of month. familyId=" + familyId);
-        }
         if (sourceMetrics.totalQuotaBytes() < 0) {
             throw new IllegalStateException(
                     "Quota snapshot cannot be negative. familyId=" + familyId);

--- a/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
@@ -1,0 +1,192 @@
+package com.template.worker.jobs.recap.monthly.query;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapSourceMetrics;
+import com.template.worker.jobs.recap.monthly.model.MonthlyWeeklyRecapSnapshot;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MonthlyFamilyRecapAggregationRepository {
+
+    private static final String READ_FULL_WEEKLY_RECAP_ROWS_SQL =
+            """
+            SELECT week_start_date,
+                   total_used_bytes,
+                   total_quota_bytes,
+                   usage_by_weekday,
+                   peak_usage,
+                   mission_created_count,
+                   mission_completed_count,
+                   mission_rejected_count,
+                   appeal_count
+            FROM family_recap_weekly
+            WHERE family_id = :familyId
+              AND week_start_date >= :monthStartDate
+              AND DATE_ADD(week_start_date, INTERVAL 7 DAY) <= :monthEndExclusiveDate
+            ORDER BY week_start_date ASC
+            """;
+
+    private static final String READ_LATEST_QUOTA_SNAPSHOT_FROM_WEEKLY_SQL =
+            """
+            SELECT total_quota_bytes
+            FROM family_recap_weekly
+            WHERE family_id = :familyId
+              AND week_start_date < :monthEndExclusiveDate
+              AND DATE_ADD(week_start_date, INTERVAL 7 DAY) > :monthStartDate
+            ORDER BY week_start_date DESC
+            LIMIT 1
+            """;
+
+    private static final String READ_FAMILY_QUOTA_BYTES_SQL =
+            """
+            SELECT total_quota_bytes
+            FROM family
+            WHERE id = :familyId
+              AND deleted_at IS NULL
+            """;
+
+    private static final String READ_TOTAL_NORMAL_APPEALS_SQL =
+            """
+            SELECT COUNT(*)
+            FROM policy_appeal pa
+            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
+            WHERE pas.family_id = :familyId
+              AND pa.type = 'NORMAL'
+              AND pa.created_at >= :monthStart
+              AND pa.created_at < :monthEndExclusive
+              AND pas.deleted_at IS NULL
+            """;
+
+    private static final String READ_APPROVED_NORMAL_APPEALS_SQL =
+            """
+            SELECT COUNT(*)
+            FROM policy_appeal pa
+            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
+            WHERE pas.family_id = :familyId
+              AND pa.type = 'NORMAL'
+              AND pa.status = 'APPROVED'
+              AND pa.created_at >= :monthStart
+              AND pa.created_at < :monthEndExclusive
+              AND pa.resolved_at < :monthEndExclusive
+              AND pas.deleted_at IS NULL
+            """;
+
+    private static final String READ_REJECTED_NORMAL_APPEALS_SQL =
+            """
+            SELECT COUNT(*)
+            FROM policy_appeal pa
+            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
+            WHERE pas.family_id = :familyId
+              AND pa.type = 'NORMAL'
+              AND pa.status = 'REJECTED'
+              AND pa.created_at >= :monthStart
+              AND pa.created_at < :monthEndExclusive
+              AND pa.resolved_at < :monthEndExclusive
+              AND pas.deleted_at IS NULL
+            """;
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public MonthlyFamilyRecapSourceMetrics aggregate(Long familyId, LocalDate targetMonth) {
+        // 월간 집계 구간 [monthStart, monthEndExclusive) 계산
+        LocalDateTime monthStart = targetMonth.atStartOfDay();
+        LocalDateTime monthEndExclusive = monthStart.plusMonths(1);
+
+        MapSqlParameterSource params =
+                new MapSqlParameterSource()
+                        .addValue("familyId", familyId)
+                        .addValue("monthStart", Timestamp.valueOf(monthStart))
+                        .addValue("monthEndExclusive", Timestamp.valueOf(monthEndExclusive))
+                        .addValue("monthStartDate", Date.valueOf(targetMonth))
+                        .addValue("monthEndExclusiveDate", Date.valueOf(targetMonth.plusMonths(1)));
+
+        // 월 내부에 완전히 포함된 full week만 1차 소스로 사용
+        List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots = readFullWeekSnapshots(params);
+        // quota는 주간 합산하지 않고 월 스냅샷 단일값으로 조회
+        long totalQuotaBytes = readQuotaSnapshot(params);
+
+        // 월간 이의제기 요약은 NORMAL 타입만 집계
+        int totalAppeals = readInt(READ_TOTAL_NORMAL_APPEALS_SQL, params);
+        int approvedAppeals = readInt(READ_APPROVED_NORMAL_APPEALS_SQL, params);
+        int rejectedAppeals = readInt(READ_REJECTED_NORMAL_APPEALS_SQL, params);
+
+        return new MonthlyFamilyRecapSourceMetrics(
+                fullWeekSnapshots, totalQuotaBytes, totalAppeals, approvedAppeals, rejectedAppeals);
+    }
+
+    private List<MonthlyWeeklyRecapSnapshot> readFullWeekSnapshots(MapSqlParameterSource params) {
+        List<Map<String, Object>> rows =
+                jdbcTemplate.queryForList(READ_FULL_WEEKLY_RECAP_ROWS_SQL, params);
+
+        return rows.stream()
+                .map(
+                        row ->
+                                new MonthlyWeeklyRecapSnapshot(
+                                        toLocalDate(row.get("week_start_date")),
+                                        ((Number) row.get("total_used_bytes")).longValue(),
+                                        ((Number) row.get("total_quota_bytes")).longValue(),
+                                        toJsonString(row.get("usage_by_weekday")),
+                                        toJsonString(row.get("peak_usage")),
+                                        ((Number) row.get("mission_created_count")).intValue(),
+                                        ((Number) row.get("mission_completed_count")).intValue(),
+                                        ((Number) row.get("mission_rejected_count")).intValue(),
+                                        ((Number) row.get("appeal_count")).intValue()))
+                .toList();
+    }
+
+    private long readQuotaSnapshot(MapSqlParameterSource params) {
+        // 주간 스냅샷이 있으면 가장 최근 값을 우선 사용
+        Long quotaFromWeekly = readNullableLong(READ_LATEST_QUOTA_SNAPSHOT_FROM_WEEKLY_SQL, params);
+        if (quotaFromWeekly != null) {
+            return quotaFromWeekly;
+        }
+
+        // 주간 스냅샷이 없으면 family 현재 quota로 fallback
+        Long quotaFromFamily = readNullableLong(READ_FAMILY_QUOTA_BYTES_SQL, params);
+        return quotaFromFamily == null ? 0L : quotaFromFamily;
+    }
+
+    private int readInt(String sql, MapSqlParameterSource params) {
+        try {
+            Integer value = jdbcTemplate.queryForObject(sql, params, Integer.class);
+            return value == null ? 0 : value;
+        } catch (EmptyResultDataAccessException exception) {
+            return 0;
+        }
+    }
+
+    private Long readNullableLong(String sql, MapSqlParameterSource params) {
+        try {
+            return jdbcTemplate.queryForObject(sql, params, Long.class);
+        } catch (EmptyResultDataAccessException exception) {
+            return null;
+        }
+    }
+
+    private LocalDate toLocalDate(Object value) {
+        if (value instanceof Date dateValue) {
+            return dateValue.toLocalDate();
+        }
+        if (value instanceof Timestamp timestampValue) {
+            return timestampValue.toLocalDateTime().toLocalDate();
+        }
+        return LocalDate.parse(String.valueOf(value));
+    }
+
+    private String toJsonString(Object value) {
+        return value == null ? "{}" : String.valueOf(value);
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
@@ -187,6 +187,6 @@ public class MonthlyFamilyRecapAggregationRepository {
     }
 
     private String toJsonString(Object value) {
-        return value == null ? "{}" : String.valueOf(value);
+        return value == null ? null : String.valueOf(value);
     }
 }

--- a/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
@@ -97,7 +97,9 @@ public class MonthlyFamilyRecapAggregationRepository {
                                         ((Number) row.get("mission_created_count")).intValue(),
                                         ((Number) row.get("mission_completed_count")).intValue(),
                                         ((Number) row.get("mission_rejected_count")).intValue(),
-                                        ((Number) row.get("total_appeal_count")).intValue()))
+                                        ((Number) row.get("total_appeal_count")).intValue(),
+                                        ((Number) row.get("approved_appeal_count")).intValue(),
+                                        ((Number) row.get("rejected_appeal_count")).intValue()))
                 .toList();
     }
 

--- a/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
@@ -3,7 +3,6 @@ package com.template.worker.jobs.recap.monthly.query;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -31,7 +30,9 @@ public class MonthlyFamilyRecapAggregationRepository {
                    mission_created_count,
                    mission_completed_count,
                    mission_rejected_count,
-                   appeal_count
+                   total_appeal_count,
+                   approved_appeal_count,
+                   rejected_appeal_count
             FROM family_recap_weekly
             WHERE family_id = :familyId
               AND week_start_date >= :monthStartDate
@@ -58,79 +59,32 @@ public class MonthlyFamilyRecapAggregationRepository {
               AND deleted_at IS NULL
             """;
 
-    private static final String READ_TOTAL_NORMAL_APPEALS_SQL =
-            """
-            SELECT COUNT(*)
-            FROM policy_appeal pa
-            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
-            WHERE pas.family_id = :familyId
-              AND pa.type = 'NORMAL'
-              AND pa.created_at >= :monthStart
-              AND pa.created_at < :monthEndExclusive
-              AND pas.deleted_at IS NULL
-            """;
-
-    private static final String READ_APPROVED_NORMAL_APPEALS_SQL =
-            """
-            SELECT COUNT(*)
-            FROM policy_appeal pa
-            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
-            WHERE pas.family_id = :familyId
-              AND pa.type = 'NORMAL'
-              AND pa.status = 'APPROVED'
-              AND pa.created_at >= :monthStart
-              AND pa.created_at < :monthEndExclusive
-              AND pa.resolved_at < :monthEndExclusive
-              AND pas.deleted_at IS NULL
-            """;
-
-    private static final String READ_REJECTED_NORMAL_APPEALS_SQL =
-            """
-            SELECT COUNT(*)
-            FROM policy_appeal pa
-            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
-            WHERE pas.family_id = :familyId
-              AND pa.type = 'NORMAL'
-              AND pa.status = 'REJECTED'
-              AND pa.created_at >= :monthStart
-              AND pa.created_at < :monthEndExclusive
-              AND pa.resolved_at < :monthEndExclusive
-              AND pas.deleted_at IS NULL
-            """;
-
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
     public MonthlyFamilyRecapSourceMetrics aggregate(Long familyId, LocalDate targetMonth) {
-        // 월간 집계 구간 [monthStart, monthEndExclusive) 계산
-        LocalDateTime monthStart = targetMonth.atStartOfDay();
-        LocalDateTime monthEndExclusive = monthStart.plusMonths(1);
-
         MapSqlParameterSource params =
                 new MapSqlParameterSource()
                         .addValue("familyId", familyId)
-                        .addValue("monthStart", Timestamp.valueOf(monthStart))
-                        .addValue("monthEndExclusive", Timestamp.valueOf(monthEndExclusive))
                         .addValue("monthStartDate", Date.valueOf(targetMonth))
                         .addValue("monthEndExclusiveDate", Date.valueOf(targetMonth.plusMonths(1)));
 
         // 월 내부에 완전히 포함된 full week만 1차 소스로 사용
-        List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots = readFullWeekSnapshots(params);
+        List<Map<String, Object>> rows =
+                jdbcTemplate.queryForList(READ_FULL_WEEKLY_RECAP_ROWS_SQL, params);
+        List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots = readFullWeekSnapshots(rows);
         // quota는 주간 합산하지 않고 월 스냅샷 단일값으로 조회
         long totalQuotaBytes = readQuotaSnapshot(params);
 
-        // 월간 이의제기 요약은 NORMAL 타입만 집계
-        int totalAppeals = readInt(READ_TOTAL_NORMAL_APPEALS_SQL, params);
-        int approvedAppeals = readInt(READ_APPROVED_NORMAL_APPEALS_SQL, params);
-        int rejectedAppeals = readInt(READ_REJECTED_NORMAL_APPEALS_SQL, params);
+        // partial week 보강 없이 full week snapshot의 이의제기 count만 합산
+        int totalAppeals = sumInt(rows, "total_appeal_count");
+        int approvedAppeals = sumInt(rows, "approved_appeal_count");
+        int rejectedAppeals = sumInt(rows, "rejected_appeal_count");
 
         return new MonthlyFamilyRecapSourceMetrics(
                 fullWeekSnapshots, totalQuotaBytes, totalAppeals, approvedAppeals, rejectedAppeals);
     }
 
-    private List<MonthlyWeeklyRecapSnapshot> readFullWeekSnapshots(MapSqlParameterSource params) {
-        List<Map<String, Object>> rows =
-                jdbcTemplate.queryForList(READ_FULL_WEEKLY_RECAP_ROWS_SQL, params);
-
+    private List<MonthlyWeeklyRecapSnapshot> readFullWeekSnapshots(List<Map<String, Object>> rows) {
         return rows.stream()
                 .map(
                         row ->
@@ -143,7 +97,7 @@ public class MonthlyFamilyRecapAggregationRepository {
                                         ((Number) row.get("mission_created_count")).intValue(),
                                         ((Number) row.get("mission_completed_count")).intValue(),
                                         ((Number) row.get("mission_rejected_count")).intValue(),
-                                        ((Number) row.get("appeal_count")).intValue()))
+                                        ((Number) row.get("total_appeal_count")).intValue()))
                 .toList();
     }
 
@@ -159,13 +113,13 @@ public class MonthlyFamilyRecapAggregationRepository {
         return quotaFromFamily == null ? 0L : quotaFromFamily;
     }
 
-    private int readInt(String sql, MapSqlParameterSource params) {
-        try {
-            Integer value = jdbcTemplate.queryForObject(sql, params, Integer.class);
-            return value == null ? 0 : value;
-        } catch (EmptyResultDataAccessException exception) {
-            return 0;
-        }
+    private int sumInt(List<Map<String, Object>> rows, String columnName) {
+        return rows.stream()
+                .map(row -> row.get(columnName))
+                .filter(Number.class::isInstance)
+                .map(Number.class::cast)
+                .mapToInt(Number::intValue)
+                .sum();
     }
 
     private Long readNullableLong(String sql, MapSqlParameterSource params) {

--- a/src/main/java/com/template/worker/jobs/recap/monthly/reader/MonthlyFamilyRecapFamilyReader.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/reader/MonthlyFamilyRecapFamilyReader.java
@@ -1,0 +1,17 @@
+package com.template.worker.jobs.recap.monthly.reader;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.common.reader.ActiveFamilyCursorReader;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapProperties;
+
+@Component
+public class MonthlyFamilyRecapFamilyReader extends ActiveFamilyCursorReader {
+
+    public MonthlyFamilyRecapFamilyReader(
+            JdbcTemplate jdbcTemplate, MonthlyFamilyRecapProperties properties) {
+        // 공통 활성 가족 커서 리더를 재사용
+        super(jdbcTemplate, properties::getDbFetchSize);
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/scheduler/MonthlyFamilyRecapScheduler.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/scheduler/MonthlyFamilyRecapScheduler.java
@@ -1,0 +1,48 @@
+package com.template.worker.jobs.recap.monthly.scheduler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.global.launcher.BatchJobLauncher;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobConstants;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobParameterSupport;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "batch.schedules.monthly-family-recap.enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+public class MonthlyFamilyRecapScheduler {
+
+    private final BatchJobLauncher launcher;
+    private final MonthlyFamilyRecapJobParameterSupport parameterSupport;
+
+    @Scheduled(
+            cron = "${batch.schedules.monthly-family-recap.cron:0 20 0 1 * *}",
+            zone = MonthlyFamilyRecapJobConstants.KST_ZONE_ID_NAME)
+    public void runMonthlyFamilyRecapJob() {
+        Map<String, String> params = new HashMap<>();
+        // 스케줄 실행 시점 기준 직전 달 시작일을 기본 파라미터로 전달
+        String targetMonth = parameterSupport.defaultTargetMonth().toString();
+        params.put(MonthlyFamilyRecapJobConstants.PARAM_TARGET_MONTH, targetMonth);
+
+        try {
+            launcher.run(MonthlyFamilyRecapJobConstants.JOB_NAME, params);
+        } catch (Exception exception) {
+            // 스케줄 실패가 다음 실행까지 전파되지 않도록 로그로만 기록
+            log.error(
+                    "Failed to run monthly family recap job by scheduler. targetMonth={}",
+                    targetMonth,
+                    exception);
+        }
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/step/AcquireMonthlyFamilyRecapLockStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/step/AcquireMonthlyFamilyRecapLockStepConfig.java
@@ -1,0 +1,32 @@
+package com.template.worker.jobs.recap.monthly.step;
+
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobConstants;
+import com.template.worker.jobs.recap.monthly.tasklet.MonthlyFamilyRecapLockTasklet;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class AcquireMonthlyFamilyRecapLockStepConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final MonthlyFamilyRecapLockTasklet tasklet;
+
+    @Bean
+    public Step acquireMonthlyFamilyRecapLockStep() {
+        // 락 획득 태스크릿을 스텝으로 구성
+        return new StepBuilder(
+                        MonthlyFamilyRecapJobConstants.STEP_ACQUIRE_MONTHLY_RECAP_LOCK,
+                        jobRepository)
+                .tasklet(tasklet, transactionManager)
+                .build();
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/step/ProcessMonthlyFamilyRecapStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/step/ProcessMonthlyFamilyRecapStepConfig.java
@@ -1,0 +1,41 @@
+package com.template.worker.jobs.recap.monthly.step;
+
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapRow;
+import com.template.worker.jobs.recap.monthly.processor.MonthlyFamilyRecapProcessor;
+import com.template.worker.jobs.recap.monthly.reader.MonthlyFamilyRecapFamilyReader;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobConstants;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapProperties;
+import com.template.worker.jobs.recap.monthly.writer.MonthlyFamilyRecapUpsertWriter;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class ProcessMonthlyFamilyRecapStepConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final MonthlyFamilyRecapFamilyReader reader;
+    private final MonthlyFamilyRecapProcessor processor;
+    private final MonthlyFamilyRecapUpsertWriter writer;
+    private final MonthlyFamilyRecapProperties properties;
+
+    @Bean
+    public Step processMonthlyFamilyRecapStep() {
+        // 활성 가족을 읽어 집계 후 즉시 업서트하는 청크 스텝
+        return new StepBuilder(
+                        MonthlyFamilyRecapJobConstants.STEP_PROCESS_MONTHLY_RECAP, jobRepository)
+                .<Long, MonthlyFamilyRecapRow>chunk(properties.getChunkSize(), transactionManager)
+                .reader(reader)
+                .processor(processor)
+                .writer(writer)
+                .build();
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/step/ReleaseMonthlyFamilyRecapLockStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/step/ReleaseMonthlyFamilyRecapLockStepConfig.java
@@ -1,0 +1,32 @@
+package com.template.worker.jobs.recap.monthly.step;
+
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobConstants;
+import com.template.worker.jobs.recap.monthly.tasklet.MonthlyFamilyRecapLockReleaseTasklet;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class ReleaseMonthlyFamilyRecapLockStepConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final MonthlyFamilyRecapLockReleaseTasklet tasklet;
+
+    @Bean
+    public Step releaseMonthlyFamilyRecapLockStep() {
+        // 마지막에 락 해제 태스크릿을 실행
+        return new StepBuilder(
+                        MonthlyFamilyRecapJobConstants.STEP_RELEASE_MONTHLY_RECAP_LOCK,
+                        jobRepository)
+                .tasklet(tasklet, transactionManager)
+                .build();
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/support/MonthlyFamilyRecapJobConstants.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/support/MonthlyFamilyRecapJobConstants.java
@@ -1,0 +1,30 @@
+package com.template.worker.jobs.recap.monthly.support;
+
+import java.time.ZoneId;
+
+public final class MonthlyFamilyRecapJobConstants {
+
+    // 월간 리캡 배치 기준 타임존
+    public static final String KST_ZONE_ID_NAME = "Asia/Seoul";
+    public static final ZoneId KST_ZONE_ID = ZoneId.of(KST_ZONE_ID_NAME);
+
+    // 잡/파라미터 식별자
+    public static final String JOB_NAME = "monthly-family-recap-job";
+    public static final String PARAM_TARGET_MONTH = "targetMonth";
+
+    // 스텝 이름
+    public static final String STEP_ACQUIRE_MONTHLY_RECAP_LOCK = "acquire-monthly-recap-lock-step";
+    public static final String STEP_PROCESS_MONTHLY_RECAP = "process-monthly-recap-step";
+    public static final String STEP_RELEASE_MONTHLY_RECAP_LOCK = "release-monthly-recap-lock-step";
+
+    // 락 미획득 종료 코드
+    public static final String EXIT_STATUS_LOCK_NOT_ACQUIRED = "LOCK_NOT_ACQUIRED";
+
+    // 실행 컨텍스트 키
+    public static final String JOB_CONTEXT_TARGET_MONTH = "targetMonth";
+    public static final String JOB_CONTEXT_TARGET_MONTH_DEFAULT = "default";
+    public static final String JOB_CONTEXT_LOCK_KEY = "lockKey";
+    public static final String JOB_CONTEXT_LOCK_OWNER = "lockOwner";
+
+    private MonthlyFamilyRecapJobConstants() {}
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/support/MonthlyFamilyRecapJobParameterSupport.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/support/MonthlyFamilyRecapJobParameterSupport.java
@@ -1,0 +1,47 @@
+package com.template.worker.jobs.recap.monthly.support;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+
+import org.springframework.batch.core.JobParameters;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.common.support.TargetMonthParameterSupport;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MonthlyFamilyRecapJobParameterSupport {
+
+    private final TargetMonthParameterSupport targetMonthParameterSupport;
+
+    public LocalDate resolveTargetMonth(JobParameters jobParameters) {
+        // 수동 실행 등으로 파라미터 객체가 없으면 기본 대상 월을 사용
+        if (jobParameters == null) {
+            return defaultTargetMonth();
+        }
+
+        String targetMonth =
+                jobParameters.getString(MonthlyFamilyRecapJobConstants.PARAM_TARGET_MONTH);
+        return resolveTargetMonth(targetMonth);
+    }
+
+    public LocalDate resolveTargetMonth(String targetMonth) {
+        // targetMonth 미지정 시 스케줄 기본 대상(직전 달)을 사용
+        if (targetMonth == null || targetMonth.isBlank()) {
+            return defaultTargetMonth();
+        }
+
+        return targetMonthParameterSupport.resolveTargetMonth(
+                targetMonth, MonthlyFamilyRecapJobConstants.KST_ZONE_ID);
+    }
+
+    public LocalDate defaultTargetMonth() {
+        // 스케줄 실행 시점 기준 직전 달 월 시작일을 기본값으로 사용
+        return ZonedDateTime.now(MonthlyFamilyRecapJobConstants.KST_ZONE_ID)
+                .toLocalDate()
+                .withDayOfMonth(1)
+                .minusMonths(1);
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/support/MonthlyFamilyRecapLockKeyGenerator.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/support/MonthlyFamilyRecapLockKeyGenerator.java
@@ -1,0 +1,24 @@
+package com.template.worker.jobs.recap.monthly.support;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.common.support.TargetMonthLockKeyGenerator;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MonthlyFamilyRecapLockKeyGenerator {
+
+    // 배치 락 키 prefix
+    private static final String BATCH_LOCK_PREFIX = "batch:lock:monthly-family-recap";
+
+    private final TargetMonthLockKeyGenerator targetMonthLockKeyGenerator;
+
+    public String monthlyFamilyRecapLockKey(LocalDate targetMonth) {
+        // 같은 월 중복 실행을 막기 위해 targetMonth 포함 키를 생성
+        return targetMonthLockKeyGenerator.targetMonthLockKey(BATCH_LOCK_PREFIX, targetMonth);
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/support/MonthlyFamilyRecapLockManager.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/support/MonthlyFamilyRecapLockManager.java
@@ -1,0 +1,26 @@
+package com.template.worker.jobs.recap.monthly.support;
+
+import java.time.Duration;
+
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.common.support.BatchLockManager;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MonthlyFamilyRecapLockManager {
+
+    private final BatchLockManager batchLockManager;
+
+    public boolean tryAcquire(String lockKey, String lockOwner, Duration ttl) {
+        // 공통 락 매니저로 월간 리캡 실행 락 획득
+        return batchLockManager.tryAcquire(lockKey, lockOwner, ttl);
+    }
+
+    public boolean releaseIfOwner(String lockKey, String lockOwner) {
+        // 락 소유자가 일치할 때만 안전하게 해제
+        return batchLockManager.releaseIfOwner(lockKey, lockOwner);
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/support/MonthlyFamilyRecapProperties.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/support/MonthlyFamilyRecapProperties.java
@@ -1,0 +1,31 @@
+package com.template.worker.jobs.recap.monthly.support;
+
+import java.time.Duration;
+
+import jakarta.validation.constraints.Min;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Validated
+@Component
+@ConfigurationProperties(prefix = "batch.jobs.monthly-family-recap")
+public class MonthlyFamilyRecapProperties {
+
+    // 분산 락 TTL
+    private Duration lockTtl = Duration.ofHours(1);
+
+    // 집계+업서트 청크 크기
+    @Min(1)
+    private int chunkSize = 1000;
+
+    // 가족 ID 커서 조회 배치 크기
+    @Min(1)
+    private int dbFetchSize = 1000;
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/tasklet/MonthlyFamilyRecapLockReleaseTasklet.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/tasklet/MonthlyFamilyRecapLockReleaseTasklet.java
@@ -1,0 +1,37 @@
+package com.template.worker.jobs.recap.monthly.tasklet;
+
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.common.tasklet.AbstractLockReleaseTasklet;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobConstants;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapLockManager;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MonthlyFamilyRecapLockReleaseTasklet extends AbstractLockReleaseTasklet {
+
+    private final MonthlyFamilyRecapLockManager lockManager;
+
+    @Override
+    protected boolean releaseIfOwner(String lockKey, String lockOwner) {
+        // 소유자 일치 여부를 확인해 락 해제
+        return lockManager.releaseIfOwner(lockKey, lockOwner);
+    }
+
+    @Override
+    protected String lockLogName() {
+        return "monthly family recap";
+    }
+
+    @Override
+    protected String lockKeyContextName() {
+        return MonthlyFamilyRecapJobConstants.JOB_CONTEXT_LOCK_KEY;
+    }
+
+    @Override
+    protected String lockOwnerContextName() {
+        return MonthlyFamilyRecapJobConstants.JOB_CONTEXT_LOCK_OWNER;
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/tasklet/MonthlyFamilyRecapLockTasklet.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/tasklet/MonthlyFamilyRecapLockTasklet.java
@@ -1,0 +1,70 @@
+package com.template.worker.jobs.recap.monthly.tasklet;
+
+import java.time.Duration;
+import java.time.LocalDate;
+
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.common.tasklet.AbstractTargetMonthLockTasklet;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobConstants;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobParameterSupport;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapLockKeyGenerator;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapLockManager;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapProperties;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MonthlyFamilyRecapLockTasklet extends AbstractTargetMonthLockTasklet {
+
+    private final MonthlyFamilyRecapLockManager lockManager;
+    private final MonthlyFamilyRecapJobParameterSupport parameterSupport;
+    private final MonthlyFamilyRecapProperties properties;
+    private final MonthlyFamilyRecapLockKeyGenerator lockKeyGenerator;
+
+    @Override
+    protected LocalDate resolveTargetMonth(JobParameters jobParameters) {
+        // job parameter에서 대상 월을 해석
+        return parameterSupport.resolveTargetMonth(jobParameters);
+    }
+
+    @Override
+    protected String generateLockKey(LocalDate targetMonth) {
+        // targetMonth 기반 락 키 생성
+        return lockKeyGenerator.monthlyFamilyRecapLockKey(targetMonth);
+    }
+
+    @Override
+    protected boolean tryAcquire(String lockKey, String lockOwner, Duration ttl) {
+        // 실행 락 획득 시도
+        return lockManager.tryAcquire(lockKey, lockOwner, ttl);
+    }
+
+    @Override
+    protected Duration lockTtl() {
+        return properties.getLockTtl();
+    }
+
+    @Override
+    protected String lockNotAcquiredExitStatus() {
+        return MonthlyFamilyRecapJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED;
+    }
+
+    @Override
+    protected String lockLogName() {
+        return "monthly family recap";
+    }
+
+    @Override
+    protected void initializeJobContext(
+            ExecutionContext jobContext, LocalDate targetMonth, String lockKey, String lockOwner) {
+        // 후속 스텝과 리스너에서 쓸 컨텍스트 값을 저장
+        jobContext.putString(
+                MonthlyFamilyRecapJobConstants.JOB_CONTEXT_TARGET_MONTH, targetMonth.toString());
+        jobContext.putString(MonthlyFamilyRecapJobConstants.JOB_CONTEXT_LOCK_KEY, lockKey);
+        jobContext.putString(MonthlyFamilyRecapJobConstants.JOB_CONTEXT_LOCK_OWNER, lockOwner);
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/writer/MonthlyFamilyRecapUpsertWriter.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/writer/MonthlyFamilyRecapUpsertWriter.java
@@ -1,0 +1,97 @@
+package com.template.worker.jobs.recap.monthly.writer;
+
+import java.sql.Date;
+
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Component;
+
+import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapRow;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MonthlyFamilyRecapUpsertWriter implements ItemWriter<MonthlyFamilyRecapRow> {
+
+    private static final String UPSERT_MONTHLY_RECAP_SQL =
+            """
+            INSERT INTO family_recap_monthly (
+              family_id,
+              report_month,
+              total_used_bytes,
+              total_quota_bytes,
+              usage_rate_percent,
+              usage_by_weekday,
+              peak_usage,
+              mission_summary_json,
+              appeal_summary_json,
+              appeal_highlights_json,
+              communication_score,
+              created_at,
+              updated_at
+            )
+            VALUES (
+              :familyId,
+              :reportMonth,
+              :totalUsedBytes,
+              :totalQuotaBytes,
+              :usageRatePercent,
+              :usageByWeekday,
+              :peakUsage,
+              :missionSummary,
+              :appealSummary,
+              :appealHighlights,
+              :communicationScore,
+              NOW(),
+              NOW()
+            )
+            ON DUPLICATE KEY UPDATE
+              total_used_bytes = VALUES(total_used_bytes),
+              total_quota_bytes = VALUES(total_quota_bytes),
+              usage_rate_percent = VALUES(usage_rate_percent),
+              usage_by_weekday = VALUES(usage_by_weekday),
+              peak_usage = VALUES(peak_usage),
+              mission_summary_json = VALUES(mission_summary_json),
+              appeal_summary_json = VALUES(appeal_summary_json),
+              appeal_highlights_json = VALUES(appeal_highlights_json),
+              communication_score = VALUES(communication_score),
+              updated_at = NOW()
+            """;
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Override
+    public void write(Chunk<? extends MonthlyFamilyRecapRow> chunk) {
+        if (chunk.isEmpty()) {
+            return;
+        }
+
+        // 청크 아이템을 배치 파라미터로 변환
+        SqlParameterSource[] batchParams =
+                chunk.getItems().stream()
+                        .map(this::toSqlParameterSource)
+                        .toArray(SqlParameterSource[]::new);
+
+        // UNIQUE(family_id, report_month) 기준 멱등 업서트 실행
+        jdbcTemplate.batchUpdate(UPSERT_MONTHLY_RECAP_SQL, batchParams);
+    }
+
+    private SqlParameterSource toSqlParameterSource(MonthlyFamilyRecapRow row) {
+        return new MapSqlParameterSource()
+                .addValue("familyId", row.familyId())
+                .addValue("reportMonth", Date.valueOf(row.reportMonth()))
+                .addValue("totalUsedBytes", row.totalUsedBytes())
+                .addValue("totalQuotaBytes", row.totalQuotaBytes())
+                .addValue("usageRatePercent", row.usageRatePercent())
+                .addValue("usageByWeekday", row.usageByWeekdayJson())
+                .addValue("peakUsage", row.peakUsageJson())
+                .addValue("missionSummary", row.missionSummaryJson())
+                .addValue("appealSummary", row.appealSummaryJson())
+                .addValue("appealHighlights", row.appealHighlightsJson())
+                .addValue("communicationScore", row.communicationScore());
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/weekly/model/WeeklyFamilyRecapRow.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/model/WeeklyFamilyRecapRow.java
@@ -15,4 +15,6 @@ public record WeeklyFamilyRecapRow(
         int missionCreatedCount,
         int missionCompletedCount,
         int missionRejectedCount,
-        int appealCount) {}
+        int totalAppealCount,
+        int approvedAppealCount,
+        int rejectedAppealCount) {}

--- a/src/main/java/com/template/worker/jobs/recap/weekly/model/WeeklyFamilyRecapSourceMetrics.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/model/WeeklyFamilyRecapSourceMetrics.java
@@ -11,4 +11,6 @@ public record WeeklyFamilyRecapSourceMetrics(
         int missionCreatedCount,
         int missionCompletedCount,
         int missionRejectedCount,
-        int appealCount) {}
+        int totalAppealCount,
+        int approvedAppealCount,
+        int rejectedAppealCount) {}

--- a/src/main/java/com/template/worker/jobs/recap/weekly/processor/WeeklyFamilyRecapProcessor.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/processor/WeeklyFamilyRecapProcessor.java
@@ -73,7 +73,9 @@ public class WeeklyFamilyRecapProcessor
                 sourceMetrics.missionCreatedCount(),
                 sourceMetrics.missionCompletedCount(),
                 sourceMetrics.missionRejectedCount(),
-                sourceMetrics.appealCount());
+                sourceMetrics.totalAppealCount(),
+                sourceMetrics.approvedAppealCount(),
+                sourceMetrics.rejectedAppealCount());
     }
 
     private void validateSourceMetrics(
@@ -88,7 +90,9 @@ public class WeeklyFamilyRecapProcessor
         if (sourceMetrics.missionCreatedCount() < 0
                 || sourceMetrics.missionCompletedCount() < 0
                 || sourceMetrics.missionRejectedCount() < 0
-                || sourceMetrics.appealCount() < 0) {
+                || sourceMetrics.totalAppealCount() < 0
+                || sourceMetrics.approvedAppealCount() < 0
+                || sourceMetrics.rejectedAppealCount() < 0) {
             throw new IllegalStateException(
                     "Count aggregate cannot be negative. familyId=" + familyId);
         }

--- a/src/main/java/com/template/worker/jobs/recap/weekly/query/WeeklyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/query/WeeklyFamilyRecapAggregationRepository.java
@@ -99,7 +99,7 @@ public class WeeklyFamilyRecapAggregationRepository {
               AND mi.deleted_at IS NULL
             """;
 
-    private static final String READ_APPEAL_COUNT_SQL =
+    private static final String READ_TOTAL_APPEAL_COUNT_SQL =
             """
             SELECT COUNT(*)
             FROM policy_appeal pa
@@ -108,6 +108,34 @@ public class WeeklyFamilyRecapAggregationRepository {
               AND pa.type = 'NORMAL'
               AND pa.created_at >= :weekStart
               AND pa.created_at < :weekEndExclusive
+              AND pas.deleted_at IS NULL
+            """;
+
+    private static final String READ_APPROVED_APPEAL_COUNT_SQL =
+            """
+            SELECT COUNT(*)
+            FROM policy_appeal pa
+            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
+            WHERE pas.family_id = :familyId
+              AND pa.type = 'NORMAL'
+              AND pa.status = 'APPROVED'
+              AND pa.created_at >= :weekStart
+              AND pa.created_at < :weekEndExclusive
+              AND pa.resolved_at < :weekEndExclusive
+              AND pas.deleted_at IS NULL
+            """;
+
+    private static final String READ_REJECTED_APPEAL_COUNT_SQL =
+            """
+            SELECT COUNT(*)
+            FROM policy_appeal pa
+            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
+            WHERE pas.family_id = :familyId
+              AND pa.type = 'NORMAL'
+              AND pa.status = 'REJECTED'
+              AND pa.created_at >= :weekStart
+              AND pa.created_at < :weekEndExclusive
+              AND pa.resolved_at < :weekEndExclusive
               AND pas.deleted_at IS NULL
             """;
 
@@ -132,7 +160,9 @@ public class WeeklyFamilyRecapAggregationRepository {
         int missionCreatedCount = readInt(READ_MISSION_CREATED_COUNT_SQL, params);
         int missionCompletedCount = readInt(READ_MISSION_COMPLETED_COUNT_SQL, params);
         int missionRejectedCount = readInt(READ_MISSION_REJECTED_COUNT_SQL, params);
-        int appealCount = readInt(READ_APPEAL_COUNT_SQL, params);
+        int totalAppealCount = readInt(READ_TOTAL_APPEAL_COUNT_SQL, params);
+        int approvedAppealCount = readInt(READ_APPROVED_APPEAL_COUNT_SQL, params);
+        int rejectedAppealCount = readInt(READ_REJECTED_APPEAL_COUNT_SQL, params);
 
         return new WeeklyFamilyRecapSourceMetrics(
                 totalUsedBytes,
@@ -142,7 +172,9 @@ public class WeeklyFamilyRecapAggregationRepository {
                 missionCreatedCount,
                 missionCompletedCount,
                 missionRejectedCount,
-                appealCount);
+                totalAppealCount,
+                approvedAppealCount,
+                rejectedAppealCount);
     }
 
     private long readLong(String sql, MapSqlParameterSource params) {

--- a/src/main/java/com/template/worker/jobs/recap/weekly/writer/WeeklyFamilyRecapUpsertWriter.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/writer/WeeklyFamilyRecapUpsertWriter.java
@@ -30,7 +30,9 @@ public class WeeklyFamilyRecapUpsertWriter implements ItemWriter<WeeklyFamilyRec
               mission_created_count,
               mission_completed_count,
               mission_rejected_count,
-              appeal_count,
+              total_appeal_count,
+              approved_appeal_count,
+              rejected_appeal_count,
               created_at,
               updated_at
             )
@@ -45,7 +47,9 @@ public class WeeklyFamilyRecapUpsertWriter implements ItemWriter<WeeklyFamilyRec
               :missionCreatedCount,
               :missionCompletedCount,
               :missionRejectedCount,
-              :appealCount,
+              :totalAppealCount,
+              :approvedAppealCount,
+              :rejectedAppealCount,
               NOW(),
               NOW()
             )
@@ -58,7 +62,9 @@ public class WeeklyFamilyRecapUpsertWriter implements ItemWriter<WeeklyFamilyRec
               mission_created_count = VALUES(mission_created_count),
               mission_completed_count = VALUES(mission_completed_count),
               mission_rejected_count = VALUES(mission_rejected_count),
-              appeal_count = VALUES(appeal_count),
+              total_appeal_count = VALUES(total_appeal_count),
+              approved_appeal_count = VALUES(approved_appeal_count),
+              rejected_appeal_count = VALUES(rejected_appeal_count),
               updated_at = NOW()
             """;
 
@@ -92,6 +98,8 @@ public class WeeklyFamilyRecapUpsertWriter implements ItemWriter<WeeklyFamilyRec
                 .addValue("missionCreatedCount", row.missionCreatedCount())
                 .addValue("missionCompletedCount", row.missionCompletedCount())
                 .addValue("missionRejectedCount", row.missionRejectedCount())
-                .addValue("appealCount", row.appealCount());
+                .addValue("totalAppealCount", row.totalAppealCount())
+                .addValue("approvedAppealCount", row.approvedAppealCount())
+                .addValue("rejectedAppealCount", row.rejectedAppealCount());
     }
 }

--- a/src/main/resources/batch.yml
+++ b/src/main/resources/batch.yml
@@ -11,6 +11,9 @@ batch:
     weekly-family-recap:
       enabled: ${BATCH_WEEKLY_FAMILY_RECAP_ENABLED:false}
       cron: ${BATCH_WEEKLY_FAMILY_RECAP_CRON:0 10 0 * * MON}
+    monthly-family-recap:
+      enabled: ${BATCH_MONTHLY_FAMILY_RECAP_ENABLED:false}
+      cron: ${BATCH_MONTHLY_FAMILY_RECAP_CRON:0 20 0 1 * *}
     monthly-usage-reset:
       enabled: ${BATCH_MONTHLY_USAGE_RESET_ENABLED:false}
       cron: ${BATCH_MONTHLY_USAGE_RESET_CRON:0 1 0 1 * *}
@@ -22,6 +25,10 @@ batch:
       lock-ttl: ${BATCH_WEEKLY_FAMILY_RECAP_LOCK_TTL:PT1H}
       chunk-size: ${BATCH_WEEKLY_FAMILY_RECAP_CHUNK_SIZE:1000}
       db-fetch-size: ${BATCH_WEEKLY_FAMILY_RECAP_DB_FETCH_SIZE:1000}
+    monthly-family-recap:
+      lock-ttl: ${BATCH_MONTHLY_FAMILY_RECAP_LOCK_TTL:PT1H}
+      chunk-size: ${BATCH_MONTHLY_FAMILY_RECAP_CHUNK_SIZE:1000}
+      db-fetch-size: ${BATCH_MONTHLY_FAMILY_RECAP_DB_FETCH_SIZE:1000}
     monthly-usage-reset:
       lock-ttl: ${BATCH_MONTHLY_USAGE_RESET_LOCK_TTL:PT1H}
       redis-chunk-size: ${BATCH_MONTHLY_USAGE_RESET_REDIS_CHUNK_SIZE:2000}

--- a/src/test/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessorTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessorTest.java
@@ -1,0 +1,246 @@
+package com.template.worker.jobs.recap.monthly.processor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepExecution;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapRow;
+import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapSourceMetrics;
+import com.template.worker.jobs.recap.monthly.model.MonthlyWeeklyRecapSnapshot;
+import com.template.worker.jobs.recap.monthly.query.MonthlyFamilyRecapAggregationRepository;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobParameterSupport;
+
+@ExtendWith(MockitoExtension.class)
+class MonthlyFamilyRecapProcessorTest {
+
+    @Mock private MonthlyFamilyRecapAggregationRepository aggregationRepository;
+    @Mock private MonthlyFamilyRecapJobParameterSupport parameterSupport;
+    @Spy private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks private MonthlyFamilyRecapProcessor processor;
+
+    @Test
+    @DisplayName("process - 월간 full week 집계 결과를 리캡 row로 변환한다")
+    void process_buildsMonthlyRecapRow() throws Exception {
+        JobExecution jobExecution =
+                new JobExecution(
+                        new JobInstance(1L, "monthly-family-recap-job"),
+                        new JobParametersBuilder()
+                                .addString("targetMonth", "2026-03-01")
+                                .toJobParameters());
+        StepExecution stepExecution = new StepExecution("process-monthly-recap-step", jobExecution);
+
+        LocalDate targetMonth = LocalDate.of(2026, 3, 1);
+        when(parameterSupport.resolveTargetMonth(any(JobParameters.class))).thenReturn(targetMonth);
+
+        List<MonthlyWeeklyRecapSnapshot> snapshots =
+                List.of(
+                        new MonthlyWeeklyRecapSnapshot(
+                                LocalDate.of(2026, 3, 2),
+                                1000L,
+                                5000L,
+                                "{\"monday\":100.00,\"tuesday\":0.00,\"wednesday\":0.00,"
+                                        + "\"thursday\":0.00,\"friday\":0.00,\"saturday\":0.00,"
+                                        + "\"sunday\":0.00}",
+                                "{\"startHour\":21,\"endHour\":22,\"peakBytes\":500}",
+                                2,
+                                1,
+                                1,
+                                1),
+                        new MonthlyWeeklyRecapSnapshot(
+                                LocalDate.of(2026, 3, 9),
+                                2000L,
+                                5000L,
+                                "{\"monday\":0.00,\"tuesday\":100.00,\"wednesday\":0.00,"
+                                        + "\"thursday\":0.00,\"friday\":0.00,\"saturday\":0.00,"
+                                        + "\"sunday\":0.00}",
+                                "{\"startHour\":20,\"endHour\":21,\"peakBytes\":800}",
+                                1,
+                                1,
+                                0,
+                                2));
+
+        when(aggregationRepository.aggregate(10L, targetMonth))
+                .thenReturn(new MonthlyFamilyRecapSourceMetrics(snapshots, 10000L, 5, 3, 1));
+
+        processor.beforeStep(stepExecution);
+        MonthlyFamilyRecapRow row = processor.process(10L);
+
+        assertThat(row.familyId()).isEqualTo(10L);
+        assertThat(row.reportMonth()).isEqualTo(targetMonth);
+        assertThat(row.totalUsedBytes()).isEqualTo(3000L);
+        assertThat(row.totalQuotaBytes()).isEqualTo(10000L);
+        assertThat(row.usageRatePercent()).isEqualTo(new BigDecimal("30.00"));
+
+        JsonNode usageByWeekday = objectMapper.readTree(row.usageByWeekdayJson());
+        assertThat(usageByWeekday.get("monday").decimalValue()).isEqualByComparingTo("33.33");
+        assertThat(usageByWeekday.get("tuesday").decimalValue()).isEqualByComparingTo("66.67");
+        assertThat(usageByWeekday.get("wednesday").decimalValue()).isEqualByComparingTo("0.00");
+
+        JsonNode peakUsage = objectMapper.readTree(row.peakUsageJson());
+        assertThat(peakUsage.get("startHour").intValue()).isEqualTo(20);
+        assertThat(peakUsage.get("endHour").intValue()).isEqualTo(21);
+        assertThat(peakUsage.get("mostUsedWeekday").textValue()).isEqualTo("tuesday");
+
+        JsonNode missionSummary = objectMapper.readTree(row.missionSummaryJson());
+        assertThat(missionSummary.get("totalMissionCount").intValue()).isEqualTo(3);
+        assertThat(missionSummary.get("completedMissionCount").intValue()).isEqualTo(2);
+        assertThat(missionSummary.get("rejectedRequestCount").intValue()).isEqualTo(1);
+
+        JsonNode appealSummary = objectMapper.readTree(row.appealSummaryJson());
+        assertThat(appealSummary.get("totalAppeals").intValue()).isEqualTo(5);
+        assertThat(appealSummary.get("approvedAppeals").intValue()).isEqualTo(3);
+        assertThat(appealSummary.get("rejectedAppeals").intValue()).isEqualTo(1);
+
+        JsonNode appealHighlights = objectMapper.readTree(row.appealHighlightsJson());
+        assertThat(appealHighlights.path("topSuccessfulRequester").path("requesterId").isNull())
+                .isTrue();
+        assertThat(
+                        appealHighlights
+                                .path("topAcceptedApprover")
+                                .path("recentAcceptedAppeals")
+                                .isArray())
+                .isTrue();
+
+        assertThat(row.communicationScore()).isEqualByComparingTo(new BigDecimal("74.83"));
+    }
+
+    @Test
+    @DisplayName("process - total_quota_bytes는 주간 합산이 아닌 단일 snapshot 값을 사용한다")
+    void process_usesSingleQuotaSnapshot() {
+        JobExecution jobExecution =
+                new JobExecution(
+                        new JobInstance(1L, "monthly-family-recap-job"),
+                        new JobParametersBuilder()
+                                .addString("targetMonth", "2026-03-01")
+                                .toJobParameters());
+        StepExecution stepExecution = new StepExecution("process-monthly-recap-step", jobExecution);
+
+        LocalDate targetMonth = LocalDate.of(2026, 3, 1);
+        when(parameterSupport.resolveTargetMonth(any(JobParameters.class))).thenReturn(targetMonth);
+
+        List<MonthlyWeeklyRecapSnapshot> snapshots =
+                List.of(
+                        new MonthlyWeeklyRecapSnapshot(
+                                LocalDate.of(2026, 3, 2), 1000L, 3000L, "{}", "{}", 0, 0, 0, 0),
+                        new MonthlyWeeklyRecapSnapshot(
+                                LocalDate.of(2026, 3, 9), 1000L, 7000L, "{}", "{}", 0, 0, 0, 0));
+
+        when(aggregationRepository.aggregate(20L, targetMonth))
+                .thenReturn(new MonthlyFamilyRecapSourceMetrics(snapshots, 9000L, 0, 0, 0));
+
+        processor.beforeStep(stepExecution);
+        MonthlyFamilyRecapRow row = processor.process(20L);
+
+        assertThat(row.totalQuotaBytes()).isEqualTo(9000L);
+    }
+
+    @Test
+    @DisplayName("process - 이의제기가 없고 미션만 있으면 소통점수는 미션 완료율 fallback을 사용한다")
+    void process_withoutAppeals_withMissions_usesFallbackCommunicationScore() {
+        JobExecution jobExecution =
+                new JobExecution(
+                        new JobInstance(1L, "monthly-family-recap-job"),
+                        new JobParametersBuilder()
+                                .addString("targetMonth", "2026-03-01")
+                                .toJobParameters());
+        StepExecution stepExecution = new StepExecution("process-monthly-recap-step", jobExecution);
+
+        LocalDate targetMonth = LocalDate.of(2026, 3, 1);
+        when(parameterSupport.resolveTargetMonth(any(JobParameters.class))).thenReturn(targetMonth);
+
+        List<MonthlyWeeklyRecapSnapshot> snapshots =
+                List.of(
+                        new MonthlyWeeklyRecapSnapshot(
+                                LocalDate.of(2026, 3, 2), 500L, 3000L, "{}", "{}", 3, 1, 0, 0));
+
+        when(aggregationRepository.aggregate(30L, targetMonth))
+                .thenReturn(new MonthlyFamilyRecapSourceMetrics(snapshots, 3000L, 0, 0, 0));
+
+        processor.beforeStep(stepExecution);
+        MonthlyFamilyRecapRow row = processor.process(30L);
+
+        assertThat(row.communicationScore()).isEqualByComparingTo(new BigDecimal("33.33"));
+    }
+
+    @Test
+    @DisplayName("process - 이의제기와 미션이 모두 0건이면 소통점수는 null이다")
+    void process_withoutAppealsAndMissions_returnsNullCommunicationScore() {
+        JobExecution jobExecution =
+                new JobExecution(
+                        new JobInstance(1L, "monthly-family-recap-job"),
+                        new JobParametersBuilder()
+                                .addString("targetMonth", "2026-03-01")
+                                .toJobParameters());
+        StepExecution stepExecution = new StepExecution("process-monthly-recap-step", jobExecution);
+
+        LocalDate targetMonth = LocalDate.of(2026, 3, 1);
+        when(parameterSupport.resolveTargetMonth(any(JobParameters.class))).thenReturn(targetMonth);
+        when(aggregationRepository.aggregate(40L, targetMonth))
+                .thenReturn(new MonthlyFamilyRecapSourceMetrics(List.of(), 0L, 0, 0, 0));
+
+        processor.beforeStep(stepExecution);
+        MonthlyFamilyRecapRow row = processor.process(40L);
+
+        assertThat(row.communicationScore()).isNull();
+    }
+
+    @Test
+    @DisplayName("process - 집계값이 음수면 예외가 발생한다")
+    void process_withNegativeAggregate_throwsException() {
+        JobExecution jobExecution =
+                new JobExecution(
+                        new JobInstance(1L, "monthly-family-recap-job"),
+                        new JobParametersBuilder()
+                                .addString("targetMonth", "2026-03-01")
+                                .toJobParameters());
+        StepExecution stepExecution = new StepExecution("process-monthly-recap-step", jobExecution);
+
+        LocalDate targetMonth = LocalDate.of(2026, 3, 1);
+        when(parameterSupport.resolveTargetMonth(any(JobParameters.class))).thenReturn(targetMonth);
+        when(aggregationRepository.aggregate(50L, targetMonth))
+                .thenReturn(
+                        new MonthlyFamilyRecapSourceMetrics(
+                                List.of(
+                                        new MonthlyWeeklyRecapSnapshot(
+                                                LocalDate.of(2026, 3, 2),
+                                                -1L,
+                                                1000L,
+                                                "{}",
+                                                "{}",
+                                                0,
+                                                0,
+                                                0,
+                                                0)),
+                                1000L,
+                                0,
+                                0,
+                                0));
+
+        processor.beforeStep(stepExecution);
+
+        assertThatThrownBy(() -> processor.process(50L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("cannot be negative");
+    }
+}

--- a/src/test/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessorTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessorTest.java
@@ -66,7 +66,9 @@ class MonthlyFamilyRecapProcessorTest {
                                 2,
                                 1,
                                 1,
-                                1),
+                                1,
+                                1,
+                                0),
                         new MonthlyWeeklyRecapSnapshot(
                                 LocalDate.of(2026, 3, 9),
                                 2000L,
@@ -78,7 +80,9 @@ class MonthlyFamilyRecapProcessorTest {
                                 1,
                                 1,
                                 0,
-                                2));
+                                2,
+                                2,
+                                0));
 
         when(aggregationRepository.aggregate(10L, targetMonth))
                 .thenReturn(new MonthlyFamilyRecapSourceMetrics(snapshots, 10000L, 5, 3, 1));
@@ -142,9 +146,29 @@ class MonthlyFamilyRecapProcessorTest {
         List<MonthlyWeeklyRecapSnapshot> snapshots =
                 List.of(
                         new MonthlyWeeklyRecapSnapshot(
-                                LocalDate.of(2026, 3, 2), 1000L, 3000L, "{}", "{}", 0, 0, 0, 0),
+                                LocalDate.of(2026, 3, 2),
+                                1000L,
+                                3000L,
+                                "{}",
+                                "{}",
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0),
                         new MonthlyWeeklyRecapSnapshot(
-                                LocalDate.of(2026, 3, 9), 1000L, 7000L, "{}", "{}", 0, 0, 0, 0));
+                                LocalDate.of(2026, 3, 9),
+                                1000L,
+                                7000L,
+                                "{}",
+                                "{}",
+                                0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                0));
 
         when(aggregationRepository.aggregate(20L, targetMonth))
                 .thenReturn(new MonthlyFamilyRecapSourceMetrics(snapshots, 9000L, 0, 0, 0));
@@ -172,7 +196,17 @@ class MonthlyFamilyRecapProcessorTest {
         List<MonthlyWeeklyRecapSnapshot> snapshots =
                 List.of(
                         new MonthlyWeeklyRecapSnapshot(
-                                LocalDate.of(2026, 3, 2), 500L, 3000L, "{}", "{}", 3, 1, 0, 0));
+                                LocalDate.of(2026, 3, 2),
+                                500L,
+                                3000L,
+                                "{}",
+                                "{}",
+                                3,
+                                1,
+                                0,
+                                0,
+                                0,
+                                0));
 
         when(aggregationRepository.aggregate(30L, targetMonth))
                 .thenReturn(new MonthlyFamilyRecapSourceMetrics(snapshots, 3000L, 0, 0, 0));
@@ -228,6 +262,8 @@ class MonthlyFamilyRecapProcessorTest {
                                                 1000L,
                                                 "{}",
                                                 "{}",
+                                                0,
+                                                0,
                                                 0,
                                                 0,
                                                 0,

--- a/src/test/java/com/template/worker/jobs/recap/monthly/support/MonthlyFamilyRecapJobParameterSupportTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/monthly/support/MonthlyFamilyRecapJobParameterSupportTest.java
@@ -1,0 +1,62 @@
+package com.template.worker.jobs.recap.monthly.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+
+import com.template.worker.jobs.common.support.TargetMonthParameterSupport;
+
+class MonthlyFamilyRecapJobParameterSupportTest {
+
+    private final MonthlyFamilyRecapJobParameterSupport support =
+            new MonthlyFamilyRecapJobParameterSupport(new TargetMonthParameterSupport());
+
+    @Test
+    @DisplayName("resolveTargetMonth - targetMonth 파라미터가 있으면 해당 값을 반환한다")
+    void resolveTargetMonth_withParam_returnsParsedValue() {
+        JobParameters parameters =
+                new JobParametersBuilder().addString("targetMonth", "2026-03-01").toJobParameters();
+
+        LocalDate targetMonth = support.resolveTargetMonth(parameters);
+
+        assertThat(targetMonth).isEqualTo(LocalDate.of(2026, 3, 1));
+    }
+
+    @Test
+    @DisplayName("resolveTargetMonth - 파라미터가 없으면 직전 달 1일을 반환한다")
+    void resolveTargetMonth_withoutParam_returnsPreviousMonthStart() {
+        JobParameters parameters = new JobParametersBuilder().toJobParameters();
+
+        LocalDate targetMonth = support.resolveTargetMonth(parameters);
+
+        LocalDate expected =
+                ZonedDateTime.now(MonthlyFamilyRecapJobConstants.KST_ZONE_ID)
+                        .toLocalDate()
+                        .withDayOfMonth(1)
+                        .minusMonths(1);
+        assertThat(targetMonth).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("resolveTargetMonth - 1일이 아니면 예외가 발생한다")
+    void resolveTargetMonth_withNonFirstDay_throwsException() {
+        assertThatThrownBy(() -> support.resolveTargetMonth("2026-03-02"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("first day of month");
+    }
+
+    @Test
+    @DisplayName("resolveTargetMonth - 포맷이 잘못되면 예외가 발생한다")
+    void resolveTargetMonth_withInvalidFormat_throwsException() {
+        assertThatThrownBy(() -> support.resolveTargetMonth("2026/03/01"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid targetMonth format");
+    }
+}

--- a/src/test/java/com/template/worker/jobs/recap/monthly/tasklet/MonthlyFamilyRecapLockTaskletTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/monthly/tasklet/MonthlyFamilyRecapLockTaskletTest.java
@@ -1,0 +1,74 @@
+package com.template.worker.jobs.recap.monthly.tasklet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.scope.context.StepContext;
+
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobConstants;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobParameterSupport;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapLockKeyGenerator;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapLockManager;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapProperties;
+
+@ExtendWith(MockitoExtension.class)
+class MonthlyFamilyRecapLockTaskletTest {
+
+    @Mock private MonthlyFamilyRecapLockManager lockManager;
+    @Mock private MonthlyFamilyRecapJobParameterSupport parameterSupport;
+    @Mock private MonthlyFamilyRecapProperties properties;
+    @Mock private MonthlyFamilyRecapLockKeyGenerator lockKeyGenerator;
+
+    @InjectMocks private MonthlyFamilyRecapLockTasklet tasklet;
+
+    @Test
+    @DisplayName("execute - 락 미획득 시 LOCK_NOT_ACQUIRED로 종료한다")
+    void execute_lockNotAcquired_setsLockNotAcquiredExitStatus() {
+        JobParameters jobParameters =
+                new JobParametersBuilder().addString("targetMonth", "2026-03-01").toJobParameters();
+        JobInstance jobInstance = new JobInstance(1L, "monthly-family-recap-job");
+        JobExecution jobExecution = new JobExecution(jobInstance, jobParameters);
+        StepExecution stepExecution = new StepExecution("acquire-lock-step", jobExecution);
+
+        LocalDate targetMonth = LocalDate.of(2026, 3, 1);
+        when(parameterSupport.resolveTargetMonth(any(JobParameters.class))).thenReturn(targetMonth);
+        when(lockKeyGenerator.monthlyFamilyRecapLockKey(targetMonth))
+                .thenReturn("batch:lock:monthly-family-recap:2026-03-01");
+        when(properties.getLockTtl()).thenReturn(Duration.ofHours(1));
+        when(lockManager.tryAcquire(anyString(), anyString(), any(Duration.class)))
+                .thenReturn(false);
+
+        tasklet.beforeStep(stepExecution);
+
+        StepContribution contribution = new StepContribution(stepExecution);
+        ChunkContext chunkContext = new ChunkContext(new StepContext(stepExecution));
+
+        tasklet.execute(contribution, chunkContext);
+
+        assertThat(contribution.getExitStatus().getExitCode())
+                .isEqualTo(MonthlyFamilyRecapJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED);
+        assertThat(
+                        jobExecution
+                                .getExecutionContext()
+                                .getString(MonthlyFamilyRecapJobConstants.JOB_CONTEXT_TARGET_MONTH))
+                .isEqualTo("2026-03-01");
+    }
+}

--- a/src/test/java/com/template/worker/jobs/recap/monthly/writer/MonthlyFamilyRecapUpsertWriterTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/monthly/writer/MonthlyFamilyRecapUpsertWriterTest.java
@@ -1,0 +1,110 @@
+package com.template.worker.jobs.recap.monthly.writer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.item.Chunk;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapRow;
+
+class MonthlyFamilyRecapUpsertWriterTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private MonthlyFamilyRecapUpsertWriter writer;
+
+    @BeforeEach
+    void setUp() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:monthly_recap_writer_test;MODE=MySQL;DB_CLOSE_DELAY=-1");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        writer = new MonthlyFamilyRecapUpsertWriter(new NamedParameterJdbcTemplate(dataSource));
+
+        jdbcTemplate.execute("DROP TABLE IF EXISTS family_recap_monthly");
+        jdbcTemplate.execute(
+                """
+                CREATE TABLE family_recap_monthly (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                  family_id BIGINT NOT NULL,
+                  report_month DATE NOT NULL,
+                  total_used_bytes BIGINT NOT NULL,
+                  total_quota_bytes BIGINT NOT NULL,
+                  usage_rate_percent DECIMAL(5,2) NOT NULL,
+                  usage_by_weekday VARCHAR(2000),
+                  peak_usage VARCHAR(1000),
+                  mission_summary_json VARCHAR(2000),
+                  appeal_summary_json VARCHAR(2000),
+                  appeal_highlights_json VARCHAR(4000),
+                  communication_score DECIMAL(5,2),
+                  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                  UNIQUE KEY uk_family_recap_monthly_family_month (family_id, report_month)
+                )
+                """);
+    }
+
+    @Test
+    @DisplayName("write - 동일 family/month 재실행 시 row 증가 없이 값만 갱신한다")
+    void write_sameFamilyAndMonth_upsertsWithoutIncreasingRows() {
+        MonthlyFamilyRecapRow firstRow =
+                new MonthlyFamilyRecapRow(
+                        10L,
+                        LocalDate.of(2026, 3, 1),
+                        100L,
+                        1000L,
+                        new BigDecimal("10.00"),
+                        "{\"monday\":10.00}",
+                        "{\"startHour\":20,\"endHour\":21,\"mostUsedWeekday\":\"monday\"}",
+                        "{\"totalMissionCount\":1,\"completedMissionCount\":1,\"rejectedRequestCount\":0}",
+                        "{\"totalAppeals\":1,\"approvedAppeals\":1,\"rejectedAppeals\":0}",
+                        "{\"topSuccessfulRequester\":{},\"topAcceptedApprover\":{}}",
+                        null);
+
+        MonthlyFamilyRecapRow secondRow =
+                new MonthlyFamilyRecapRow(
+                        10L,
+                        LocalDate.of(2026, 3, 1),
+                        250L,
+                        1000L,
+                        new BigDecimal("25.00"),
+                        "{\"monday\":25.00}",
+                        "{\"startHour\":21,\"endHour\":22,\"mostUsedWeekday\":\"tuesday\"}",
+                        "{\"totalMissionCount\":2,\"completedMissionCount\":2,\"rejectedRequestCount\":0}",
+                        "{\"totalAppeals\":2,\"approvedAppeals\":1,\"rejectedAppeals\":1}",
+                        "{\"topSuccessfulRequester\":{},\"topAcceptedApprover\":{}}",
+                        new BigDecimal("88.88"));
+
+        writer.write(new Chunk<>(List.of(firstRow)));
+        writer.write(new Chunk<>(List.of(secondRow)));
+
+        Integer rowCount =
+                jdbcTemplate.queryForObject(
+                        "SELECT COUNT(*) FROM family_recap_monthly", Integer.class);
+        Long totalUsedBytes =
+                jdbcTemplate.queryForObject(
+                        "SELECT total_used_bytes FROM family_recap_monthly "
+                                + "WHERE family_id = 10 AND report_month = '2026-03-01'",
+                        Long.class);
+        BigDecimal communicationScore =
+                jdbcTemplate.queryForObject(
+                        "SELECT communication_score FROM family_recap_monthly "
+                                + "WHERE family_id = 10 AND report_month = '2026-03-01'",
+                        BigDecimal.class);
+
+        assertThat(rowCount).isEqualTo(1);
+        assertThat(totalUsedBytes).isEqualTo(250L);
+        assertThat(communicationScore).isEqualByComparingTo("88.88");
+    }
+}

--- a/src/test/java/com/template/worker/jobs/recap/weekly/processor/WeeklyFamilyRecapProcessorTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/weekly/processor/WeeklyFamilyRecapProcessorTest.java
@@ -70,7 +70,9 @@ class WeeklyFamilyRecapProcessorTest {
                         3,
                         2,
                         1,
-                        4);
+                        4,
+                        2,
+                        1);
 
         when(aggregationRepository.aggregate(10L, weekStartDate)).thenReturn(sourceMetrics);
 
@@ -92,7 +94,9 @@ class WeeklyFamilyRecapProcessorTest {
         assertThat(row.missionCreatedCount()).isEqualTo(3);
         assertThat(row.missionCompletedCount()).isEqualTo(2);
         assertThat(row.missionRejectedCount()).isEqualTo(1);
-        assertThat(row.appealCount()).isEqualTo(4);
+        assertThat(row.totalAppealCount()).isEqualTo(4);
+        assertThat(row.approvedAppealCount()).isEqualTo(2);
+        assertThat(row.rejectedAppealCount()).isEqualTo(1);
     }
 
     @Test
@@ -116,6 +120,8 @@ class WeeklyFamilyRecapProcessorTest {
                         4000L,
                         Map.of("monday", 1L),
                         new WeeklyPeakUsage(0, 1, 1L),
+                        0,
+                        0,
                         0,
                         0,
                         0,
@@ -151,6 +157,8 @@ class WeeklyFamilyRecapProcessorTest {
                         4000L,
                         Map.of("monday", 1000L),
                         new WeeklyPeakUsage(21, 22, 500L),
+                        0,
+                        0,
                         0,
                         0,
                         0,

--- a/src/test/java/com/template/worker/jobs/recap/weekly/writer/WeeklyFamilyRecapUpsertWriterTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/weekly/writer/WeeklyFamilyRecapUpsertWriterTest.java
@@ -47,7 +47,9 @@ class WeeklyFamilyRecapUpsertWriterTest {
                   mission_created_count INT NOT NULL,
                   mission_completed_count INT NOT NULL,
                   mission_rejected_count INT NOT NULL,
-                  appeal_count INT NOT NULL,
+                  total_appeal_count INT NOT NULL,
+                  approved_appeal_count INT NOT NULL,
+                  rejected_appeal_count INT NOT NULL,
                   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                   UNIQUE KEY uk_family_recap_weekly_family_week (family_id, week_start_date)
@@ -72,7 +74,9 @@ class WeeklyFamilyRecapUpsertWriterTest {
                         1,
                         1,
                         0,
-                        1);
+                        1,
+                        1,
+                        0);
 
         WeeklyFamilyRecapRow secondRow =
                 new WeeklyFamilyRecapRow(
@@ -88,7 +92,9 @@ class WeeklyFamilyRecapUpsertWriterTest {
                         2,
                         2,
                         1,
-                        3);
+                        3,
+                        2,
+                        1);
 
         writer.write(new Chunk<>(List.of(firstRow)));
         writer.write(new Chunk<>(List.of(secondRow)));
@@ -101,14 +107,26 @@ class WeeklyFamilyRecapUpsertWriterTest {
                         "SELECT total_used_bytes FROM family_recap_weekly "
                                 + "WHERE family_id = 10 AND week_start_date = '2026-03-02'",
                         Long.class);
-        Integer appealCount =
+        Integer totalAppealCount =
                 jdbcTemplate.queryForObject(
-                        "SELECT appeal_count FROM family_recap_weekly "
+                        "SELECT total_appeal_count FROM family_recap_weekly "
+                                + "WHERE family_id = 10 AND week_start_date = '2026-03-02'",
+                        Integer.class);
+        Integer approvedAppealCount =
+                jdbcTemplate.queryForObject(
+                        "SELECT approved_appeal_count FROM family_recap_weekly "
+                                + "WHERE family_id = 10 AND week_start_date = '2026-03-02'",
+                        Integer.class);
+        Integer rejectedAppealCount =
+                jdbcTemplate.queryForObject(
+                        "SELECT rejected_appeal_count FROM family_recap_weekly "
                                 + "WHERE family_id = 10 AND week_start_date = '2026-03-02'",
                         Integer.class);
 
         assertThat(rowCount).isEqualTo(1);
         assertThat(totalUsedBytes).isEqualTo(250L);
-        assertThat(appealCount).isEqualTo(3);
+        assertThat(totalAppealCount).isEqualTo(3);
+        assertThat(approvedAppealCount).isEqualTo(2);
+        assertThat(rejectedAppealCount).isEqualTo(1);
     }
 }


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #8 
- jira: DABOM-385

---

## 🎯 목적

- `monthly-family-recap-job`를 구현해 `family_recap_monthly`를 월 단위로 생성/갱신
- 월간 기본 집계(full week 기반), quota snapshot 단일값 규칙, UPSERT 멱등성을 확보
- 월간 JSON 필드(`usageByWeekday`, `peakUsage`, `missionSummary`, `appealSummary`, `appealHighlights`)와 `communication_score` 기본 산출 골격을 반영

## 📝 변경 사항

- 월간 리캡 배치 기본 구성 추가
  - `MonthlyFamilyRecapJobConfig`, `MonthlyFamilyRecapScheduler`, `MonthlyFamilyRecapProperties`
  - `batch.yml`에 `monthly-family-recap` 스케줄/잡 설정 추가
- 파라미터/락 처리 추가
  - `MonthlyFamilyRecapJobParameterSupport` (`targetMonth` 기본값: 직전 달 1일)
  - acquire/release lock step + tasklet + lock manager/key generator
  - `MonthlyFamilyRecapJobListener`에서 요약 로그 및 final lock cleanup
- 집계/저장 로직 추가
  - `MonthlyFamilyRecapAggregationRepository`에서 weekly full week 조회 + quota snapshot fallback + NORMAL appeal 카운트 SQL 구현
  - `MonthlyFamilyRecapProcessor`에서 집계 검증, JSON 직렬화, `communication_score` 계산
  - `MonthlyFamilyRecapUpsertWriter`에서 `UNIQUE(family_id, report_month)` 기준 UPSERT
- 테스트 추가
  - `MonthlyFamilyRecapJobParameterSupportTest`
  - `MonthlyFamilyRecapLockTaskletTest`
  - `MonthlyFamilyRecapProcessorTest`
  - `MonthlyFamilyRecapUpsertWriterTest`

## 📂 변경 범위

| Job | api (controller/service/dto) | job config | step config | reader | processor | writer | global (config/launcher/listener) |
| :-: | :--------------------------: | :--------: | :---------: | :----: | :-------: | :----: | :-------------------------------: |
| [x] |             [ ]              |    [x]     |     [x]     |  [x]   |    [x]    |  [x]   |               [ ]                |

---

## 🖥️ 주요 코드 설명

```java
// 소통 점수 계산
private BigDecimal calculateCommunicationScore(
        int approvedAppeals,
        int rejectedAppeals,
        int totalAppeals,
        int totalMissionCount,
        int completedMissionCount) {
    if (totalAppeals > 0) {
        int respondedAppeals = approvedAppeals + rejectedAppeals;

        BigDecimal factorA = respondedAppeals == 0
                ? BigDecimal.ZERO
                : divide(approvedAppeals, respondedAppeals);
        BigDecimal factorB = divide(respondedAppeals, totalAppeals);
        BigDecimal factorC = approvedAppeals == 0
                ? BigDecimal.ZERO
                : divide(completedMissionCount, approvedAppeals).min(BigDecimal.ONE);

        return factorA.multiply(BigDecimal.valueOf(0.5))
                .add(factorB.multiply(BigDecimal.valueOf(0.3)))
                .add(factorC.multiply(BigDecimal.valueOf(0.2)))
                .multiply(BigDecimal.valueOf(100))
                .setScale(2, RoundingMode.HALF_UP);
    }

    if (totalMissionCount > 0) {
        return calculatePercent(completedMissionCount, totalMissionCount);
    }

    return null;
}
```

- `totalAppeals > 0`: NORMAL appeal 기준 A/B/C 수식으로 점수 계산
- `totalAppeals = 0 && totalMissionCount > 0`: 미션 완료율 fallback
- 둘 다 0이면 `communication_score = null`

## 💬 리뷰어에게

- 이번 이슈 범위는 “월간 기본 집계”이므로 usage/mission은 weekly full week 기준, appealSummary는 NORMAL 원천 카운트 기준으로 우선 구현했습니다.
- `appeal_highlights_json`는 기본 shape만 채우고 상세 Top/최근 3건 로직은 후속 이슈에서 확장 예정입니다.
- `weekly.appeal_count`는 현재 월간 계산에 직접 사용하지 않고 snapshot 모델 검증 용도로만 참조합니다.

---

## 📋 체크리스트

**기본**

- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [ ] 전체 변경사항이 500줄을 넘지 않는가?

**배치 코드 품질**

- [x] 의존성 방향을 준수하는가? (`Controller → Service → BatchJobLauncher → Job → Step → Reader/Processor/Writer`)
- [x] 모든 Job에 `JobResultListener`를 등록했는가?
- [x] Reader/Processor/Writer가 각각 단일 책임만 수행하는가?
- [x] Job/Step 이름이 kebab-case인가?
- [x] 하나의 Config 파일에 하나의 Job/Step만 정의했는가?

**테스트**

- [x] 신규 배치 로직에 대한 단위 테스트를 작성했는가?


## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
