### PR TITLE
[DABOM-386] 월간 보강 집계 구현

### DIFF
--- a/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyAppealHighlights.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyAppealHighlights.java
@@ -1,0 +1,49 @@
+package com.template.worker.jobs.recap.monthly.model;
+
+import java.util.List;
+
+// 월간 이의제기 하이라이트 JSON 원본 모델
+public record MonthlyAppealHighlights(
+        TopSuccessfulRequester topSuccessfulRequester, TopAcceptedApprover topAcceptedApprover) {
+
+    public static MonthlyAppealHighlights empty() {
+        return new MonthlyAppealHighlights(
+                TopSuccessfulRequester.empty(), TopAcceptedApprover.empty());
+    }
+
+    public record TopSuccessfulRequester(
+            Long requesterId,
+            String requesterName,
+            int approvedAppealCount,
+            List<RecentApprovedAppeal> recentApprovedAppeals) {
+
+        public static TopSuccessfulRequester empty() {
+            return new TopSuccessfulRequester(null, null, 0, List.of());
+        }
+    }
+
+    public record RecentApprovedAppeal(
+            Long appealId,
+            Long approverId,
+            String approverName,
+            String requestReason,
+            String requestedAt) {}
+
+    public record TopAcceptedApprover(
+            Long approverId,
+            String approverName,
+            int approvedAppealCount,
+            List<RecentAcceptedAppeal> recentAcceptedAppeals) {
+
+        public static TopAcceptedApprover empty() {
+            return new TopAcceptedApprover(null, null, 0, List.of());
+        }
+    }
+
+    public record RecentAcceptedAppeal(
+            Long appealId,
+            Long requesterId,
+            String requesterName,
+            String requestReason,
+            String resolvedAt) {}
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyAppealSummary.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyAppealSummary.java
@@ -1,0 +1,9 @@
+package com.template.worker.jobs.recap.monthly.model;
+
+// 월간 이의제기 요약 JSON 원본 모델
+public record MonthlyAppealSummary(int totalAppeals, int approvedAppeals, int rejectedAppeals) {
+
+    public static MonthlyAppealSummary empty() {
+        return new MonthlyAppealSummary(0, 0, 0);
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyFamilyRecapSourceMetrics.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyFamilyRecapSourceMetrics.java
@@ -9,4 +9,6 @@ public record MonthlyFamilyRecapSourceMetrics(
         MonthlyUsageSupplementMetrics partialUsageMetrics,
         MonthlyMissionSummary missionSummary,
         MonthlyAppealSummary appealSummary,
+        int missionCarryInCount,
+        int appealCarryInCount,
         MonthlyAppealHighlights appealHighlights) {}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyFamilyRecapSourceMetrics.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyFamilyRecapSourceMetrics.java
@@ -2,10 +2,11 @@ package com.template.worker.jobs.recap.monthly.model;
 
 import java.util.List;
 
-// 리포지토리 집계 원본 값을 담는 모델
+// 리포지토리에서 수집한 월간 리캡 원본 집계값 묶음
 public record MonthlyFamilyRecapSourceMetrics(
         List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots,
         long totalQuotaBytes,
-        int totalAppeals,
-        int approvedAppeals,
-        int rejectedAppeals) {}
+        MonthlyUsageSupplementMetrics partialUsageMetrics,
+        MonthlyMissionSummary missionSummary,
+        MonthlyAppealSummary appealSummary,
+        MonthlyAppealHighlights appealHighlights) {}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyMissionSummary.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyMissionSummary.java
@@ -1,0 +1,10 @@
+package com.template.worker.jobs.recap.monthly.model;
+
+// 월간 미션 요약 JSON 원본 모델
+public record MonthlyMissionSummary(
+        int totalMissionCount, int completedMissionCount, int rejectedRequestCount) {
+
+    public static MonthlyMissionSummary empty() {
+        return new MonthlyMissionSummary(0, 0, 0);
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyUsagePeakCandidate.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyUsagePeakCandidate.java
@@ -1,0 +1,25 @@
+package com.template.worker.jobs.recap.monthly.model;
+
+// 월간 peak 계산 시 full week / partial week 후보를 비교하기 위한 모델
+public record MonthlyUsagePeakCandidate(int startHour, int endHour, long peakBytes) {
+
+    public static MonthlyUsagePeakCandidate empty() {
+        return new MonthlyUsagePeakCandidate(0, 1, 0L);
+    }
+
+    public boolean isBetterThan(MonthlyUsagePeakCandidate current) {
+        if (peakBytes > current.peakBytes) {
+            return true;
+        }
+        if (peakBytes < current.peakBytes) {
+            return false;
+        }
+        if (startHour < current.startHour) {
+            return true;
+        }
+        if (startHour > current.startHour) {
+            return false;
+        }
+        return endHour < current.endHour;
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyUsageSupplementMetrics.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyUsageSupplementMetrics.java
@@ -1,0 +1,26 @@
+package com.template.worker.jobs.recap.monthly.model;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+// 월 경계 partial week에서 보강한 사용량 집계값
+public record MonthlyUsageSupplementMetrics(
+        long totalUsedBytes,
+        Map<String, Long> usageBytesByWeekday,
+        MonthlyUsagePeakCandidate peakUsageCandidate) {
+
+    public static MonthlyUsageSupplementMetrics empty() {
+        return new MonthlyUsageSupplementMetrics(
+                0L,
+                new LinkedHashMap<>(
+                        Map.of(
+                                "monday", 0L,
+                                "tuesday", 0L,
+                                "wednesday", 0L,
+                                "thursday", 0L,
+                                "friday", 0L,
+                                "saturday", 0L,
+                                "sunday", 0L)),
+                MonthlyUsagePeakCandidate.empty());
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyWeeklyRecapSnapshot.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyWeeklyRecapSnapshot.java
@@ -11,4 +11,7 @@ public record MonthlyWeeklyRecapSnapshot(
         String peakUsageJson,
         int missionCreatedCount,
         int missionCompletedCount,
-        int missionRejectedCount) {}
+        int missionRejectedCount,
+        int totalAppealCount,
+        int approvedAppealCount,
+        int rejectedAppealCount) {}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyWeeklyRecapSnapshot.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/model/MonthlyWeeklyRecapSnapshot.java
@@ -2,7 +2,7 @@ package com.template.worker.jobs.recap.monthly.model;
 
 import java.time.LocalDate;
 
-// 월간 집계 시 사용하는 주간 리캡 스냅샷
+// 월간 집계 시 재사용하는 주간 리캡 스냅샷
 public record MonthlyWeeklyRecapSnapshot(
         LocalDate weekStartDate,
         long totalUsedBytes,
@@ -11,7 +11,4 @@ public record MonthlyWeeklyRecapSnapshot(
         String peakUsageJson,
         int missionCreatedCount,
         int missionCompletedCount,
-        int missionRejectedCount,
-        int totalAppealCount,
-        int approvedAppealCount,
-        int rejectedAppealCount) {}
+        int missionRejectedCount) {}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
@@ -58,7 +58,9 @@ public class MonthlyFamilyRecapProcessor
         // writer 진입 전에 집계값 검증
         validateSourceMetrics(familyId, sourceMetrics);
 
+        // 월 내부 full week snapshot
         List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots = sourceMetrics.fullWeekSnapshots();
+        // 월 경계 partial raw 보강값
         MonthlyUsageSupplementMetrics partialUsageMetrics =
                 normalizePartialUsageMetrics(sourceMetrics);
         MonthlyMissionSummary missionSummary = normalizeMissionSummary(sourceMetrics);
@@ -80,27 +82,29 @@ public class MonthlyFamilyRecapProcessor
                         familyId, fullWeekSnapshots, partialUsageMetrics, totalUsedBytes);
         String usageByWeekdayJson = toJson(familyId, usageByWeekday, "usageByWeekday");
 
+        // weekday tie 결과 사용
         String mostUsedWeekday = resolveMostUsedWeekday(usageByWeekday);
         MonthlyPeakUsage peakUsage =
                 aggregatePeakUsage(
                         familyId, fullWeekSnapshots, partialUsageMetrics, mostUsedWeekday);
         String peakUsageJson = toJson(familyId, peakUsage, "peakUsage");
 
-        // mission/appeal은 repository에서 이미 월 raw 기준으로 정리해 두고, 여기서는 JSON 직렬화만 맡음
+        // summary 직렬화
         String missionSummaryJson = toJson(familyId, missionSummary, "missionSummary");
         String appealSummaryJson = toJson(familyId, appealSummary, "appealSummary");
         String appealHighlightsJson = toJson(familyId, appealHighlights, "appealHighlights");
 
-        // communication score는 raw mission/appeal summary를 그대로 사용해 월 기준 공식을 적용
+        // backlog 포함 score 계산
         BigDecimal communicationScore =
                 calculateCommunicationScore(
                         appealSummary.approvedAppeals(),
                         appealSummary.rejectedAppeals(),
                         appealSummary.totalAppeals(),
                         missionSummary.totalMissionCount(),
-                        missionSummary.completedMissionCount());
+                        missionSummary.completedMissionCount(),
+                        sourceMetrics.appealCarryInCount(),
+                        sourceMetrics.missionCarryInCount());
 
-        // 업서트 모델로 변환
         return new MonthlyFamilyRecapRow(
                 familyId,
                 targetMonth,
@@ -120,6 +124,10 @@ public class MonthlyFamilyRecapProcessor
         if (sourceMetrics.totalQuotaBytes() < 0) {
             throw new IllegalStateException(
                     "Quota snapshot cannot be negative. familyId=" + familyId);
+        }
+        if (sourceMetrics.missionCarryInCount() < 0 || sourceMetrics.appealCarryInCount() < 0) {
+            throw new IllegalStateException(
+                    "Carry-in aggregate cannot be negative. familyId=" + familyId);
         }
 
         MonthlyUsageSupplementMetrics partialUsageMetrics =
@@ -170,11 +178,18 @@ public class MonthlyFamilyRecapProcessor
                 throw new IllegalStateException(
                         "Weekly mission aggregate cannot be negative. familyId=" + familyId);
             }
+            if (snapshot.totalAppealCount() < 0
+                    || snapshot.approvedAppealCount() < 0
+                    || snapshot.rejectedAppealCount() < 0) {
+                throw new IllegalStateException(
+                        "Weekly appeal aggregate cannot be negative. familyId=" + familyId);
+            }
         }
     }
 
     private MonthlyUsageSupplementMetrics normalizePartialUsageMetrics(
             MonthlyFamilyRecapSourceMetrics sourceMetrics) {
+        // partial raw 보강이 없으면 빈 값 사용
         return sourceMetrics.partialUsageMetrics() == null
                 ? MonthlyUsageSupplementMetrics.empty()
                 : sourceMetrics.partialUsageMetrics();
@@ -182,6 +197,7 @@ public class MonthlyFamilyRecapProcessor
 
     private MonthlyMissionSummary normalizeMissionSummary(
             MonthlyFamilyRecapSourceMetrics sourceMetrics) {
+        // summary null 방어
         return sourceMetrics.missionSummary() == null
                 ? MonthlyMissionSummary.empty()
                 : sourceMetrics.missionSummary();
@@ -189,6 +205,7 @@ public class MonthlyFamilyRecapProcessor
 
     private MonthlyAppealSummary normalizeAppealSummary(
             MonthlyFamilyRecapSourceMetrics sourceMetrics) {
+        // summary null 방어
         return sourceMetrics.appealSummary() == null
                 ? MonthlyAppealSummary.empty()
                 : sourceMetrics.appealSummary();
@@ -196,6 +213,7 @@ public class MonthlyFamilyRecapProcessor
 
     private MonthlyAppealHighlights normalizeAppealHighlights(
             MonthlyFamilyRecapSourceMetrics sourceMetrics) {
+        // highlight null 방어
         return sourceMetrics.appealHighlights() == null
                 ? MonthlyAppealHighlights.empty()
                 : sourceMetrics.appealHighlights();
@@ -208,7 +226,7 @@ public class MonthlyFamilyRecapProcessor
             long totalUsedBytes) {
         Map<String, BigDecimal> weekdayUsedBytes = initWeekdayDecimalMap();
 
-        // full week는 weekly 퍼센트를 주간 총사용량으로 역산해 바이트로 되돌림
+        // weekly 비율을 바이트로 환산
         for (MonthlyWeeklyRecapSnapshot snapshot : fullWeekSnapshots) {
             Map<String, BigDecimal> weeklyUsageByWeekday =
                     parseUsageByWeekdayJson(
@@ -239,7 +257,7 @@ public class MonthlyFamilyRecapProcessor
                                                     .getOrDefault(weekday, 0L))));
         }
 
-        // 누적 바이트를 월 totalUsedBytes 대비 퍼센트로 재계산
+        // 월 퍼센트 재계산
         Map<String, BigDecimal> monthlyUsageByWeekday = new LinkedHashMap<>();
         for (String weekday : WEEKDAY_KEYS) {
             monthlyUsageByWeekday.put(
@@ -321,7 +339,7 @@ public class MonthlyFamilyRecapProcessor
         String mostUsedWeekday = WEEKDAY_KEYS.get(0);
         BigDecimal mostUsedValue = usageByWeekday.getOrDefault(mostUsedWeekday, BigDecimal.ZERO);
 
-        // tie는 monday -> sunday 순서를 유지하기 위해 strictly greater만 갱신
+        // tie는 앞선 요일 유지
         for (String weekday : WEEKDAY_KEYS) {
             BigDecimal current = usageByWeekday.getOrDefault(weekday, BigDecimal.ZERO);
             if (current.compareTo(mostUsedValue) > 0) {
@@ -338,35 +356,41 @@ public class MonthlyFamilyRecapProcessor
             int rejectedAppeals,
             int totalAppeals,
             int totalMissionCount,
-            int completedMissionCount) {
-        if (totalAppeals > 0) {
-            // NORMAL 이의제기가 1건 이상이면 가이드 수식(A/B/C)으로 계산
-            int respondedAppeals = approvedAppeals + rejectedAppeals;
+            int completedMissionCount,
+            int appealCarryInCount,
+            int missionCarryInCount) {
+        int respondedAppeals = approvedAppeals + rejectedAppeals;
+        // 월초 backlog 포함 분모
+        int appealBase = appealCarryInCount + totalAppeals;
+        int missionBase = missionCarryInCount + totalMissionCount;
 
-            BigDecimal factorA =
-                    respondedAppeals == 0
-                            ? BigDecimal.ZERO
-                            : divide(approvedAppeals, respondedAppeals);
-            BigDecimal factorB = divide(respondedAppeals, totalAppeals);
-            BigDecimal factorC =
-                    approvedAppeals == 0
-                            ? BigDecimal.ZERO
-                            : divide(completedMissionCount, approvedAppeals).min(BigDecimal.ONE);
+        // 일이 없던 축은 계산 제외
+        BigDecimal appealResponseRate =
+                appealBase > 0 ? divide(respondedAppeals, appealBase) : null;
+        BigDecimal missionCompletionRate =
+                missionBase > 0 ? divide(completedMissionCount, missionBase) : null;
 
-            return factorA.multiply(BigDecimal.valueOf(0.5))
-                    .add(factorB.multiply(BigDecimal.valueOf(0.3)))
-                    .add(factorC.multiply(BigDecimal.valueOf(0.2)))
-                    .multiply(BigDecimal.valueOf(100))
-                    .setScale(2, RoundingMode.HALF_UP);
+        if (appealResponseRate == null && missionCompletionRate == null) {
+            return null;
+        }
+        // 한 축만 있으면 단일 축 점수
+        if (appealResponseRate == null) {
+            return toPercent(missionCompletionRate);
+        }
+        if (missionCompletionRate == null) {
+            return toPercent(appealResponseRate);
         }
 
-        if (totalMissionCount > 0) {
-            // 이의제기 0건이면 미션 완료율 fallback 점수를 사용
-            return calculatePercent(completedMissionCount, totalMissionCount);
-        }
+        // 두 축 모두 있으면 가중 평균
+        return appealResponseRate
+                .multiply(BigDecimal.valueOf(0.55))
+                .add(missionCompletionRate.multiply(BigDecimal.valueOf(0.45)))
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(2, RoundingMode.HALF_UP);
+    }
 
-        // 이의제기/미션 모두 없으면 점수 미산정(null)
-        return null;
+    private BigDecimal toPercent(BigDecimal rate) {
+        return rate.multiply(BigDecimal.valueOf(100)).setScale(2, RoundingMode.HALF_UP);
     }
 
     private Map<String, BigDecimal> initWeekdayDecimalMap() {

--- a/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
@@ -132,58 +132,80 @@ public class MonthlyFamilyRecapProcessor
 
         MonthlyUsageSupplementMetrics partialUsageMetrics =
                 normalizePartialUsageMetrics(sourceMetrics);
+        validatePartialUsageMetrics(familyId, partialUsageMetrics);
+
+        MonthlyMissionSummary missionSummary = normalizeMissionSummary(sourceMetrics);
+        validateMissionSummary(familyId, missionSummary);
+
+        MonthlyAppealSummary appealSummary = normalizeAppealSummary(sourceMetrics);
+        validateAppealSummary(familyId, appealSummary);
+
+        MonthlyAppealHighlights appealHighlights = normalizeAppealHighlights(sourceMetrics);
+        validateAppealHighlights(familyId, appealHighlights);
+
+        for (MonthlyWeeklyRecapSnapshot snapshot : sourceMetrics.fullWeekSnapshots()) {
+            validateWeeklySnapshot(familyId, snapshot);
+        }
+    }
+
+    private void validatePartialUsageMetrics(
+            Long familyId, MonthlyUsageSupplementMetrics partialUsageMetrics) {
         if (partialUsageMetrics.totalUsedBytes() < 0
                 || partialUsageMetrics.peakUsageCandidate().peakBytes() < 0) {
             throw new IllegalStateException(
                     "Partial usage aggregate cannot be negative. familyId=" + familyId);
         }
+
         for (Long bytes : partialUsageMetrics.usageBytesByWeekday().values()) {
             if (bytes != null && bytes < 0) {
                 throw new IllegalStateException(
                         "Partial weekday usage cannot be negative. familyId=" + familyId);
             }
         }
+    }
 
-        MonthlyMissionSummary missionSummary = normalizeMissionSummary(sourceMetrics);
+    private void validateMissionSummary(Long familyId, MonthlyMissionSummary missionSummary) {
         if (missionSummary.totalMissionCount() < 0
                 || missionSummary.completedMissionCount() < 0
                 || missionSummary.rejectedRequestCount() < 0) {
             throw new IllegalStateException(
                     "Mission aggregate cannot be negative. familyId=" + familyId);
         }
+    }
 
-        MonthlyAppealSummary appealSummary = normalizeAppealSummary(sourceMetrics);
+    private void validateAppealSummary(Long familyId, MonthlyAppealSummary appealSummary) {
         if (appealSummary.totalAppeals() < 0
                 || appealSummary.approvedAppeals() < 0
                 || appealSummary.rejectedAppeals() < 0) {
             throw new IllegalStateException(
                     "Appeal aggregate cannot be negative. familyId=" + familyId);
         }
+    }
 
-        MonthlyAppealHighlights appealHighlights = normalizeAppealHighlights(sourceMetrics);
+    private void validateAppealHighlights(Long familyId, MonthlyAppealHighlights appealHighlights) {
         if (appealHighlights.topSuccessfulRequester().approvedAppealCount() < 0
                 || appealHighlights.topAcceptedApprover().approvedAppealCount() < 0) {
             throw new IllegalStateException(
                     "Appeal highlight aggregate cannot be negative. familyId=" + familyId);
         }
+    }
 
-        for (MonthlyWeeklyRecapSnapshot snapshot : sourceMetrics.fullWeekSnapshots()) {
-            if (snapshot.totalUsedBytes() < 0 || snapshot.totalQuotaBytes() < 0) {
-                throw new IllegalStateException(
-                        "Weekly usage aggregate cannot be negative. familyId=" + familyId);
-            }
-            if (snapshot.missionCreatedCount() < 0
-                    || snapshot.missionCompletedCount() < 0
-                    || snapshot.missionRejectedCount() < 0) {
-                throw new IllegalStateException(
-                        "Weekly mission aggregate cannot be negative. familyId=" + familyId);
-            }
-            if (snapshot.totalAppealCount() < 0
-                    || snapshot.approvedAppealCount() < 0
-                    || snapshot.rejectedAppealCount() < 0) {
-                throw new IllegalStateException(
-                        "Weekly appeal aggregate cannot be negative. familyId=" + familyId);
-            }
+    private void validateWeeklySnapshot(Long familyId, MonthlyWeeklyRecapSnapshot snapshot) {
+        if (snapshot.totalUsedBytes() < 0 || snapshot.totalQuotaBytes() < 0) {
+            throw new IllegalStateException(
+                    "Weekly usage aggregate cannot be negative. familyId=" + familyId);
+        }
+        if (snapshot.missionCreatedCount() < 0
+                || snapshot.missionCompletedCount() < 0
+                || snapshot.missionRejectedCount() < 0) {
+            throw new IllegalStateException(
+                    "Weekly mission aggregate cannot be negative. familyId=" + familyId);
+        }
+        if (snapshot.totalAppealCount() < 0
+                || snapshot.approvedAppealCount() < 0
+                || snapshot.rejectedAppealCount() < 0) {
+            throw new IllegalStateException(
+                    "Weekly appeal aggregate cannot be negative. familyId=" + familyId);
         }
     }
 

--- a/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
@@ -15,9 +15,14 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.template.worker.jobs.recap.monthly.model.MonthlyAppealHighlights;
+import com.template.worker.jobs.recap.monthly.model.MonthlyAppealSummary;
 import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapRow;
 import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapSourceMetrics;
+import com.template.worker.jobs.recap.monthly.model.MonthlyMissionSummary;
 import com.template.worker.jobs.recap.monthly.model.MonthlyPeakUsage;
+import com.template.worker.jobs.recap.monthly.model.MonthlyUsagePeakCandidate;
+import com.template.worker.jobs.recap.monthly.model.MonthlyUsageSupplementMetrics;
 import com.template.worker.jobs.recap.monthly.model.MonthlyWeeklyRecapSnapshot;
 import com.template.worker.jobs.recap.monthly.query.MonthlyFamilyRecapAggregationRepository;
 import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobParameterSupport;
@@ -54,59 +59,46 @@ public class MonthlyFamilyRecapProcessor
         validateSourceMetrics(familyId, sourceMetrics);
 
         List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots = sourceMetrics.fullWeekSnapshots();
+        MonthlyUsageSupplementMetrics partialUsageMetrics =
+                normalizePartialUsageMetrics(sourceMetrics);
+        MonthlyMissionSummary missionSummary = normalizeMissionSummary(sourceMetrics);
+        MonthlyAppealSummary appealSummary = normalizeAppealSummary(sourceMetrics);
+        MonthlyAppealHighlights appealHighlights = normalizeAppealHighlights(sourceMetrics);
 
-        // 이번 이슈 범위에서는 full week 합산값만 월간 사용량에 반영
+        // 월 사용량은 full week snapshot 합계에 partial raw usage를 더해 만듦
         long totalUsedBytes =
                 fullWeekSnapshots.stream()
-                        .mapToLong(MonthlyWeeklyRecapSnapshot::totalUsedBytes)
-                        .sum();
+                                .mapToLong(MonthlyWeeklyRecapSnapshot::totalUsedBytes)
+                                .sum()
+                        + partialUsageMetrics.totalUsedBytes();
         long totalQuotaBytes = sourceMetrics.totalQuotaBytes();
         BigDecimal usageRatePercent = calculatePercent(totalUsedBytes, totalQuotaBytes);
 
         // 주간 퍼센트 평균이 아니라 주간 사용량 가중합으로 월간 요일 비율 계산
         Map<String, BigDecimal> usageByWeekday =
-                aggregateUsageByWeekday(familyId, fullWeekSnapshots);
+                aggregateUsageByWeekday(
+                        familyId, fullWeekSnapshots, partialUsageMetrics, totalUsedBytes);
         String usageByWeekdayJson = toJson(familyId, usageByWeekday, "usageByWeekday");
 
         String mostUsedWeekday = resolveMostUsedWeekday(usageByWeekday);
         MonthlyPeakUsage peakUsage =
-                aggregatePeakUsage(familyId, fullWeekSnapshots, mostUsedWeekday);
+                aggregatePeakUsage(
+                        familyId, fullWeekSnapshots, partialUsageMetrics, mostUsedWeekday);
         String peakUsageJson = toJson(familyId, peakUsage, "peakUsage");
 
-        int totalMissionCount =
-                fullWeekSnapshots.stream()
-                        .mapToInt(MonthlyWeeklyRecapSnapshot::missionCreatedCount)
-                        .sum();
-        int completedMissionCount =
-                fullWeekSnapshots.stream()
-                        .mapToInt(MonthlyWeeklyRecapSnapshot::missionCompletedCount)
-                        .sum();
-        int rejectedRequestCount =
-                fullWeekSnapshots.stream()
-                        .mapToInt(MonthlyWeeklyRecapSnapshot::missionRejectedCount)
-                        .sum();
+        // mission/appeal은 repository에서 이미 월 raw 기준으로 정리해 두고, 여기서는 JSON 직렬화만 맡음
+        String missionSummaryJson = toJson(familyId, missionSummary, "missionSummary");
+        String appealSummaryJson = toJson(familyId, appealSummary, "appealSummary");
+        String appealHighlightsJson = toJson(familyId, appealHighlights, "appealHighlights");
 
-        String missionSummaryJson =
-                buildMissionSummaryJson(
-                        familyId, totalMissionCount, completedMissionCount, rejectedRequestCount);
-
-        // full week snapshot에서 합산한 이의제기 요약을 월간 JSON으로 변환
-        String appealSummaryJson =
-                buildAppealSummaryJson(
-                        familyId,
-                        sourceMetrics.totalAppeals(),
-                        sourceMetrics.approvedAppeals(),
-                        sourceMetrics.rejectedAppeals());
-
-        String appealHighlightsJson = buildDefaultAppealHighlightsJson(familyId);
-
+        // communication score는 raw mission/appeal summary를 그대로 사용해 월 기준 공식을 적용
         BigDecimal communicationScore =
                 calculateCommunicationScore(
-                        sourceMetrics.approvedAppeals(),
-                        sourceMetrics.rejectedAppeals(),
-                        sourceMetrics.totalAppeals(),
-                        totalMissionCount,
-                        completedMissionCount);
+                        appealSummary.approvedAppeals(),
+                        appealSummary.rejectedAppeals(),
+                        appealSummary.totalAppeals(),
+                        missionSummary.totalMissionCount(),
+                        missionSummary.completedMissionCount());
 
         // 업서트 모델로 변환
         return new MonthlyFamilyRecapRow(
@@ -129,11 +121,42 @@ public class MonthlyFamilyRecapProcessor
             throw new IllegalStateException(
                     "Quota snapshot cannot be negative. familyId=" + familyId);
         }
-        if (sourceMetrics.totalAppeals() < 0
-                || sourceMetrics.approvedAppeals() < 0
-                || sourceMetrics.rejectedAppeals() < 0) {
+
+        MonthlyUsageSupplementMetrics partialUsageMetrics =
+                normalizePartialUsageMetrics(sourceMetrics);
+        if (partialUsageMetrics.totalUsedBytes() < 0
+                || partialUsageMetrics.peakUsageCandidate().peakBytes() < 0) {
+            throw new IllegalStateException(
+                    "Partial usage aggregate cannot be negative. familyId=" + familyId);
+        }
+        for (Long bytes : partialUsageMetrics.usageBytesByWeekday().values()) {
+            if (bytes != null && bytes < 0) {
+                throw new IllegalStateException(
+                        "Partial weekday usage cannot be negative. familyId=" + familyId);
+            }
+        }
+
+        MonthlyMissionSummary missionSummary = normalizeMissionSummary(sourceMetrics);
+        if (missionSummary.totalMissionCount() < 0
+                || missionSummary.completedMissionCount() < 0
+                || missionSummary.rejectedRequestCount() < 0) {
+            throw new IllegalStateException(
+                    "Mission aggregate cannot be negative. familyId=" + familyId);
+        }
+
+        MonthlyAppealSummary appealSummary = normalizeAppealSummary(sourceMetrics);
+        if (appealSummary.totalAppeals() < 0
+                || appealSummary.approvedAppeals() < 0
+                || appealSummary.rejectedAppeals() < 0) {
             throw new IllegalStateException(
                     "Appeal aggregate cannot be negative. familyId=" + familyId);
+        }
+
+        MonthlyAppealHighlights appealHighlights = normalizeAppealHighlights(sourceMetrics);
+        if (appealHighlights.topSuccessfulRequester().approvedAppealCount() < 0
+                || appealHighlights.topAcceptedApprover().approvedAppealCount() < 0) {
+            throw new IllegalStateException(
+                    "Appeal highlight aggregate cannot be negative. familyId=" + familyId);
         }
 
         for (MonthlyWeeklyRecapSnapshot snapshot : sourceMetrics.fullWeekSnapshots()) {
@@ -143,20 +166,49 @@ public class MonthlyFamilyRecapProcessor
             }
             if (snapshot.missionCreatedCount() < 0
                     || snapshot.missionCompletedCount() < 0
-                    || snapshot.missionRejectedCount() < 0
-                    || snapshot.totalAppealCount() < 0
-                    || snapshot.approvedAppealCount() < 0
-                    || snapshot.rejectedAppealCount() < 0) {
+                    || snapshot.missionRejectedCount() < 0) {
                 throw new IllegalStateException(
-                        "Weekly count aggregate cannot be negative. familyId=" + familyId);
+                        "Weekly mission aggregate cannot be negative. familyId=" + familyId);
             }
         }
     }
 
+    private MonthlyUsageSupplementMetrics normalizePartialUsageMetrics(
+            MonthlyFamilyRecapSourceMetrics sourceMetrics) {
+        return sourceMetrics.partialUsageMetrics() == null
+                ? MonthlyUsageSupplementMetrics.empty()
+                : sourceMetrics.partialUsageMetrics();
+    }
+
+    private MonthlyMissionSummary normalizeMissionSummary(
+            MonthlyFamilyRecapSourceMetrics sourceMetrics) {
+        return sourceMetrics.missionSummary() == null
+                ? MonthlyMissionSummary.empty()
+                : sourceMetrics.missionSummary();
+    }
+
+    private MonthlyAppealSummary normalizeAppealSummary(
+            MonthlyFamilyRecapSourceMetrics sourceMetrics) {
+        return sourceMetrics.appealSummary() == null
+                ? MonthlyAppealSummary.empty()
+                : sourceMetrics.appealSummary();
+    }
+
+    private MonthlyAppealHighlights normalizeAppealHighlights(
+            MonthlyFamilyRecapSourceMetrics sourceMetrics) {
+        return sourceMetrics.appealHighlights() == null
+                ? MonthlyAppealHighlights.empty()
+                : sourceMetrics.appealHighlights();
+    }
+
     private Map<String, BigDecimal> aggregateUsageByWeekday(
-            Long familyId, List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots) {
+            Long familyId,
+            List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots,
+            MonthlyUsageSupplementMetrics partialUsageMetrics,
+            long totalUsedBytes) {
         Map<String, BigDecimal> weekdayUsedBytes = initWeekdayDecimalMap();
 
+        // full week는 weekly 퍼센트를 주간 총사용량으로 역산해 바이트로 되돌림
         for (MonthlyWeeklyRecapSnapshot snapshot : fullWeekSnapshots) {
             Map<String, BigDecimal> weeklyUsageByWeekday =
                     parseUsageByWeekdayJson(
@@ -170,87 +222,53 @@ public class MonthlyFamilyRecapProcessor
                         BigDecimal.valueOf(snapshot.totalUsedBytes())
                                 .multiply(usagePercent)
                                 .divide(BigDecimal.valueOf(100), 6, RoundingMode.HALF_UP);
-
                 weekdayUsedBytes.put(weekday, weekdayUsedBytes.get(weekday).add(weightedBytes));
             }
         }
 
-        long totalUsedBytes =
-                fullWeekSnapshots.stream()
-                        .mapToLong(MonthlyWeeklyRecapSnapshot::totalUsedBytes)
-                        .sum();
+        // partial week는 raw bytes를 그대로 더해 월 기준 바이트 총합을 만듦
+        for (String weekday : WEEKDAY_KEYS) {
+            weekdayUsedBytes.put(
+                    weekday,
+                    weekdayUsedBytes
+                            .get(weekday)
+                            .add(
+                                    BigDecimal.valueOf(
+                                            partialUsageMetrics
+                                                    .usageBytesByWeekday()
+                                                    .getOrDefault(weekday, 0L))));
+        }
 
         // 누적 바이트를 월 totalUsedBytes 대비 퍼센트로 재계산
         Map<String, BigDecimal> monthlyUsageByWeekday = new LinkedHashMap<>();
         for (String weekday : WEEKDAY_KEYS) {
-            BigDecimal weekdayUsed = weekdayUsedBytes.getOrDefault(weekday, BigDecimal.ZERO);
-            monthlyUsageByWeekday.put(weekday, calculatePercent(weekdayUsed, totalUsedBytes));
+            monthlyUsageByWeekday.put(
+                    weekday,
+                    calculatePercent(
+                            weekdayUsedBytes.getOrDefault(weekday, BigDecimal.ZERO),
+                            totalUsedBytes));
         }
-
         return monthlyUsageByWeekday;
     }
 
     private MonthlyPeakUsage aggregatePeakUsage(
             Long familyId,
             List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots,
+            MonthlyUsageSupplementMetrics partialUsageMetrics,
             String mostUsedWeekday) {
-        // peakBytes 우선, 동률이면 더 이른 시간대를 우선 선택
-        WeeklyPeakUsageCandidate selected = new WeeklyPeakUsageCandidate(0, 1, 0L);
+        // partial raw peak를 기본 후보로 두고 full week peak들과 비교해 최종 시간대를 고름
+        MonthlyUsagePeakCandidate selected = partialUsageMetrics.peakUsageCandidate();
 
         for (MonthlyWeeklyRecapSnapshot snapshot : fullWeekSnapshots) {
-            WeeklyPeakUsageCandidate candidate =
+            MonthlyUsagePeakCandidate candidate =
                     parsePeakUsageJson(
                             familyId, snapshot.weekStartDate(), snapshot.peakUsageJson());
-
             if (candidate.isBetterThan(selected)) {
                 selected = candidate;
             }
         }
 
         return new MonthlyPeakUsage(selected.startHour(), selected.endHour(), mostUsedWeekday);
-    }
-
-    private String buildMissionSummaryJson(
-            Long familyId,
-            int totalMissionCount,
-            int completedMissionCount,
-            int rejectedRequestCount) {
-        Map<String, Integer> missionSummary = new LinkedHashMap<>();
-        missionSummary.put("totalMissionCount", totalMissionCount);
-        missionSummary.put("completedMissionCount", completedMissionCount);
-        missionSummary.put("rejectedRequestCount", rejectedRequestCount);
-
-        return toJson(familyId, missionSummary, "missionSummary");
-    }
-
-    private String buildAppealSummaryJson(
-            Long familyId, int totalAppeals, int approvedAppeals, int rejectedAppeals) {
-        Map<String, Integer> appealSummary = new LinkedHashMap<>();
-        appealSummary.put("totalAppeals", totalAppeals);
-        appealSummary.put("approvedAppeals", approvedAppeals);
-        appealSummary.put("rejectedAppeals", rejectedAppeals);
-
-        return toJson(familyId, appealSummary, "appealSummary");
-    }
-
-    private String buildDefaultAppealHighlightsJson(Long familyId) {
-        Map<String, Object> topSuccessfulRequester = new LinkedHashMap<>();
-        topSuccessfulRequester.put("requesterId", null);
-        topSuccessfulRequester.put("requesterName", null);
-        topSuccessfulRequester.put("approvedAppealCount", 0);
-        topSuccessfulRequester.put("recentApprovedAppeals", List.of());
-
-        Map<String, Object> topAcceptedApprover = new LinkedHashMap<>();
-        topAcceptedApprover.put("approverId", null);
-        topAcceptedApprover.put("approverName", null);
-        topAcceptedApprover.put("approvedAppealCount", 0);
-        topAcceptedApprover.put("recentAcceptedAppeals", List.of());
-
-        Map<String, Object> highlights = new LinkedHashMap<>();
-        highlights.put("topSuccessfulRequester", topSuccessfulRequester);
-        highlights.put("topAcceptedApprover", topAcceptedApprover);
-
-        return toJson(familyId, highlights, "appealHighlights");
     }
 
     private Map<String, BigDecimal> parseUsageByWeekdayJson(
@@ -264,8 +282,7 @@ public class MonthlyFamilyRecapProcessor
         try {
             JsonNode root = objectMapper.readTree(usageByWeekdayJson);
             for (String weekday : WEEKDAY_KEYS) {
-                JsonNode valueNode = root.get(weekday);
-                usageByWeekday.put(weekday, parseBigDecimal(valueNode));
+                usageByWeekday.put(weekday, parseBigDecimal(root.get(weekday)));
             }
             return usageByWeekday;
         } catch (JsonProcessingException exception) {
@@ -278,10 +295,10 @@ public class MonthlyFamilyRecapProcessor
         }
     }
 
-    private WeeklyPeakUsageCandidate parsePeakUsageJson(
+    private MonthlyUsagePeakCandidate parsePeakUsageJson(
             Long familyId, LocalDate weekStartDate, String peakUsageJson) {
         if (peakUsageJson == null || peakUsageJson.isBlank()) {
-            return new WeeklyPeakUsageCandidate(0, 1, 0L);
+            return MonthlyUsagePeakCandidate.empty();
         }
 
         try {
@@ -289,7 +306,7 @@ public class MonthlyFamilyRecapProcessor
             int startHour = root.path("startHour").asInt(0);
             int endHour = root.path("endHour").asInt(startHour + 1);
             long peakBytes = root.path("peakBytes").asLong(0L);
-            return new WeeklyPeakUsageCandidate(startHour, endHour, peakBytes);
+            return new MonthlyUsagePeakCandidate(startHour, endHour, peakBytes);
         } catch (JsonProcessingException exception) {
             throw new IllegalStateException(
                     "Failed to parse weekly peakUsage JSON. familyId="
@@ -304,6 +321,7 @@ public class MonthlyFamilyRecapProcessor
         String mostUsedWeekday = WEEKDAY_KEYS.get(0);
         BigDecimal mostUsedValue = usageByWeekday.getOrDefault(mostUsedWeekday, BigDecimal.ZERO);
 
+        // tie는 monday -> sunday 순서를 유지하기 위해 strictly greater만 갱신
         for (String weekday : WEEKDAY_KEYS) {
             BigDecimal current = usageByWeekday.getOrDefault(weekday, BigDecimal.ZERO);
             if (current.compareTo(mostUsedValue) > 0) {
@@ -408,24 +426,5 @@ public class MonthlyFamilyRecapProcessor
 
         return BigDecimal.valueOf(numerator)
                 .divide(BigDecimal.valueOf(denominator), 6, RoundingMode.HALF_UP);
-    }
-
-    private record WeeklyPeakUsageCandidate(int startHour, int endHour, long peakBytes) {
-
-        private boolean isBetterThan(WeeklyPeakUsageCandidate current) {
-            if (peakBytes > current.peakBytes) {
-                return true;
-            }
-            if (peakBytes < current.peakBytes) {
-                return false;
-            }
-            if (startHour < current.startHour) {
-                return true;
-            }
-            if (startHour > current.startHour) {
-                return false;
-            }
-            return endHour < current.endHour;
-        }
     }
 }

--- a/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
@@ -2,7 +2,13 @@ package com.template.worker.jobs.recap.monthly.query;
 
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -11,7 +17,12 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.jobs.recap.monthly.model.MonthlyAppealHighlights;
+import com.template.worker.jobs.recap.monthly.model.MonthlyAppealSummary;
 import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapSourceMetrics;
+import com.template.worker.jobs.recap.monthly.model.MonthlyMissionSummary;
+import com.template.worker.jobs.recap.monthly.model.MonthlyUsagePeakCandidate;
+import com.template.worker.jobs.recap.monthly.model.MonthlyUsageSupplementMetrics;
 import com.template.worker.jobs.recap.monthly.model.MonthlyWeeklyRecapSnapshot;
 
 import lombok.RequiredArgsConstructor;
@@ -19,6 +30,8 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class MonthlyFamilyRecapAggregationRepository {
+
+    private static final DateTimeFormatter ISO_DATE_TIME = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
     private static final String READ_FULL_WEEKLY_RECAP_ROWS_SQL =
             """
@@ -29,14 +42,11 @@ public class MonthlyFamilyRecapAggregationRepository {
                    peak_usage,
                    mission_created_count,
                    mission_completed_count,
-                   mission_rejected_count,
-                   total_appeal_count,
-                   approved_appeal_count,
-                   rejected_appeal_count
+                   mission_rejected_count
             FROM family_recap_weekly
             WHERE family_id = :familyId
               AND week_start_date >= :monthStartDate
-              AND DATE_ADD(week_start_date, INTERVAL 7 DAY) <= :monthEndExclusiveDate
+              AND week_start_date <= :lastFullWeekStartDate
             ORDER BY week_start_date ASC
             """;
 
@@ -46,7 +56,7 @@ public class MonthlyFamilyRecapAggregationRepository {
             FROM family_recap_weekly
             WHERE family_id = :familyId
               AND week_start_date < :monthEndExclusiveDate
-              AND DATE_ADD(week_start_date, INTERVAL 7 DAY) > :monthStartDate
+              AND week_start_date >= :overlapStartDate
             ORDER BY week_start_date DESC
             LIMIT 1
             """;
@@ -59,29 +69,243 @@ public class MonthlyFamilyRecapAggregationRepository {
               AND deleted_at IS NULL
             """;
 
+    private static final String READ_TOTAL_USED_BYTES_IN_RANGE_SQL =
+            """
+            SELECT COALESCE(SUM(bytes_used), 0)
+            FROM usage_record
+            WHERE family_id = :familyId
+              AND event_time >= :rangeStart
+              AND event_time < :rangeEndExclusive
+              AND deleted_at IS NULL
+            """;
+
+    private static final String READ_USAGE_BY_WEEKDAY_IN_RANGE_SQL =
+            """
+            SELECT DAYOFWEEK(event_time) AS day_of_week,
+                   COALESCE(SUM(bytes_used), 0) AS total_bytes
+            FROM usage_record
+            WHERE family_id = :familyId
+              AND event_time >= :rangeStart
+              AND event_time < :rangeEndExclusive
+              AND deleted_at IS NULL
+            GROUP BY DAYOFWEEK(event_time)
+            """;
+
+    private static final String READ_USAGE_BY_HOUR_IN_RANGE_SQL =
+            """
+            SELECT HOUR(event_time) AS start_hour,
+                   COALESCE(SUM(bytes_used), 0) AS total_bytes
+            FROM usage_record
+            WHERE family_id = :familyId
+              AND event_time >= :rangeStart
+              AND event_time < :rangeEndExclusive
+              AND deleted_at IS NULL
+            GROUP BY HOUR(event_time)
+            """;
+
+    private static final String READ_MISSION_CREATED_COUNT_SQL =
+            """
+            SELECT COUNT(*)
+            FROM mission_item
+            WHERE family_id = :familyId
+              AND created_at >= :monthStart
+              AND created_at < :monthEndExclusive
+              AND deleted_at IS NULL
+            """;
+
+    private static final String READ_MISSION_COMPLETED_COUNT_SQL =
+            """
+            SELECT COUNT(*)
+            FROM mission_item
+            WHERE family_id = :familyId
+              AND status = 'COMPLETED'
+              AND completed_at >= :monthStart
+              AND completed_at < :monthEndExclusive
+              AND deleted_at IS NULL
+            """;
+
+    private static final String READ_MISSION_REJECTED_COUNT_SQL =
+            """
+            SELECT COUNT(*)
+            FROM mission_request mr
+            JOIN mission_item mi ON mr.mission_item_id = mi.id
+            WHERE mi.family_id = :familyId
+              AND mr.status = 'REJECTED'
+              AND mr.resolved_at >= :monthStart
+              AND mr.resolved_at < :monthEndExclusive
+              AND mr.deleted_at IS NULL
+              AND mi.deleted_at IS NULL
+            """;
+
+    private static final String READ_TOTAL_APPEAL_COUNT_SQL =
+            """
+            SELECT COUNT(*)
+            FROM policy_appeal pa
+            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
+            WHERE pas.family_id = :familyId
+              AND pa.type = 'NORMAL'
+              AND pa.created_at >= :monthStart
+              AND pa.created_at < :monthEndExclusive
+              AND pa.deleted_at IS NULL
+              AND pas.deleted_at IS NULL
+            """;
+
+    private static final String READ_APPROVED_APPEAL_COUNT_SQL =
+            """
+            SELECT COUNT(*)
+            FROM policy_appeal pa
+            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
+            WHERE pas.family_id = :familyId
+              AND pa.type = 'NORMAL'
+              AND pa.status = 'APPROVED'
+              AND pa.created_at >= :monthStart
+              AND pa.created_at < :monthEndExclusive
+              AND pa.resolved_at < :monthEndExclusive
+              AND pa.deleted_at IS NULL
+              AND pas.deleted_at IS NULL
+            """;
+
+    private static final String READ_REJECTED_APPEAL_COUNT_SQL =
+            """
+            SELECT COUNT(*)
+            FROM policy_appeal pa
+            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
+            WHERE pas.family_id = :familyId
+              AND pa.type = 'NORMAL'
+              AND pa.status = 'REJECTED'
+              AND pa.created_at >= :monthStart
+              AND pa.created_at < :monthEndExclusive
+              AND pa.resolved_at < :monthEndExclusive
+              AND pa.deleted_at IS NULL
+              AND pas.deleted_at IS NULL
+            """;
+
+    private static final String READ_TOP_SUCCESSFUL_REQUESTER_SQL =
+            """
+            SELECT pa.requester_id AS requester_id,
+                   requester.name AS requester_name,
+                   COUNT(*) AS approved_appeal_count,
+                   MAX(pa.created_at) AS latest_requested_at
+            FROM policy_appeal pa
+            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
+            JOIN customer requester ON pa.requester_id = requester.id
+            WHERE pas.family_id = :familyId
+              AND pa.type = 'NORMAL'
+              AND pa.status = 'APPROVED'
+              AND pa.created_at >= :monthStart
+              AND pa.created_at < :monthEndExclusive
+              AND pa.resolved_at < :monthEndExclusive
+              AND pa.deleted_at IS NULL
+              AND pas.deleted_at IS NULL
+              AND requester.deleted_at IS NULL
+            GROUP BY pa.requester_id, requester.name
+            ORDER BY approved_appeal_count DESC, latest_requested_at DESC, requester_id ASC
+            LIMIT 1
+            """;
+
+    private static final String READ_RECENT_APPROVED_APPEALS_SQL =
+            """
+            SELECT pa.id AS appeal_id,
+                   pa.resolved_by_id AS approver_id,
+                   approver.name AS approver_name,
+                   pa.request_reason,
+                   pa.created_at AS requested_at
+            FROM policy_appeal pa
+            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
+            LEFT JOIN customer approver
+              ON pa.resolved_by_id = approver.id
+             AND approver.deleted_at IS NULL
+            WHERE pas.family_id = :familyId
+              AND pa.requester_id = :requesterId
+              AND pa.type = 'NORMAL'
+              AND pa.status = 'APPROVED'
+              AND pa.created_at >= :monthStart
+              AND pa.created_at < :monthEndExclusive
+              AND pa.resolved_at < :monthEndExclusive
+              AND pa.deleted_at IS NULL
+              AND pas.deleted_at IS NULL
+            ORDER BY pa.created_at DESC, pa.id DESC
+            LIMIT 3
+            """;
+
+    private static final String READ_TOP_ACCEPTED_APPROVER_SQL =
+            """
+            SELECT pa.resolved_by_id AS approver_id,
+                   approver.name AS approver_name,
+                   COUNT(*) AS approved_appeal_count,
+                   MAX(pa.resolved_at) AS latest_resolved_at
+            FROM policy_appeal pa
+            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
+            JOIN customer approver ON pa.resolved_by_id = approver.id
+            WHERE pas.family_id = :familyId
+              AND pa.type = 'NORMAL'
+              AND pa.status = 'APPROVED'
+              AND pa.resolved_by_id IS NOT NULL
+              AND pa.created_at >= :monthStart
+              AND pa.created_at < :monthEndExclusive
+              AND pa.resolved_at < :monthEndExclusive
+              AND pa.deleted_at IS NULL
+              AND pas.deleted_at IS NULL
+              AND approver.deleted_at IS NULL
+            GROUP BY pa.resolved_by_id, approver.name
+            ORDER BY approved_appeal_count DESC, latest_resolved_at DESC, approver_id ASC
+            LIMIT 1
+            """;
+
+    private static final String READ_RECENT_ACCEPTED_APPEALS_SQL =
+            """
+            SELECT pa.id AS appeal_id,
+                   pa.requester_id,
+                   requester.name AS requester_name,
+                   pa.request_reason,
+                   pa.resolved_at
+            FROM policy_appeal pa
+            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
+            LEFT JOIN customer requester
+              ON pa.requester_id = requester.id
+             AND requester.deleted_at IS NULL
+            WHERE pas.family_id = :familyId
+              AND pa.resolved_by_id = :approverId
+              AND pa.type = 'NORMAL'
+              AND pa.status = 'APPROVED'
+              AND pa.created_at >= :monthStart
+              AND pa.created_at < :monthEndExclusive
+              AND pa.resolved_at < :monthEndExclusive
+              AND pa.deleted_at IS NULL
+              AND pas.deleted_at IS NULL
+            ORDER BY pa.resolved_at DESC, pa.id DESC
+            LIMIT 3
+            """;
+
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
     public MonthlyFamilyRecapSourceMetrics aggregate(Long familyId, LocalDate targetMonth) {
-        MapSqlParameterSource params =
+        LocalDate monthEndExclusiveDate = targetMonth.plusMonths(1);
+        LocalDateTime monthStart = targetMonth.atStartOfDay();
+        LocalDateTime monthEndExclusive = monthEndExclusiveDate.atStartOfDay();
+
+        MapSqlParameterSource monthlyParams =
                 new MapSqlParameterSource()
                         .addValue("familyId", familyId)
                         .addValue("monthStartDate", Date.valueOf(targetMonth))
-                        .addValue("monthEndExclusiveDate", Date.valueOf(targetMonth.plusMonths(1)));
+                        .addValue("monthEndExclusiveDate", Date.valueOf(monthEndExclusiveDate))
+                        .addValue(
+                                "lastFullWeekStartDate",
+                                Date.valueOf(monthEndExclusiveDate.minusDays(7)))
+                        .addValue("overlapStartDate", Date.valueOf(targetMonth.minusDays(6)))
+                        .addValue("monthStart", Timestamp.valueOf(monthStart))
+                        .addValue("monthEndExclusive", Timestamp.valueOf(monthEndExclusive));
 
-        // 월 내부에 완전히 포함된 full week만 1차 소스로 사용
-        List<Map<String, Object>> rows =
-                jdbcTemplate.queryForList(READ_FULL_WEEKLY_RECAP_ROWS_SQL, params);
-        List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots = readFullWeekSnapshots(rows);
-        // quota는 주간 합산하지 않고 월 스냅샷 단일값으로 조회
-        long totalQuotaBytes = readQuotaSnapshot(params);
-
-        // partial week 보강 없이 full week snapshot의 이의제기 count만 합산
-        int totalAppeals = sumInt(rows, "total_appeal_count");
-        int approvedAppeals = sumInt(rows, "approved_appeal_count");
-        int rejectedAppeals = sumInt(rows, "rejected_appeal_count");
+        List<Map<String, Object>> fullWeekRows =
+                jdbcTemplate.queryForList(READ_FULL_WEEKLY_RECAP_ROWS_SQL, monthlyParams);
 
         return new MonthlyFamilyRecapSourceMetrics(
-                fullWeekSnapshots, totalQuotaBytes, totalAppeals, approvedAppeals, rejectedAppeals);
+                readFullWeekSnapshots(fullWeekRows),
+                readQuotaSnapshot(monthlyParams),
+                readPartialUsageMetrics(familyId, targetMonth),
+                readMissionSummary(monthlyParams),
+                readAppealSummary(monthlyParams),
+                readAppealHighlights(monthlyParams));
     }
 
     private List<MonthlyWeeklyRecapSnapshot> readFullWeekSnapshots(List<Map<String, Object>> rows) {
@@ -90,21 +314,18 @@ public class MonthlyFamilyRecapAggregationRepository {
                         row ->
                                 new MonthlyWeeklyRecapSnapshot(
                                         toLocalDate(row.get("week_start_date")),
-                                        ((Number) row.get("total_used_bytes")).longValue(),
-                                        ((Number) row.get("total_quota_bytes")).longValue(),
+                                        toLong(row.get("total_used_bytes")),
+                                        toLong(row.get("total_quota_bytes")),
                                         toJsonString(row.get("usage_by_weekday")),
                                         toJsonString(row.get("peak_usage")),
-                                        ((Number) row.get("mission_created_count")).intValue(),
-                                        ((Number) row.get("mission_completed_count")).intValue(),
-                                        ((Number) row.get("mission_rejected_count")).intValue(),
-                                        ((Number) row.get("total_appeal_count")).intValue(),
-                                        ((Number) row.get("approved_appeal_count")).intValue(),
-                                        ((Number) row.get("rejected_appeal_count")).intValue()))
+                                        toInt(row.get("mission_created_count")),
+                                        toInt(row.get("mission_completed_count")),
+                                        toInt(row.get("mission_rejected_count"))))
                 .toList();
     }
 
     private long readQuotaSnapshot(MapSqlParameterSource params) {
-        // 주간 스냅샷이 있으면 가장 최근 값을 우선 사용
+        // quota는 합산하지 않고 월과 겹치는 가장 최근 weekly snapshot 1건만 사용
         Long quotaFromWeekly = readNullableLong(READ_LATEST_QUOTA_SNAPSHOT_FROM_WEEKLY_SQL, params);
         if (quotaFromWeekly != null) {
             return quotaFromWeekly;
@@ -115,13 +336,214 @@ public class MonthlyFamilyRecapAggregationRepository {
         return quotaFromFamily == null ? 0L : quotaFromFamily;
     }
 
-    private int sumInt(List<Map<String, Object>> rows, String columnName) {
-        return rows.stream()
-                .map(row -> row.get(columnName))
-                .filter(Number.class::isInstance)
-                .map(Number.class::cast)
-                .mapToInt(Number::intValue)
-                .sum();
+    private MonthlyUsageSupplementMetrics readPartialUsageMetrics(
+            Long familyId, LocalDate targetMonth) {
+        List<DateRange> partialRanges = resolvePartialRanges(targetMonth);
+        if (partialRanges.isEmpty()) {
+            return MonthlyUsageSupplementMetrics.empty();
+        }
+
+        long totalUsedBytes = 0L;
+        Map<String, Long> usageBytesByWeekday = initWeekdayUsageMap();
+        Map<Integer, Long> usageBytesByHour = new LinkedHashMap<>();
+
+        // 월 경계를 걸치는 좌/우 partial week만 raw 사용량으로 보강
+        for (DateRange range : partialRanges) {
+            MapSqlParameterSource rangeParams =
+                    new MapSqlParameterSource()
+                            .addValue("familyId", familyId)
+                            .addValue("rangeStart", Timestamp.valueOf(range.startInclusive()))
+                            .addValue("rangeEndExclusive", Timestamp.valueOf(range.endExclusive()));
+
+            totalUsedBytes += readLong(READ_TOTAL_USED_BYTES_IN_RANGE_SQL, rangeParams);
+
+            for (Map<String, Object> row :
+                    jdbcTemplate.queryForList(READ_USAGE_BY_WEEKDAY_IN_RANGE_SQL, rangeParams)) {
+                String weekday = resolveWeekdayKey(toInt(row.get("day_of_week")));
+                long bytes = toLong(row.get("total_bytes"));
+                usageBytesByWeekday.put(
+                        weekday, usageBytesByWeekday.getOrDefault(weekday, 0L) + bytes);
+            }
+
+            for (Map<String, Object> row :
+                    jdbcTemplate.queryForList(READ_USAGE_BY_HOUR_IN_RANGE_SQL, rangeParams)) {
+                int startHour = toInt(row.get("start_hour"));
+                long bytes = toLong(row.get("total_bytes"));
+                usageBytesByHour.put(
+                        startHour, usageBytesByHour.getOrDefault(startHour, 0L) + bytes);
+            }
+        }
+
+        MonthlyUsagePeakCandidate peakUsageCandidate = MonthlyUsagePeakCandidate.empty();
+        for (Map.Entry<Integer, Long> entry : usageBytesByHour.entrySet()) {
+            MonthlyUsagePeakCandidate candidate =
+                    new MonthlyUsagePeakCandidate(
+                            entry.getKey(), entry.getKey() + 1, entry.getValue());
+            if (candidate.isBetterThan(peakUsageCandidate)) {
+                peakUsageCandidate = candidate;
+            }
+        }
+
+        return new MonthlyUsageSupplementMetrics(
+                totalUsedBytes, usageBytesByWeekday, peakUsageCandidate);
+    }
+
+    private List<DateRange> resolvePartialRanges(LocalDate targetMonth) {
+        LocalDate monthStartDate = targetMonth;
+        LocalDate monthEndExclusiveDate = targetMonth.plusMonths(1);
+        LocalDate firstFullWeekStart =
+                monthStartDate.with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY));
+        LocalDate rightPartialWeekStart =
+                monthEndExclusiveDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+
+        // 월 내부 full week 밖에 남는 좌/우 구간만 partial raw 대상이 됨
+        List<DateRange> ranges = new ArrayList<>();
+        if (monthStartDate.isBefore(firstFullWeekStart)) {
+            ranges.add(
+                    new DateRange(
+                            monthStartDate.atStartOfDay(), firstFullWeekStart.atStartOfDay()));
+        }
+        if (rightPartialWeekStart.isBefore(monthEndExclusiveDate)) {
+            ranges.add(
+                    new DateRange(
+                            rightPartialWeekStart.atStartOfDay(),
+                            monthEndExclusiveDate.atStartOfDay()));
+        }
+        return ranges;
+    }
+
+    private MonthlyMissionSummary readMissionSummary(MapSqlParameterSource params) {
+        // mission summary는 월 경계 정합성을 위해 weekly 합산 대신 raw 월 집계를 사용
+        return new MonthlyMissionSummary(
+                readInt(READ_MISSION_CREATED_COUNT_SQL, params),
+                readInt(READ_MISSION_COMPLETED_COUNT_SQL, params),
+                readInt(READ_MISSION_REJECTED_COUNT_SQL, params));
+    }
+
+    private MonthlyAppealSummary readAppealSummary(MapSqlParameterSource params) {
+        // appeal summary/highlights/score가 같은 규칙을 보게 하려고 월 raw 집계를 한 번에 맞춤
+        return new MonthlyAppealSummary(
+                readInt(READ_TOTAL_APPEAL_COUNT_SQL, params),
+                readInt(READ_APPROVED_APPEAL_COUNT_SQL, params),
+                readInt(READ_REJECTED_APPEAL_COUNT_SQL, params));
+    }
+
+    private MonthlyAppealHighlights readAppealHighlights(MapSqlParameterSource params) {
+        MonthlyAppealHighlights.TopSuccessfulRequester topSuccessfulRequester =
+                readTopSuccessfulRequester(params);
+        MonthlyAppealHighlights.TopAcceptedApprover topAcceptedApprover =
+                readTopAcceptedApprover(params);
+        return new MonthlyAppealHighlights(topSuccessfulRequester, topAcceptedApprover);
+    }
+
+    private MonthlyAppealHighlights.TopSuccessfulRequester readTopSuccessfulRequester(
+            MapSqlParameterSource params) {
+        try {
+            Map<String, Object> row =
+                    jdbcTemplate.queryForMap(READ_TOP_SUCCESSFUL_REQUESTER_SQL, params);
+            Long requesterId = toLongObject(row.get("requester_id"));
+
+            // 대표 requester를 고른 뒤 최신 승인 이력 3건을 requestedAt 기준으로 붙임
+            MapSqlParameterSource recentParams = copyParams(params);
+            recentParams.addValue("requesterId", requesterId);
+            List<MonthlyAppealHighlights.RecentApprovedAppeal> recentApprovedAppeals =
+                    jdbcTemplate
+                            .queryForList(READ_RECENT_APPROVED_APPEALS_SQL, recentParams)
+                            .stream()
+                            .map(
+                                    recentRow ->
+                                            new MonthlyAppealHighlights.RecentApprovedAppeal(
+                                                    toLongObject(recentRow.get("appeal_id")),
+                                                    toLongObject(recentRow.get("approver_id")),
+                                                    toNullableString(
+                                                            recentRow.get("approver_name")),
+                                                    toNullableString(
+                                                            recentRow.get("request_reason")),
+                                                    toIsoDateTime(recentRow.get("requested_at"))))
+                            .toList();
+
+            return new MonthlyAppealHighlights.TopSuccessfulRequester(
+                    requesterId,
+                    toNullableString(row.get("requester_name")),
+                    toInt(row.get("approved_appeal_count")),
+                    recentApprovedAppeals);
+        } catch (EmptyResultDataAccessException exception) {
+            return MonthlyAppealHighlights.TopSuccessfulRequester.empty();
+        }
+    }
+
+    private MonthlyAppealHighlights.TopAcceptedApprover readTopAcceptedApprover(
+            MapSqlParameterSource params) {
+        try {
+            Map<String, Object> row =
+                    jdbcTemplate.queryForMap(READ_TOP_ACCEPTED_APPROVER_SQL, params);
+            Long approverId = toLongObject(row.get("approver_id"));
+
+            // 대표 approver를 고른 뒤 최신 수락 이력 3건을 resolvedAt 기준으로 붙임
+            MapSqlParameterSource recentParams = copyParams(params);
+            recentParams.addValue("approverId", approverId);
+            List<MonthlyAppealHighlights.RecentAcceptedAppeal> recentAcceptedAppeals =
+                    jdbcTemplate
+                            .queryForList(READ_RECENT_ACCEPTED_APPEALS_SQL, recentParams)
+                            .stream()
+                            .map(
+                                    recentRow ->
+                                            new MonthlyAppealHighlights.RecentAcceptedAppeal(
+                                                    toLongObject(recentRow.get("appeal_id")),
+                                                    toLongObject(recentRow.get("requester_id")),
+                                                    toNullableString(
+                                                            recentRow.get("requester_name")),
+                                                    toNullableString(
+                                                            recentRow.get("request_reason")),
+                                                    toIsoDateTime(recentRow.get("resolved_at"))))
+                            .toList();
+
+            return new MonthlyAppealHighlights.TopAcceptedApprover(
+                    approverId,
+                    toNullableString(row.get("approver_name")),
+                    toInt(row.get("approved_appeal_count")),
+                    recentAcceptedAppeals);
+        } catch (EmptyResultDataAccessException exception) {
+            return MonthlyAppealHighlights.TopAcceptedApprover.empty();
+        }
+    }
+
+    private MapSqlParameterSource copyParams(MapSqlParameterSource params) {
+        MapSqlParameterSource copied = new MapSqlParameterSource();
+        for (String name : params.getParameterNames()) {
+            copied.addValue(name, params.getValue(name));
+        }
+        return copied;
+    }
+
+    private Map<String, Long> initWeekdayUsageMap() {
+        Map<String, Long> usageByWeekday = new LinkedHashMap<>();
+        usageByWeekday.put("monday", 0L);
+        usageByWeekday.put("tuesday", 0L);
+        usageByWeekday.put("wednesday", 0L);
+        usageByWeekday.put("thursday", 0L);
+        usageByWeekday.put("friday", 0L);
+        usageByWeekday.put("saturday", 0L);
+        usageByWeekday.put("sunday", 0L);
+        return usageByWeekday;
+    }
+
+    private long readLong(String sql, MapSqlParameterSource params) {
+        try {
+            Long value = jdbcTemplate.queryForObject(sql, params, Long.class);
+            return value == null ? 0L : value;
+        } catch (EmptyResultDataAccessException exception) {
+            return 0L;
+        }
+    }
+
+    private int readInt(String sql, MapSqlParameterSource params) {
+        try {
+            Integer value = jdbcTemplate.queryForObject(sql, params, Integer.class);
+            return value == null ? 0 : value;
+        } catch (EmptyResultDataAccessException exception) {
+            return 0;
+        }
     }
 
     private Long readNullableLong(String sql, MapSqlParameterSource params) {
@@ -145,4 +567,45 @@ public class MonthlyFamilyRecapAggregationRepository {
     private String toJsonString(Object value) {
         return value == null ? null : String.valueOf(value);
     }
+
+    private int toInt(Object value) {
+        return value instanceof Number numberValue ? numberValue.intValue() : 0;
+    }
+
+    private long toLong(Object value) {
+        return value instanceof Number numberValue ? numberValue.longValue() : 0L;
+    }
+
+    private Long toLongObject(Object value) {
+        return value == null ? null : toLong(value);
+    }
+
+    private String toNullableString(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private String toIsoDateTime(Object value) {
+        if (value instanceof Timestamp timestampValue) {
+            return timestampValue.toLocalDateTime().format(ISO_DATE_TIME);
+        }
+        if (value instanceof Date dateValue) {
+            return dateValue.toLocalDate().atStartOfDay().format(ISO_DATE_TIME);
+        }
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private String resolveWeekdayKey(int dayOfWeek) {
+        return switch (dayOfWeek) {
+            case 1 -> "sunday";
+            case 2 -> "monday";
+            case 3 -> "tuesday";
+            case 4 -> "wednesday";
+            case 5 -> "thursday";
+            case 6 -> "friday";
+            case 7 -> "saturday";
+            default -> throw new IllegalArgumentException("Unexpected day_of_week: " + dayOfWeek);
+        };
+    }
+
+    private record DateRange(LocalDateTime startInclusive, LocalDateTime endExclusive) {}
 }

--- a/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
@@ -737,6 +737,3 @@ public class MonthlyFamilyRecapAggregationRepository {
 
     private record DateRange(LocalDateTime startInclusive, LocalDateTime endExclusive) {}
 }
-
-
-

--- a/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
@@ -33,6 +33,8 @@ public class MonthlyFamilyRecapAggregationRepository {
 
     private static final DateTimeFormatter ISO_DATE_TIME = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
+    private static final String APPROVED_APPEAL_COUNT = "approved_appeal_count";
+
     private static final String READ_FULL_WEEKLY_RECAP_ROWS_SQL =
             """
             SELECT week_start_date,
@@ -357,7 +359,7 @@ public class MonthlyFamilyRecapAggregationRepository {
                                         toInt(row.get("mission_completed_count")),
                                         toInt(row.get("mission_rejected_count")),
                                         toInt(row.get("total_appeal_count")),
-                                        toInt(row.get("approved_appeal_count")),
+                                        toInt(row.get(APPROVED_APPEAL_COUNT)),
                                         toInt(row.get("rejected_appeal_count"))))
                 .toList();
     }
@@ -584,7 +586,7 @@ public class MonthlyFamilyRecapAggregationRepository {
             return new MonthlyAppealHighlights.TopSuccessfulRequester(
                     requesterId,
                     toNullableString(row.get("requester_name")),
-                    toInt(row.get("approved_appeal_count")),
+                    toInt(row.get(APPROVED_APPEAL_COUNT)),
                     recentApprovedAppeals);
         } catch (EmptyResultDataAccessException exception) {
             return MonthlyAppealHighlights.TopSuccessfulRequester.empty();
@@ -620,7 +622,7 @@ public class MonthlyFamilyRecapAggregationRepository {
             return new MonthlyAppealHighlights.TopAcceptedApprover(
                     approverId,
                     toNullableString(row.get("approver_name")),
-                    toInt(row.get("approved_appeal_count")),
+                    toInt(row.get(APPROVED_APPEAL_COUNT)),
                     recentAcceptedAppeals);
         } catch (EmptyResultDataAccessException exception) {
             return MonthlyAppealHighlights.TopAcceptedApprover.empty();
@@ -735,3 +737,6 @@ public class MonthlyFamilyRecapAggregationRepository {
 
     private record DateRange(LocalDateTime startInclusive, LocalDateTime endExclusive) {}
 }
+
+
+

--- a/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
@@ -42,7 +42,10 @@ public class MonthlyFamilyRecapAggregationRepository {
                    peak_usage,
                    mission_created_count,
                    mission_completed_count,
-                   mission_rejected_count
+                   mission_rejected_count,
+                   total_appeal_count,
+                   approved_appeal_count,
+                   rejected_appeal_count
             FROM family_recap_weekly
             WHERE family_id = :familyId
               AND week_start_date >= :monthStartDate
@@ -103,54 +106,71 @@ public class MonthlyFamilyRecapAggregationRepository {
             GROUP BY HOUR(event_time)
             """;
 
-    private static final String READ_MISSION_CREATED_COUNT_SQL =
+    private static final String READ_MISSION_CREATED_COUNT_IN_RANGE_SQL =
             """
             SELECT COUNT(*)
             FROM mission_item
             WHERE family_id = :familyId
-              AND created_at >= :monthStart
-              AND created_at < :monthEndExclusive
+              AND created_at >= :rangeStart
+              AND created_at < :rangeEndExclusive
               AND deleted_at IS NULL
             """;
 
-    private static final String READ_MISSION_COMPLETED_COUNT_SQL =
+    private static final String READ_MISSION_COMPLETED_COUNT_IN_RANGE_SQL =
             """
             SELECT COUNT(*)
             FROM mission_item
             WHERE family_id = :familyId
               AND status = 'COMPLETED'
-              AND completed_at >= :monthStart
-              AND completed_at < :monthEndExclusive
+              AND completed_at >= :rangeStart
+              AND completed_at < :rangeEndExclusive
               AND deleted_at IS NULL
             """;
 
-    private static final String READ_MISSION_REJECTED_COUNT_SQL =
+    private static final String READ_MISSION_REJECTED_COUNT_IN_RANGE_SQL =
             """
             SELECT COUNT(*)
             FROM mission_request mr
             JOIN mission_item mi ON mr.mission_item_id = mi.id
             WHERE mi.family_id = :familyId
               AND mr.status = 'REJECTED'
-              AND mr.resolved_at >= :monthStart
-              AND mr.resolved_at < :monthEndExclusive
+              AND mr.resolved_at >= :rangeStart
+              AND mr.resolved_at < :rangeEndExclusive
               AND mr.deleted_at IS NULL
               AND mi.deleted_at IS NULL
             """;
 
-    private static final String READ_TOTAL_APPEAL_COUNT_SQL =
+    private static final String READ_MISSION_CARRY_IN_COUNT_SQL =
+            """
+            SELECT COUNT(*)
+            FROM mission_item mi
+            WHERE mi.family_id = :familyId
+              AND mi.created_at < :monthStart
+              AND mi.deleted_at IS NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM mission_log ml
+                  WHERE ml.mission_item_id = mi.id
+                    AND ml.action_type IN ('MISSION_COMPLETED', 'MISSION_CANCELLED')
+                    AND ml.created_at < :monthStart
+                    AND ml.deleted_at IS NULL
+              )
+            """;
+
+    private static final String READ_TOTAL_APPEAL_COUNT_IN_RANGE_SQL =
             """
             SELECT COUNT(*)
             FROM policy_appeal pa
             JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
             WHERE pas.family_id = :familyId
               AND pa.type = 'NORMAL'
-              AND pa.created_at >= :monthStart
-              AND pa.created_at < :monthEndExclusive
+              AND pa.created_at >= :rangeStart
+              AND pa.created_at < :rangeEndExclusive
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
             """;
 
-    private static final String READ_APPROVED_APPEAL_COUNT_SQL =
+    private static final String READ_APPROVED_APPEAL_COUNT_IN_RANGE_SQL =
             """
             SELECT COUNT(*)
             FROM policy_appeal pa
@@ -158,14 +178,13 @@ public class MonthlyFamilyRecapAggregationRepository {
             WHERE pas.family_id = :familyId
               AND pa.type = 'NORMAL'
               AND pa.status = 'APPROVED'
-              AND pa.created_at >= :monthStart
-              AND pa.created_at < :monthEndExclusive
-              AND pa.resolved_at < :monthEndExclusive
+              AND pa.resolved_at >= :rangeStart
+              AND pa.resolved_at < :rangeEndExclusive
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
             """;
 
-    private static final String READ_REJECTED_APPEAL_COUNT_SQL =
+    private static final String READ_REJECTED_APPEAL_COUNT_IN_RANGE_SQL =
             """
             SELECT COUNT(*)
             FROM policy_appeal pa
@@ -173,9 +192,22 @@ public class MonthlyFamilyRecapAggregationRepository {
             WHERE pas.family_id = :familyId
               AND pa.type = 'NORMAL'
               AND pa.status = 'REJECTED'
-              AND pa.created_at >= :monthStart
-              AND pa.created_at < :monthEndExclusive
-              AND pa.resolved_at < :monthEndExclusive
+              AND pa.resolved_at >= :rangeStart
+              AND pa.resolved_at < :rangeEndExclusive
+              AND pa.deleted_at IS NULL
+              AND pas.deleted_at IS NULL
+            """;
+
+    private static final String READ_APPEAL_CARRY_IN_COUNT_SQL =
+            """
+            SELECT COUNT(*)
+            FROM policy_appeal pa
+            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
+            WHERE pas.family_id = :familyId
+              AND pa.type = 'NORMAL'
+              AND pa.created_at < :monthStart
+              AND (pa.resolved_at IS NULL OR pa.resolved_at >= :monthStart)
+              AND (pa.cancelled_at IS NULL OR pa.cancelled_at >= :monthStart)
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
             """;
@@ -185,21 +217,20 @@ public class MonthlyFamilyRecapAggregationRepository {
             SELECT pa.requester_id AS requester_id,
                    requester.name AS requester_name,
                    COUNT(*) AS approved_appeal_count,
-                   MAX(pa.created_at) AS latest_requested_at
+                   MAX(pa.resolved_at) AS latest_resolved_at
             FROM policy_appeal pa
             JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
             JOIN customer requester ON pa.requester_id = requester.id
             WHERE pas.family_id = :familyId
               AND pa.type = 'NORMAL'
               AND pa.status = 'APPROVED'
-              AND pa.created_at >= :monthStart
-              AND pa.created_at < :monthEndExclusive
+              AND pa.resolved_at >= :monthStart
               AND pa.resolved_at < :monthEndExclusive
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
               AND requester.deleted_at IS NULL
             GROUP BY pa.requester_id, requester.name
-            ORDER BY approved_appeal_count DESC, latest_requested_at DESC, requester_id ASC
+            ORDER BY approved_appeal_count DESC, latest_resolved_at DESC, requester_id ASC
             LIMIT 1
             """;
 
@@ -219,12 +250,11 @@ public class MonthlyFamilyRecapAggregationRepository {
               AND pa.requester_id = :requesterId
               AND pa.type = 'NORMAL'
               AND pa.status = 'APPROVED'
-              AND pa.created_at >= :monthStart
-              AND pa.created_at < :monthEndExclusive
+              AND pa.resolved_at >= :monthStart
               AND pa.resolved_at < :monthEndExclusive
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
-            ORDER BY pa.created_at DESC, pa.id DESC
+            ORDER BY pa.resolved_at DESC, pa.id DESC
             LIMIT 3
             """;
 
@@ -241,8 +271,7 @@ public class MonthlyFamilyRecapAggregationRepository {
               AND pa.type = 'NORMAL'
               AND pa.status = 'APPROVED'
               AND pa.resolved_by_id IS NOT NULL
-              AND pa.created_at >= :monthStart
-              AND pa.created_at < :monthEndExclusive
+              AND pa.resolved_at >= :monthStart
               AND pa.resolved_at < :monthEndExclusive
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
@@ -268,8 +297,7 @@ public class MonthlyFamilyRecapAggregationRepository {
               AND pa.resolved_by_id = :approverId
               AND pa.type = 'NORMAL'
               AND pa.status = 'APPROVED'
-              AND pa.created_at >= :monthStart
-              AND pa.created_at < :monthEndExclusive
+              AND pa.resolved_at >= :monthStart
               AND pa.resolved_at < :monthEndExclusive
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
@@ -284,27 +312,34 @@ public class MonthlyFamilyRecapAggregationRepository {
         LocalDateTime monthStart = targetMonth.atStartOfDay();
         LocalDateTime monthEndExclusive = monthEndExclusiveDate.atStartOfDay();
 
+        // full week 조회와 carry-in 조회에 함께 쓰는 월 경계값
         MapSqlParameterSource monthlyParams =
                 new MapSqlParameterSource()
                         .addValue("familyId", familyId)
                         .addValue("monthStartDate", Date.valueOf(targetMonth))
                         .addValue("monthEndExclusiveDate", Date.valueOf(monthEndExclusiveDate))
+                        // 월 안에 완전히 들어오는 마지막 주 시작일
                         .addValue(
                                 "lastFullWeekStartDate",
                                 Date.valueOf(monthEndExclusiveDate.minusDays(7)))
+                        // 월과 겹칠 수 있는 최근 weekly snapshot 탐색 시작점
                         .addValue("overlapStartDate", Date.valueOf(targetMonth.minusDays(6)))
                         .addValue("monthStart", Timestamp.valueOf(monthStart))
                         .addValue("monthEndExclusive", Timestamp.valueOf(monthEndExclusive));
 
         List<Map<String, Object>> fullWeekRows =
                 jdbcTemplate.queryForList(READ_FULL_WEEKLY_RECAP_ROWS_SQL, monthlyParams);
+        // 월 내부 full week row만 weekly 합산에 사용
+        List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots = readFullWeekSnapshots(fullWeekRows);
 
         return new MonthlyFamilyRecapSourceMetrics(
-                readFullWeekSnapshots(fullWeekRows),
+                fullWeekSnapshots,
                 readQuotaSnapshot(monthlyParams),
                 readPartialUsageMetrics(familyId, targetMonth),
-                readMissionSummary(monthlyParams),
-                readAppealSummary(monthlyParams),
+                readMissionSummary(familyId, targetMonth, fullWeekSnapshots),
+                readAppealSummary(familyId, targetMonth, fullWeekSnapshots),
+                readMissionCarryInCount(monthlyParams),
+                readAppealCarryInCount(monthlyParams),
                 readAppealHighlights(monthlyParams));
     }
 
@@ -320,7 +355,10 @@ public class MonthlyFamilyRecapAggregationRepository {
                                         toJsonString(row.get("peak_usage")),
                                         toInt(row.get("mission_created_count")),
                                         toInt(row.get("mission_completed_count")),
-                                        toInt(row.get("mission_rejected_count"))))
+                                        toInt(row.get("mission_rejected_count")),
+                                        toInt(row.get("total_appeal_count")),
+                                        toInt(row.get("approved_appeal_count")),
+                                        toInt(row.get("rejected_appeal_count"))))
                 .toList();
     }
 
@@ -349,11 +387,7 @@ public class MonthlyFamilyRecapAggregationRepository {
 
         // 월 경계를 걸치는 좌/우 partial week만 raw 사용량으로 보강
         for (DateRange range : partialRanges) {
-            MapSqlParameterSource rangeParams =
-                    new MapSqlParameterSource()
-                            .addValue("familyId", familyId)
-                            .addValue("rangeStart", Timestamp.valueOf(range.startInclusive()))
-                            .addValue("rangeEndExclusive", Timestamp.valueOf(range.endExclusive()));
+            MapSqlParameterSource rangeParams = buildRangeParams(familyId, range);
 
             totalUsedBytes += readLong(READ_TOTAL_USED_BYTES_IN_RANGE_SQL, rangeParams);
 
@@ -396,14 +430,16 @@ public class MonthlyFamilyRecapAggregationRepository {
         LocalDate rightPartialWeekStart =
                 monthEndExclusiveDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
 
-        // 월 내부 full week 밖에 남는 좌/우 구간만 partial raw 대상이 됨
+        // 월 바깥으로 걸친 구간만 보강
         List<DateRange> ranges = new ArrayList<>();
         if (monthStartDate.isBefore(firstFullWeekStart)) {
+            // 좌측 partial
             ranges.add(
                     new DateRange(
                             monthStartDate.atStartOfDay(), firstFullWeekStart.atStartOfDay()));
         }
         if (rightPartialWeekStart.isBefore(monthEndExclusiveDate)) {
+            // 우측 partial
             ranges.add(
                     new DateRange(
                             rightPartialWeekStart.atStartOfDay(),
@@ -412,20 +448,102 @@ public class MonthlyFamilyRecapAggregationRepository {
         return ranges;
     }
 
-    private MonthlyMissionSummary readMissionSummary(MapSqlParameterSource params) {
-        // mission summary는 월 경계 정합성을 위해 weekly 합산 대신 raw 월 집계를 사용
+    private MonthlyMissionSummary readMissionSummary(
+            Long familyId,
+            LocalDate targetMonth,
+            List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots) {
+        // 월 경계 partial만 raw로 보강
+        MonthlyMissionSummary partialMissionSummary =
+                readPartialMissionSummary(familyId, targetMonth);
+
+        int totalMissionCount = partialMissionSummary.totalMissionCount();
+        int completedMissionCount = partialMissionSummary.completedMissionCount();
+        int rejectedRequestCount = partialMissionSummary.rejectedRequestCount();
+
+        // 월 내부 full week는 weekly snapshot 재사용
+        for (MonthlyWeeklyRecapSnapshot snapshot : fullWeekSnapshots) {
+            totalMissionCount += snapshot.missionCreatedCount();
+            completedMissionCount += snapshot.missionCompletedCount();
+            rejectedRequestCount += snapshot.missionRejectedCount();
+        }
+
         return new MonthlyMissionSummary(
-                readInt(READ_MISSION_CREATED_COUNT_SQL, params),
-                readInt(READ_MISSION_COMPLETED_COUNT_SQL, params),
-                readInt(READ_MISSION_REJECTED_COUNT_SQL, params));
+                totalMissionCount, completedMissionCount, rejectedRequestCount);
     }
 
-    private MonthlyAppealSummary readAppealSummary(MapSqlParameterSource params) {
-        // appeal summary/highlights/score가 같은 규칙을 보게 하려고 월 raw 집계를 한 번에 맞춤
-        return new MonthlyAppealSummary(
-                readInt(READ_TOTAL_APPEAL_COUNT_SQL, params),
-                readInt(READ_APPROVED_APPEAL_COUNT_SQL, params),
-                readInt(READ_REJECTED_APPEAL_COUNT_SQL, params));
+    private MonthlyAppealSummary readAppealSummary(
+            Long familyId,
+            LocalDate targetMonth,
+            List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots) {
+        // 월 경계 partial만 raw로 보강
+        MonthlyAppealSummary partialAppealSummary = readPartialAppealSummary(familyId, targetMonth);
+
+        int totalAppeals = partialAppealSummary.totalAppeals();
+        int approvedAppeals = partialAppealSummary.approvedAppeals();
+        int rejectedAppeals = partialAppealSummary.rejectedAppeals();
+
+        // 월 내부 full week는 weekly snapshot 재사용
+        for (MonthlyWeeklyRecapSnapshot snapshot : fullWeekSnapshots) {
+            totalAppeals += snapshot.totalAppealCount();
+            approvedAppeals += snapshot.approvedAppealCount();
+            rejectedAppeals += snapshot.rejectedAppealCount();
+        }
+
+        return new MonthlyAppealSummary(totalAppeals, approvedAppeals, rejectedAppeals);
+    }
+
+    private MonthlyMissionSummary readPartialMissionSummary(Long familyId, LocalDate targetMonth) {
+        List<DateRange> partialRanges = resolvePartialRanges(targetMonth);
+        if (partialRanges.isEmpty()) {
+            // full week만으로 월 집계 가능
+            return MonthlyMissionSummary.empty();
+        }
+
+        int totalMissionCount = 0;
+        int completedMissionCount = 0;
+        int rejectedRequestCount = 0;
+
+        for (DateRange range : partialRanges) {
+            MapSqlParameterSource rangeParams = buildRangeParams(familyId, range);
+            totalMissionCount += readInt(READ_MISSION_CREATED_COUNT_IN_RANGE_SQL, rangeParams);
+            completedMissionCount +=
+                    readInt(READ_MISSION_COMPLETED_COUNT_IN_RANGE_SQL, rangeParams);
+            rejectedRequestCount += readInt(READ_MISSION_REJECTED_COUNT_IN_RANGE_SQL, rangeParams);
+        }
+
+        return new MonthlyMissionSummary(
+                totalMissionCount, completedMissionCount, rejectedRequestCount);
+    }
+
+    private MonthlyAppealSummary readPartialAppealSummary(Long familyId, LocalDate targetMonth) {
+        List<DateRange> partialRanges = resolvePartialRanges(targetMonth);
+        if (partialRanges.isEmpty()) {
+            // full week만으로 월 집계 가능
+            return MonthlyAppealSummary.empty();
+        }
+
+        int totalAppeals = 0;
+        int approvedAppeals = 0;
+        int rejectedAppeals = 0;
+
+        for (DateRange range : partialRanges) {
+            MapSqlParameterSource rangeParams = buildRangeParams(familyId, range);
+            totalAppeals += readInt(READ_TOTAL_APPEAL_COUNT_IN_RANGE_SQL, rangeParams);
+            approvedAppeals += readInt(READ_APPROVED_APPEAL_COUNT_IN_RANGE_SQL, rangeParams);
+            rejectedAppeals += readInt(READ_REJECTED_APPEAL_COUNT_IN_RANGE_SQL, rangeParams);
+        }
+
+        return new MonthlyAppealSummary(totalAppeals, approvedAppeals, rejectedAppeals);
+    }
+
+    private int readMissionCarryInCount(MapSqlParameterSource params) {
+        // 월초 시점 미완료 미션 수
+        return readInt(READ_MISSION_CARRY_IN_COUNT_SQL, params);
+    }
+
+    private int readAppealCarryInCount(MapSqlParameterSource params) {
+        // 월초 시점 미해결 NORMAL 이의제기 수
+        return readInt(READ_APPEAL_CARRY_IN_COUNT_SQL, params);
     }
 
     private MonthlyAppealHighlights readAppealHighlights(MapSqlParameterSource params) {
@@ -444,6 +562,7 @@ public class MonthlyFamilyRecapAggregationRepository {
             Long requesterId = toLongObject(row.get("requester_id"));
 
             // 대표 requester를 고른 뒤 최신 승인 이력 3건을 requestedAt 기준으로 붙임
+            // 정렬은 resolvedAt 기준
             MapSqlParameterSource recentParams = copyParams(params);
             recentParams.addValue("requesterId", requesterId);
             List<MonthlyAppealHighlights.RecentApprovedAppeal> recentApprovedAppeals =
@@ -514,6 +633,13 @@ public class MonthlyFamilyRecapAggregationRepository {
             copied.addValue(name, params.getValue(name));
         }
         return copied;
+    }
+
+    private MapSqlParameterSource buildRangeParams(Long familyId, DateRange range) {
+        return new MapSqlParameterSource()
+                .addValue("familyId", familyId)
+                .addValue("rangeStart", Timestamp.valueOf(range.startInclusive()))
+                .addValue("rangeEndExclusive", Timestamp.valueOf(range.endExclusive()));
     }
 
     private Map<String, Long> initWeekdayUsageMap() {

--- a/src/main/java/com/template/worker/jobs/recap/weekly/query/WeeklyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/query/WeeklyFamilyRecapAggregationRepository.java
@@ -108,6 +108,7 @@ public class WeeklyFamilyRecapAggregationRepository {
               AND pa.type = 'NORMAL'
               AND pa.created_at >= :weekStart
               AND pa.created_at < :weekEndExclusive
+              AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
             """;
 
@@ -119,9 +120,9 @@ public class WeeklyFamilyRecapAggregationRepository {
             WHERE pas.family_id = :familyId
               AND pa.type = 'NORMAL'
               AND pa.status = 'APPROVED'
-              AND pa.created_at >= :weekStart
-              AND pa.created_at < :weekEndExclusive
+              AND pa.resolved_at >= :weekStart
               AND pa.resolved_at < :weekEndExclusive
+              AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
             """;
 
@@ -133,16 +134,16 @@ public class WeeklyFamilyRecapAggregationRepository {
             WHERE pas.family_id = :familyId
               AND pa.type = 'NORMAL'
               AND pa.status = 'REJECTED'
-              AND pa.created_at >= :weekStart
-              AND pa.created_at < :weekEndExclusive
+              AND pa.resolved_at >= :weekStart
               AND pa.resolved_at < :weekEndExclusive
+              AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
             """;
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
     public WeeklyFamilyRecapSourceMetrics aggregate(Long familyId, LocalDate weekStartDate) {
-        // 주간 집계 구간 [weekStart, weekStart+7days) 계산
+        // 주간 집계 구간 고정
         LocalDateTime weekStart = weekStartDate.atStartOfDay();
         LocalDateTime weekEndExclusive = weekStart.plusDays(7);
 
@@ -196,7 +197,7 @@ public class WeeklyFamilyRecapAggregationRepository {
     }
 
     private Map<String, Long> readUsageByWeekday(MapSqlParameterSource params) {
-        // 7요일 고정 키를 먼저 채워 누락 없이 반환
+        // 7요일 기본값 유지
         Map<String, Long> usageByWeekday = new LinkedHashMap<>();
         usageByWeekday.put("monday", 0L);
         usageByWeekday.put("tuesday", 0L);
@@ -218,7 +219,7 @@ public class WeeklyFamilyRecapAggregationRepository {
     }
 
     private WeeklyPeakUsage readPeakUsage(MapSqlParameterSource params) {
-        // 최대 사용량 시간대를 선택하고 동률이면 더 이른 시간을 우선
+        // 최대 시간대 선택
         List<Map<String, Object>> rows = jdbcTemplate.queryForList(READ_PEAK_USAGE_SQL, params);
         if (rows.isEmpty()) {
             return new WeeklyPeakUsage(0, 1, 0L);
@@ -232,7 +233,7 @@ public class WeeklyFamilyRecapAggregationRepository {
     }
 
     private String resolveWeekdayKey(int dayOfWeek) {
-        // MySQL DAYOFWEEK 숫자를 API 요일 키로 변환
+        // MySQL 요일 변환
         return switch (dayOfWeek) {
             case 1 -> "sunday";
             case 2 -> "monday";

--- a/src/main/resources/mysql.yml
+++ b/src/main/resources/mysql.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${DATABASE_URL:jdbc:mysql://localhost:3310/app_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
+    url: ${DATABASE_URL:jdbc:mysql://localhost:13306/app_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8}
     username: ${DATABASE_USER:app_user}
     password: ${DATABASE_PASSWORD:app_password}
     hikari:

--- a/src/main/resources/redis.yml
+++ b/src/main/resources/redis.yml
@@ -2,7 +2,7 @@ spring:
   data:
     redis:
       host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
+      port: ${REDIS_PORT:16379}
       password: ${REDIS_PASSWORD:}
       ssl:
         enabled: ${REDIS_SSL_ENABLED:false}

--- a/src/test/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessorTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessorTest.java
@@ -65,7 +65,10 @@ class MonthlyFamilyRecapProcessorTest {
                                 "{\"startHour\":21,\"endHour\":22,\"peakBytes\":500}",
                                 2,
                                 1,
-                                1),
+                                1,
+                                1,
+                                1,
+                                0),
                         new MonthlyWeeklyRecapSnapshot(
                                 LocalDate.of(2026, 3, 9),
                                 2000L,
@@ -76,7 +79,10 @@ class MonthlyFamilyRecapProcessorTest {
                                 "{\"startHour\":20,\"endHour\":21,\"peakBytes\":800}",
                                 1,
                                 1,
-                                0));
+                                0,
+                                2,
+                                1,
+                                1));
 
         MonthlyUsageSupplementMetrics partialUsageMetrics =
                 new MonthlyUsageSupplementMetrics(
@@ -117,6 +123,8 @@ class MonthlyFamilyRecapProcessorTest {
                                 partialUsageMetrics,
                                 new MonthlyMissionSummary(4, 3, 2),
                                 new MonthlyAppealSummary(5, 3, 1),
+                                0,
+                                0,
                                 appealHighlights));
 
         processor.beforeStep(stepExecution);
@@ -162,7 +170,7 @@ class MonthlyFamilyRecapProcessorTest {
         assertThat(highlights.path("topAcceptedApprover").path("approverId").longValue())
                 .isEqualTo(201L);
 
-        assertThat(row.communicationScore()).isEqualByComparingTo(new BigDecimal("81.50"));
+        assertThat(row.communicationScore()).isEqualByComparingTo(new BigDecimal("77.75"));
     }
 
     @Test
@@ -184,6 +192,9 @@ class MonthlyFamilyRecapProcessorTest {
                                 "{\"startHour\":20,\"endHour\":21,\"peakBytes\":100}",
                                 0,
                                 0,
+                                0,
+                                0,
+                                0,
                                 0));
 
         when(aggregationRepository.aggregate(20L, targetMonth))
@@ -194,6 +205,8 @@ class MonthlyFamilyRecapProcessorTest {
                                 MonthlyUsageSupplementMetrics.empty(),
                                 MonthlyMissionSummary.empty(),
                                 MonthlyAppealSummary.empty(),
+                                0,
+                                0,
                                 MonthlyAppealHighlights.empty()));
 
         processor.beforeStep(stepExecution);
@@ -217,12 +230,38 @@ class MonthlyFamilyRecapProcessorTest {
                                 MonthlyUsageSupplementMetrics.empty(),
                                 new MonthlyMissionSummary(3, 1, 0),
                                 MonthlyAppealSummary.empty(),
+                                0,
+                                0,
                                 MonthlyAppealHighlights.empty()));
 
         processor.beforeStep(stepExecution);
         MonthlyFamilyRecapRow row = processor.process(30L);
 
         assertThat(row.communicationScore()).isEqualByComparingTo(new BigDecimal("33.33"));
+    }
+
+    @Test
+    @DisplayName("process - 신규 요청이 없어도 carry in이 있으면 소통점수를 계산한다")
+    void process_withCarryInOnly_returnsCarryInBasedCommunicationScore() {
+        StepExecution stepExecution = createStepExecution("2026-03-01");
+        LocalDate targetMonth = LocalDate.of(2026, 3, 1);
+        when(parameterSupport.resolveTargetMonth(any(JobParameters.class))).thenReturn(targetMonth);
+        when(aggregationRepository.aggregate(35L, targetMonth))
+                .thenReturn(
+                        new MonthlyFamilyRecapSourceMetrics(
+                                List.of(),
+                                3000L,
+                                MonthlyUsageSupplementMetrics.empty(),
+                                MonthlyMissionSummary.empty(),
+                                new MonthlyAppealSummary(0, 1, 0),
+                                0,
+                                2,
+                                MonthlyAppealHighlights.empty()));
+
+        processor.beforeStep(stepExecution);
+        MonthlyFamilyRecapRow row = processor.process(35L);
+
+        assertThat(row.communicationScore()).isEqualByComparingTo(new BigDecimal("50.00"));
     }
 
     @Test
@@ -239,6 +278,8 @@ class MonthlyFamilyRecapProcessorTest {
                                 MonthlyUsageSupplementMetrics.empty(),
                                 MonthlyMissionSummary.empty(),
                                 MonthlyAppealSummary.empty(),
+                                0,
+                                0,
                                 MonthlyAppealHighlights.empty()));
 
         processor.beforeStep(stepExecution);
@@ -264,6 +305,8 @@ class MonthlyFamilyRecapProcessorTest {
                                         MonthlyUsagePeakCandidate.empty()),
                                 MonthlyMissionSummary.empty(),
                                 MonthlyAppealSummary.empty(),
+                                0,
+                                0,
                                 MonthlyAppealHighlights.empty()));
 
         processor.beforeStep(stepExecution);

--- a/src/test/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessorTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessorTest.java
@@ -7,7 +7,9 @@ import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,8 +26,13 @@ import org.springframework.batch.core.StepExecution;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.template.worker.jobs.recap.monthly.model.MonthlyAppealHighlights;
+import com.template.worker.jobs.recap.monthly.model.MonthlyAppealSummary;
 import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapRow;
 import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapSourceMetrics;
+import com.template.worker.jobs.recap.monthly.model.MonthlyMissionSummary;
+import com.template.worker.jobs.recap.monthly.model.MonthlyUsagePeakCandidate;
+import com.template.worker.jobs.recap.monthly.model.MonthlyUsageSupplementMetrics;
 import com.template.worker.jobs.recap.monthly.model.MonthlyWeeklyRecapSnapshot;
 import com.template.worker.jobs.recap.monthly.query.MonthlyFamilyRecapAggregationRepository;
 import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobParameterSupport;
@@ -40,16 +47,9 @@ class MonthlyFamilyRecapProcessorTest {
     @InjectMocks private MonthlyFamilyRecapProcessor processor;
 
     @Test
-    @DisplayName("process - 월간 full week 집계 결과를 리캡 row로 변환한다")
-    void process_buildsMonthlyRecapRow() throws Exception {
-        JobExecution jobExecution =
-                new JobExecution(
-                        new JobInstance(1L, "monthly-family-recap-job"),
-                        new JobParametersBuilder()
-                                .addString("targetMonth", "2026-03-01")
-                                .toJobParameters());
-        StepExecution stepExecution = new StepExecution("process-monthly-recap-step", jobExecution);
-
+    @DisplayName("process - full week와 partial week를 합쳐 월간 리캡 row를 만든다")
+    void process_buildsMonthlyRecapRowWithPartialSupplement() throws Exception {
+        StepExecution stepExecution = createStepExecution("2026-03-01");
         LocalDate targetMonth = LocalDate.of(2026, 3, 1);
         when(parameterSupport.resolveTargetMonth(any(JobParameters.class))).thenReturn(targetMonth);
 
@@ -65,10 +65,7 @@ class MonthlyFamilyRecapProcessorTest {
                                 "{\"startHour\":21,\"endHour\":22,\"peakBytes\":500}",
                                 2,
                                 1,
-                                1,
-                                1,
-                                1,
-                                0),
+                                1),
                         new MonthlyWeeklyRecapSnapshot(
                                 LocalDate.of(2026, 3, 9),
                                 2000L,
@@ -79,67 +76,99 @@ class MonthlyFamilyRecapProcessorTest {
                                 "{\"startHour\":20,\"endHour\":21,\"peakBytes\":800}",
                                 1,
                                 1,
-                                0,
-                                2,
-                                2,
                                 0));
 
+        MonthlyUsageSupplementMetrics partialUsageMetrics =
+                new MonthlyUsageSupplementMetrics(
+                        500L,
+                        weekdayBytes(0L, 0L, 500L, 0L, 0L, 0L, 0L),
+                        new MonthlyUsagePeakCandidate(22, 23, 900L));
+
+        MonthlyAppealHighlights appealHighlights =
+                new MonthlyAppealHighlights(
+                        new MonthlyAppealHighlights.TopSuccessfulRequester(
+                                101L,
+                                "김민지",
+                                3,
+                                List.of(
+                                        new MonthlyAppealHighlights.RecentApprovedAppeal(
+                                                91L,
+                                                201L,
+                                                "김철수",
+                                                "야간 차단 해제를 요청했어요.",
+                                                "2026-03-21T14:32:00"))),
+                        new MonthlyAppealHighlights.TopAcceptedApprover(
+                                201L,
+                                "김철수",
+                                3,
+                                List.of(
+                                        new MonthlyAppealHighlights.RecentAcceptedAppeal(
+                                                91L,
+                                                101L,
+                                                "김민지",
+                                                "야간 차단 해제를 요청했어요.",
+                                                "2026-03-21T14:32:00"))));
+
         when(aggregationRepository.aggregate(10L, targetMonth))
-                .thenReturn(new MonthlyFamilyRecapSourceMetrics(snapshots, 10000L, 5, 3, 1));
+                .thenReturn(
+                        new MonthlyFamilyRecapSourceMetrics(
+                                snapshots,
+                                10000L,
+                                partialUsageMetrics,
+                                new MonthlyMissionSummary(4, 3, 2),
+                                new MonthlyAppealSummary(5, 3, 1),
+                                appealHighlights));
 
         processor.beforeStep(stepExecution);
         MonthlyFamilyRecapRow row = processor.process(10L);
 
         assertThat(row.familyId()).isEqualTo(10L);
         assertThat(row.reportMonth()).isEqualTo(targetMonth);
-        assertThat(row.totalUsedBytes()).isEqualTo(3000L);
+        assertThat(row.totalUsedBytes()).isEqualTo(3500L);
         assertThat(row.totalQuotaBytes()).isEqualTo(10000L);
-        assertThat(row.usageRatePercent()).isEqualTo(new BigDecimal("30.00"));
+        assertThat(row.usageRatePercent()).isEqualByComparingTo("35.00");
 
         JsonNode usageByWeekday = objectMapper.readTree(row.usageByWeekdayJson());
-        assertThat(usageByWeekday.get("monday").decimalValue()).isEqualByComparingTo("33.33");
-        assertThat(usageByWeekday.get("tuesday").decimalValue()).isEqualByComparingTo("66.67");
-        assertThat(usageByWeekday.get("wednesday").decimalValue()).isEqualByComparingTo("0.00");
+        assertThat(usageByWeekday.get("monday").decimalValue()).isEqualByComparingTo("28.57");
+        assertThat(usageByWeekday.get("tuesday").decimalValue()).isEqualByComparingTo("57.14");
+        assertThat(usageByWeekday.get("wednesday").decimalValue()).isEqualByComparingTo("14.29");
 
         JsonNode peakUsage = objectMapper.readTree(row.peakUsageJson());
-        assertThat(peakUsage.get("startHour").intValue()).isEqualTo(20);
-        assertThat(peakUsage.get("endHour").intValue()).isEqualTo(21);
+        assertThat(peakUsage.get("startHour").intValue()).isEqualTo(22);
+        assertThat(peakUsage.get("endHour").intValue()).isEqualTo(23);
         assertThat(peakUsage.get("mostUsedWeekday").textValue()).isEqualTo("tuesday");
 
         JsonNode missionSummary = objectMapper.readTree(row.missionSummaryJson());
-        assertThat(missionSummary.get("totalMissionCount").intValue()).isEqualTo(3);
-        assertThat(missionSummary.get("completedMissionCount").intValue()).isEqualTo(2);
-        assertThat(missionSummary.get("rejectedRequestCount").intValue()).isEqualTo(1);
+        assertThat(missionSummary.get("totalMissionCount").intValue()).isEqualTo(4);
+        assertThat(missionSummary.get("completedMissionCount").intValue()).isEqualTo(3);
+        assertThat(missionSummary.get("rejectedRequestCount").intValue()).isEqualTo(2);
 
         JsonNode appealSummary = objectMapper.readTree(row.appealSummaryJson());
         assertThat(appealSummary.get("totalAppeals").intValue()).isEqualTo(5);
         assertThat(appealSummary.get("approvedAppeals").intValue()).isEqualTo(3);
         assertThat(appealSummary.get("rejectedAppeals").intValue()).isEqualTo(1);
 
-        JsonNode appealHighlights = objectMapper.readTree(row.appealHighlightsJson());
-        assertThat(appealHighlights.path("topSuccessfulRequester").path("requesterId").isNull())
-                .isTrue();
+        JsonNode highlights = objectMapper.readTree(row.appealHighlightsJson());
+        assertThat(highlights.path("topSuccessfulRequester").path("requesterId").longValue())
+                .isEqualTo(101L);
         assertThat(
-                        appealHighlights
-                                .path("topAcceptedApprover")
-                                .path("recentAcceptedAppeals")
-                                .isArray())
-                .isTrue();
+                        highlights
+                                .path("topSuccessfulRequester")
+                                .path("recentApprovedAppeals")
+                                .get(0)
+                                .path("requestedAt")
+                                .textValue())
+                .isEqualTo("2026-03-21T14:32:00");
+        assertThat(highlights.path("topAcceptedApprover").path("approverId").longValue())
+                .isEqualTo(201L);
 
-        assertThat(row.communicationScore()).isEqualByComparingTo(new BigDecimal("74.83"));
+        assertThat(row.communicationScore()).isEqualByComparingTo(new BigDecimal("81.50"));
     }
 
     @Test
-    @DisplayName("process - total_quota_bytes는 주간 합산이 아닌 단일 snapshot 값을 사용한다")
-    void process_usesSingleQuotaSnapshot() {
-        JobExecution jobExecution =
-                new JobExecution(
-                        new JobInstance(1L, "monthly-family-recap-job"),
-                        new JobParametersBuilder()
-                                .addString("targetMonth", "2026-03-01")
-                                .toJobParameters());
-        StepExecution stepExecution = new StepExecution("process-monthly-recap-step", jobExecution);
-
+    @DisplayName("process - mostUsedWeekday tie는 monday부터 우선한다")
+    void process_whenWeekdayUsageIsTied_prefersEarlierWeekday() throws Exception {
+        StepExecution stepExecution = createStepExecution("2026-03-01");
         LocalDate targetMonth = LocalDate.of(2026, 3, 1);
         when(parameterSupport.resolveTargetMonth(any(JobParameters.class))).thenReturn(targetMonth);
 
@@ -149,67 +178,46 @@ class MonthlyFamilyRecapProcessorTest {
                                 LocalDate.of(2026, 3, 2),
                                 1000L,
                                 3000L,
-                                "{}",
-                                "{}",
-                                0,
-                                0,
-                                0,
-                                0,
-                                0,
-                                0),
-                        new MonthlyWeeklyRecapSnapshot(
-                                LocalDate.of(2026, 3, 9),
-                                1000L,
-                                7000L,
-                                "{}",
-                                "{}",
-                                0,
-                                0,
-                                0,
+                                "{\"monday\":50.00,\"tuesday\":50.00,\"wednesday\":0.00,"
+                                        + "\"thursday\":0.00,\"friday\":0.00,\"saturday\":0.00,"
+                                        + "\"sunday\":0.00}",
+                                "{\"startHour\":20,\"endHour\":21,\"peakBytes\":100}",
                                 0,
                                 0,
                                 0));
 
         when(aggregationRepository.aggregate(20L, targetMonth))
-                .thenReturn(new MonthlyFamilyRecapSourceMetrics(snapshots, 9000L, 0, 0, 0));
+                .thenReturn(
+                        new MonthlyFamilyRecapSourceMetrics(
+                                snapshots,
+                                3000L,
+                                MonthlyUsageSupplementMetrics.empty(),
+                                MonthlyMissionSummary.empty(),
+                                MonthlyAppealSummary.empty(),
+                                MonthlyAppealHighlights.empty()));
 
         processor.beforeStep(stepExecution);
         MonthlyFamilyRecapRow row = processor.process(20L);
 
-        assertThat(row.totalQuotaBytes()).isEqualTo(9000L);
+        JsonNode peakUsage = objectMapper.readTree(row.peakUsageJson());
+        assertThat(peakUsage.get("mostUsedWeekday").textValue()).isEqualTo("monday");
     }
 
     @Test
     @DisplayName("process - 이의제기가 없고 미션만 있으면 소통점수는 미션 완료율 fallback을 사용한다")
     void process_withoutAppeals_withMissions_usesFallbackCommunicationScore() {
-        JobExecution jobExecution =
-                new JobExecution(
-                        new JobInstance(1L, "monthly-family-recap-job"),
-                        new JobParametersBuilder()
-                                .addString("targetMonth", "2026-03-01")
-                                .toJobParameters());
-        StepExecution stepExecution = new StepExecution("process-monthly-recap-step", jobExecution);
-
+        StepExecution stepExecution = createStepExecution("2026-03-01");
         LocalDate targetMonth = LocalDate.of(2026, 3, 1);
         when(parameterSupport.resolveTargetMonth(any(JobParameters.class))).thenReturn(targetMonth);
-
-        List<MonthlyWeeklyRecapSnapshot> snapshots =
-                List.of(
-                        new MonthlyWeeklyRecapSnapshot(
-                                LocalDate.of(2026, 3, 2),
-                                500L,
-                                3000L,
-                                "{}",
-                                "{}",
-                                3,
-                                1,
-                                0,
-                                0,
-                                0,
-                                0));
-
         when(aggregationRepository.aggregate(30L, targetMonth))
-                .thenReturn(new MonthlyFamilyRecapSourceMetrics(snapshots, 3000L, 0, 0, 0));
+                .thenReturn(
+                        new MonthlyFamilyRecapSourceMetrics(
+                                List.of(),
+                                3000L,
+                                MonthlyUsageSupplementMetrics.empty(),
+                                new MonthlyMissionSummary(3, 1, 0),
+                                MonthlyAppealSummary.empty(),
+                                MonthlyAppealHighlights.empty()));
 
         processor.beforeStep(stepExecution);
         MonthlyFamilyRecapRow row = processor.process(30L);
@@ -220,18 +228,18 @@ class MonthlyFamilyRecapProcessorTest {
     @Test
     @DisplayName("process - 이의제기와 미션이 모두 0건이면 소통점수는 null이다")
     void process_withoutAppealsAndMissions_returnsNullCommunicationScore() {
-        JobExecution jobExecution =
-                new JobExecution(
-                        new JobInstance(1L, "monthly-family-recap-job"),
-                        new JobParametersBuilder()
-                                .addString("targetMonth", "2026-03-01")
-                                .toJobParameters());
-        StepExecution stepExecution = new StepExecution("process-monthly-recap-step", jobExecution);
-
+        StepExecution stepExecution = createStepExecution("2026-03-01");
         LocalDate targetMonth = LocalDate.of(2026, 3, 1);
         when(parameterSupport.resolveTargetMonth(any(JobParameters.class))).thenReturn(targetMonth);
         when(aggregationRepository.aggregate(40L, targetMonth))
-                .thenReturn(new MonthlyFamilyRecapSourceMetrics(List.of(), 0L, 0, 0, 0));
+                .thenReturn(
+                        new MonthlyFamilyRecapSourceMetrics(
+                                List.of(),
+                                0L,
+                                MonthlyUsageSupplementMetrics.empty(),
+                                MonthlyMissionSummary.empty(),
+                                MonthlyAppealSummary.empty(),
+                                MonthlyAppealHighlights.empty()));
 
         processor.beforeStep(stepExecution);
         MonthlyFamilyRecapRow row = processor.process(40L);
@@ -242,41 +250,55 @@ class MonthlyFamilyRecapProcessorTest {
     @Test
     @DisplayName("process - 집계값이 음수면 예외가 발생한다")
     void process_withNegativeAggregate_throwsException() {
-        JobExecution jobExecution =
-                new JobExecution(
-                        new JobInstance(1L, "monthly-family-recap-job"),
-                        new JobParametersBuilder()
-                                .addString("targetMonth", "2026-03-01")
-                                .toJobParameters());
-        StepExecution stepExecution = new StepExecution("process-monthly-recap-step", jobExecution);
-
+        StepExecution stepExecution = createStepExecution("2026-03-01");
         LocalDate targetMonth = LocalDate.of(2026, 3, 1);
         when(parameterSupport.resolveTargetMonth(any(JobParameters.class))).thenReturn(targetMonth);
         when(aggregationRepository.aggregate(50L, targetMonth))
                 .thenReturn(
                         new MonthlyFamilyRecapSourceMetrics(
-                                List.of(
-                                        new MonthlyWeeklyRecapSnapshot(
-                                                LocalDate.of(2026, 3, 2),
-                                                -1L,
-                                                1000L,
-                                                "{}",
-                                                "{}",
-                                                0,
-                                                0,
-                                                0,
-                                                0,
-                                                0,
-                                                0)),
+                                List.of(),
                                 1000L,
-                                0,
-                                0,
-                                0));
+                                new MonthlyUsageSupplementMetrics(
+                                        -1L,
+                                        weekdayBytes(0L, 0L, 0L, 0L, 0L, 0L, 0L),
+                                        MonthlyUsagePeakCandidate.empty()),
+                                MonthlyMissionSummary.empty(),
+                                MonthlyAppealSummary.empty(),
+                                MonthlyAppealHighlights.empty()));
 
         processor.beforeStep(stepExecution);
 
         assertThatThrownBy(() -> processor.process(50L))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("cannot be negative");
+    }
+
+    private StepExecution createStepExecution(String targetMonth) {
+        JobExecution jobExecution =
+                new JobExecution(
+                        new JobInstance(1L, "monthly-family-recap-job"),
+                        new JobParametersBuilder()
+                                .addString("targetMonth", targetMonth)
+                                .toJobParameters());
+        return new StepExecution("process-monthly-recap-step", jobExecution);
+    }
+
+    private Map<String, Long> weekdayBytes(
+            long monday,
+            long tuesday,
+            long wednesday,
+            long thursday,
+            long friday,
+            long saturday,
+            long sunday) {
+        Map<String, Long> bytesByWeekday = new LinkedHashMap<>();
+        bytesByWeekday.put("monday", monday);
+        bytesByWeekday.put("tuesday", tuesday);
+        bytesByWeekday.put("wednesday", wednesday);
+        bytesByWeekday.put("thursday", thursday);
+        bytesByWeekday.put("friday", friday);
+        bytesByWeekday.put("saturday", saturday);
+        bytesByWeekday.put("sunday", sunday);
+        return bytesByWeekday;
     }
 }

--- a/src/test/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepositoryTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepositoryTest.java
@@ -1,0 +1,229 @@
+package com.template.worker.jobs.recap.monthly.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import com.template.worker.jobs.recap.monthly.model.MonthlyAppealHighlights;
+import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapSourceMetrics;
+
+class MonthlyFamilyRecapAggregationRepositoryTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private MonthlyFamilyRecapAggregationRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        DataSource dataSource = createDataSource();
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        repository =
+                new MonthlyFamilyRecapAggregationRepository(
+                        new NamedParameterJdbcTemplate(dataSource));
+
+        jdbcTemplate.execute("DROP ALL OBJECTS");
+        createTables();
+    }
+
+    @Test
+    @DisplayName("aggregate - full week snapshot과 partial/raw 집계를 함께 읽는다")
+    void aggregate_readsFullWeekAndRawMonthlySupplement() {
+        jdbcTemplate.update(
+                "INSERT INTO family (id, total_quota_bytes, deleted_at) VALUES (1, 10000, NULL)");
+
+        jdbcTemplate.update(
+                "INSERT INTO family_recap_weekly (family_id, week_start_date, total_used_bytes,"
+                    + " total_quota_bytes, usage_by_weekday, peak_usage, mission_created_count,"
+                    + " mission_completed_count, mission_rejected_count) VALUES (1, DATE"
+                    + " '2026-03-02', 1000, 8000,"
+                    + " '{\"monday\":100.00,\"tuesday\":0.00,\"wednesday\":0.00,\"thursday\":0.00,\"friday\":0.00,\"saturday\":0.00,\"sunday\":0.00}',"
+                    + " '{\"startHour\":21,\"endHour\":22,\"peakBytes\":500}', 2, 1, 1)");
+        jdbcTemplate.update(
+                "INSERT INTO family_recap_weekly (family_id, week_start_date, total_used_bytes,"
+                    + " total_quota_bytes, usage_by_weekday, peak_usage, mission_created_count,"
+                    + " mission_completed_count, mission_rejected_count) VALUES (1, DATE"
+                    + " '2026-03-23', 2000, 9000,"
+                    + " '{\"monday\":0.00,\"tuesday\":100.00,\"wednesday\":0.00,\"thursday\":0.00,\"friday\":0.00,\"saturday\":0.00,\"sunday\":0.00}',"
+                    + " '{\"startHour\":20,\"endHour\":21,\"peakBytes\":800}', 1, 1, 0)");
+
+        jdbcTemplate.update(
+                "INSERT INTO usage_record (id, family_id, event_time, bytes_used, deleted_at)"
+                        + " VALUES (1, 1, TIMESTAMP '2026-03-01 22:10:00', 300, NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO usage_record (id, family_id, event_time, bytes_used, deleted_at)"
+                        + " VALUES (2, 1, TIMESTAMP '2026-03-31 22:20:00', 200, NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO usage_record (id, family_id, event_time, bytes_used, deleted_at)"
+                        + " VALUES (3, 1, TIMESTAMP '2026-03-31 10:00:00', 100, NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO usage_record (id, family_id, event_time, bytes_used, deleted_at)"
+                        + " VALUES (4, 1, TIMESTAMP '2026-03-10 10:00:00', 999, NULL)");
+
+        jdbcTemplate.update(
+                "INSERT INTO mission_item (id, family_id, status, completed_at, created_at,"
+                    + " deleted_at) VALUES (1, 1, 'ACTIVE', NULL, TIMESTAMP '2026-03-01 08:00:00',"
+                    + " NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO mission_item (id, family_id, status, completed_at, created_at,"
+                        + " deleted_at) VALUES (2, 1, 'COMPLETED', TIMESTAMP '2026-03-31 18:00:00',"
+                        + " TIMESTAMP '2026-03-15 09:00:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO mission_request (id, mission_item_id, status, resolved_at, deleted_at)"
+                        + " VALUES (1, 2, 'REJECTED', TIMESTAMP '2026-03-31 19:00:00', NULL)");
+
+        jdbcTemplate.update(
+                "INSERT INTO customer (id, name, deleted_at) VALUES (101, '김민지', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO customer (id, name, deleted_at) VALUES (102, '김민수', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO customer (id, name, deleted_at) VALUES (201, '김철수', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO policy_assignment (id, family_id, deleted_at) VALUES (11, 1, NULL)");
+
+        jdbcTemplate.update(
+                "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
+                    + " request_reason, resolved_by_id, resolved_at, created_at, deleted_at) VALUES"
+                    + " (83, 11, 101, 'NORMAL', 'APPROVED', '인강 시청 시간 연장을 요청했어요.', 201, TIMESTAMP"
+                    + " '2026-03-12 19:30:00', TIMESTAMP '2026-03-12 19:05:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
+                    + " request_reason, resolved_by_id, resolved_at, created_at, deleted_at) VALUES"
+                    + " (87, 11, 101, 'NORMAL', 'APPROVED', '주말 사용 제한 완화를 요청했어요.', 201, TIMESTAMP"
+                    + " '2026-03-18 20:40:00', TIMESTAMP '2026-03-18 20:10:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
+                    + " request_reason, resolved_by_id, resolved_at, created_at, deleted_at) VALUES"
+                    + " (91, 11, 101, 'NORMAL', 'APPROVED', '야간 차단 해제를 요청했어요.', 201, TIMESTAMP"
+                    + " '2026-03-21 15:00:00', TIMESTAMP '2026-03-21 14:32:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
+                    + " request_reason, resolved_by_id, resolved_at, created_at, deleted_at) VALUES"
+                    + " (95, 11, 102, 'NORMAL', 'APPROVED', '월말 예외 사용을 요청했어요.', 201, TIMESTAMP"
+                    + " '2026-04-02 10:00:00', TIMESTAMP '2026-03-30 09:00:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
+                    + " request_reason, resolved_by_id, resolved_at, created_at, deleted_at) VALUES"
+                    + " (96, 11, 101, 'NORMAL', 'REJECTED', '게임 시간 연장을 요청했어요.', 201, TIMESTAMP"
+                    + " '2026-03-25 11:30:00', TIMESTAMP '2026-03-25 10:00:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
+                    + " request_reason, resolved_by_id, resolved_at, created_at, deleted_at) VALUES"
+                    + " (97, 11, 101, 'EMERGENCY', 'APPROVED', '긴급 데이터 충전을 요청했어요.', 201, TIMESTAMP"
+                    + " '2026-03-10 12:00:00', TIMESTAMP '2026-03-10 11:00:00', NULL)");
+
+        MonthlyFamilyRecapSourceMetrics result = repository.aggregate(1L, LocalDate.of(2026, 3, 1));
+
+        assertThat(result.fullWeekSnapshots()).hasSize(2);
+        assertThat(result.totalQuotaBytes()).isEqualTo(9000L);
+        assertThat(result.partialUsageMetrics().totalUsedBytes()).isEqualTo(600L);
+        assertThat(result.partialUsageMetrics().usageBytesByWeekday())
+                .containsEntry("sunday", 300L)
+                .containsEntry("tuesday", 300L);
+        assertThat(result.partialUsageMetrics().peakUsageCandidate().startHour()).isEqualTo(22);
+        assertThat(result.partialUsageMetrics().peakUsageCandidate().peakBytes()).isEqualTo(500L);
+
+        assertThat(result.missionSummary().totalMissionCount()).isEqualTo(2);
+        assertThat(result.missionSummary().completedMissionCount()).isEqualTo(1);
+        assertThat(result.missionSummary().rejectedRequestCount()).isEqualTo(1);
+
+        assertThat(result.appealSummary().totalAppeals()).isEqualTo(5);
+        assertThat(result.appealSummary().approvedAppeals()).isEqualTo(3);
+        assertThat(result.appealSummary().rejectedAppeals()).isEqualTo(1);
+
+        MonthlyAppealHighlights.TopSuccessfulRequester topRequester =
+                result.appealHighlights().topSuccessfulRequester();
+        assertThat(topRequester.requesterId()).isEqualTo(101L);
+        assertThat(topRequester.requesterName()).isEqualTo("김민지");
+        assertThat(topRequester.approvedAppealCount()).isEqualTo(3);
+        assertThat(topRequester.recentApprovedAppeals())
+                .extracting(MonthlyAppealHighlights.RecentApprovedAppeal::appealId)
+                .containsExactly(91L, 87L, 83L);
+
+        MonthlyAppealHighlights.TopAcceptedApprover topApprover =
+                result.appealHighlights().topAcceptedApprover();
+        assertThat(topApprover.approverId()).isEqualTo(201L);
+        assertThat(topApprover.approvedAppealCount()).isEqualTo(3);
+        assertThat(topApprover.recentAcceptedAppeals())
+                .extracting(MonthlyAppealHighlights.RecentAcceptedAppeal::appealId)
+                .containsExactly(91L, 87L, 83L);
+    }
+
+    @Test
+    @DisplayName("aggregate - overlapping weekly snapshot이 없으면 family quota와 empty highlight를 사용한다")
+    void aggregate_withoutWeeklySnapshot_fallsBackToFamilyQuota() {
+        jdbcTemplate.update(
+                "INSERT INTO family (id, total_quota_bytes, deleted_at) VALUES (2, 7000, NULL)");
+
+        MonthlyFamilyRecapSourceMetrics result = repository.aggregate(2L, LocalDate.of(2026, 3, 1));
+
+        assertThat(result.fullWeekSnapshots()).isEmpty();
+        assertThat(result.totalQuotaBytes()).isEqualTo(7000L);
+        assertThat(result.partialUsageMetrics().totalUsedBytes()).isZero();
+        assertThat(result.appealHighlights().topSuccessfulRequester().requesterId()).isNull();
+        assertThat(result.appealHighlights().topAcceptedApprover().approverId()).isNull();
+    }
+
+    private DataSource createDataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:monthly_recap_repo_test;MODE=MySQL;DB_CLOSE_DELAY=-1");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+        return dataSource;
+    }
+
+    private void createTables() {
+        jdbcTemplate.execute(
+                "CREATE TABLE family (id BIGINT PRIMARY KEY, total_quota_bytes BIGINT NOT NULL,"
+                        + " deleted_at TIMESTAMP NULL)");
+        jdbcTemplate.execute(
+                "CREATE TABLE family_recap_weekly ("
+                        + "family_id BIGINT NOT NULL, "
+                        + "week_start_date DATE NOT NULL, "
+                        + "total_used_bytes BIGINT NOT NULL, "
+                        + "total_quota_bytes BIGINT NOT NULL, "
+                        + "usage_by_weekday VARCHAR(2000), "
+                        + "peak_usage VARCHAR(1000), "
+                        + "mission_created_count INT NOT NULL, "
+                        + "mission_completed_count INT NOT NULL, "
+                        + "mission_rejected_count INT NOT NULL)");
+        jdbcTemplate.execute(
+                "CREATE TABLE usage_record (id BIGINT PRIMARY KEY, family_id BIGINT NOT NULL,"
+                        + " event_time TIMESTAMP NOT NULL, bytes_used BIGINT NOT NULL, deleted_at"
+                        + " TIMESTAMP NULL)");
+        jdbcTemplate.execute(
+                "CREATE TABLE mission_item (id BIGINT PRIMARY KEY, family_id BIGINT NOT NULL,"
+                        + " status VARCHAR(20) NOT NULL, completed_at TIMESTAMP NULL, created_at"
+                        + " TIMESTAMP NOT NULL, deleted_at TIMESTAMP NULL)");
+        jdbcTemplate.execute(
+                "CREATE TABLE mission_request (id BIGINT PRIMARY KEY, mission_item_id BIGINT NOT"
+                    + " NULL, status VARCHAR(20) NOT NULL, resolved_at TIMESTAMP NULL, deleted_at"
+                    + " TIMESTAMP NULL)");
+        jdbcTemplate.execute(
+                "CREATE TABLE customer (id BIGINT PRIMARY KEY, name VARCHAR(100) NOT NULL,"
+                        + " deleted_at TIMESTAMP NULL)");
+        jdbcTemplate.execute(
+                "CREATE TABLE policy_assignment (id BIGINT PRIMARY KEY, family_id BIGINT NOT NULL,"
+                        + " deleted_at TIMESTAMP NULL)");
+        jdbcTemplate.execute(
+                "CREATE TABLE policy_appeal ("
+                        + "id BIGINT PRIMARY KEY, "
+                        + "policy_assignment_id BIGINT NULL, "
+                        + "requester_id BIGINT NOT NULL, "
+                        + "type VARCHAR(20) NOT NULL, "
+                        + "status VARCHAR(20) NOT NULL, "
+                        + "request_reason VARCHAR(500) NULL, "
+                        + "resolved_by_id BIGINT NULL, "
+                        + "resolved_at TIMESTAMP NULL, "
+                        + "created_at TIMESTAMP NOT NULL, "
+                        + "deleted_at TIMESTAMP NULL)");
+    }
+}

--- a/src/test/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepositoryTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepositoryTest.java
@@ -29,30 +29,32 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
                 new MonthlyFamilyRecapAggregationRepository(
                         new NamedParameterJdbcTemplate(dataSource));
 
-        jdbcTemplate.execute("DROP ALL OBJECTS");
+        dropTables();
         createTables();
     }
 
     @Test
-    @DisplayName("aggregate - full week snapshot과 partial/raw 집계를 함께 읽는다")
-    void aggregate_readsFullWeekAndRawMonthlySupplement() {
+    @DisplayName("aggregate - full week snapshot과 partial raw를 합쳐 월간 집계를 만든다")
+    void aggregate_readsWeeklyFullCountsAndPartialRawCounts() {
         jdbcTemplate.update(
                 "INSERT INTO family (id, total_quota_bytes, deleted_at) VALUES (1, 10000, NULL)");
 
         jdbcTemplate.update(
                 "INSERT INTO family_recap_weekly (family_id, week_start_date, total_used_bytes,"
                     + " total_quota_bytes, usage_by_weekday, peak_usage, mission_created_count,"
-                    + " mission_completed_count, mission_rejected_count) VALUES (1, DATE"
-                    + " '2026-03-02', 1000, 8000,"
+                    + " mission_completed_count, mission_rejected_count, total_appeal_count,"
+                    + " approved_appeal_count, rejected_appeal_count) VALUES (1, DATE '2026-03-09',"
+                    + " 1000, 8000,"
                     + " '{\"monday\":100.00,\"tuesday\":0.00,\"wednesday\":0.00,\"thursday\":0.00,\"friday\":0.00,\"saturday\":0.00,\"sunday\":0.00}',"
-                    + " '{\"startHour\":21,\"endHour\":22,\"peakBytes\":500}', 2, 1, 1)");
+                    + " '{\"startHour\":21,\"endHour\":22,\"peakBytes\":500}', 1, 1, 1, 1, 2, 0)");
         jdbcTemplate.update(
                 "INSERT INTO family_recap_weekly (family_id, week_start_date, total_used_bytes,"
                     + " total_quota_bytes, usage_by_weekday, peak_usage, mission_created_count,"
-                    + " mission_completed_count, mission_rejected_count) VALUES (1, DATE"
-                    + " '2026-03-23', 2000, 9000,"
+                    + " mission_completed_count, mission_rejected_count, total_appeal_count,"
+                    + " approved_appeal_count, rejected_appeal_count) VALUES (1, DATE '2026-03-23',"
+                    + " 2000, 9000,"
                     + " '{\"monday\":0.00,\"tuesday\":100.00,\"wednesday\":0.00,\"thursday\":0.00,\"friday\":0.00,\"saturday\":0.00,\"sunday\":0.00}',"
-                    + " '{\"startHour\":20,\"endHour\":21,\"peakBytes\":800}', 1, 1, 0)");
+                    + " '{\"startHour\":20,\"endHour\":21,\"peakBytes\":800}', 1, 1, 0, 2, 1, 1)");
 
         jdbcTemplate.update(
                 "INSERT INTO usage_record (id, family_id, event_time, bytes_used, deleted_at)"
@@ -69,15 +71,45 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
 
         jdbcTemplate.update(
                 "INSERT INTO mission_item (id, family_id, status, completed_at, created_at,"
-                    + " deleted_at) VALUES (1, 1, 'ACTIVE', NULL, TIMESTAMP '2026-03-01 08:00:00',"
+                    + " deleted_at) VALUES (10, 1, 'COMPLETED', TIMESTAMP '2026-03-10 18:00:00',"
+                    + " TIMESTAMP '2026-02-28 08:00:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO mission_item (id, family_id, status, completed_at, created_at,"
+                    + " deleted_at) VALUES (11, 1, 'ACTIVE', NULL, TIMESTAMP '2026-03-12 09:00:00',"
                     + " NULL)");
         jdbcTemplate.update(
                 "INSERT INTO mission_item (id, family_id, status, completed_at, created_at,"
-                        + " deleted_at) VALUES (2, 1, 'COMPLETED', TIMESTAMP '2026-03-31 18:00:00',"
-                        + " TIMESTAMP '2026-03-15 09:00:00', NULL)");
+                    + " deleted_at) VALUES (12, 1, 'COMPLETED', TIMESTAMP '2026-03-25 18:00:00',"
+                    + " TIMESTAMP '2026-03-25 09:00:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO mission_item (id, family_id, status, completed_at, created_at,"
+                    + " deleted_at) VALUES (13, 1, 'ACTIVE', NULL, TIMESTAMP '2026-03-31 08:00:00',"
+                    + " NULL)");
+
         jdbcTemplate.update(
                 "INSERT INTO mission_request (id, mission_item_id, status, resolved_at, deleted_at)"
-                        + " VALUES (1, 2, 'REJECTED', TIMESTAMP '2026-03-31 19:00:00', NULL)");
+                        + " VALUES (1, 11, 'REJECTED', TIMESTAMP '2026-03-13 12:00:00', NULL)");
+
+        jdbcTemplate.update(
+                "INSERT INTO mission_log (id, mission_item_id, action_type, created_at, deleted_at)"
+                    + " VALUES (1, 10, 'MISSION_CREATED', TIMESTAMP '2026-02-28 08:00:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO mission_log (id, mission_item_id, action_type, created_at, deleted_at)"
+                        + " VALUES (2, 10, 'MISSION_COMPLETED', TIMESTAMP '2026-03-10 18:00:00',"
+                        + " NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO mission_log (id, mission_item_id, action_type, created_at, deleted_at)"
+                    + " VALUES (3, 11, 'MISSION_CREATED', TIMESTAMP '2026-03-12 09:00:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO mission_log (id, mission_item_id, action_type, created_at, deleted_at)"
+                    + " VALUES (4, 12, 'MISSION_CREATED', TIMESTAMP '2026-03-25 09:00:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO mission_log (id, mission_item_id, action_type, created_at, deleted_at)"
+                        + " VALUES (5, 12, 'MISSION_COMPLETED', TIMESTAMP '2026-03-25 18:00:00',"
+                        + " NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO mission_log (id, mission_item_id, action_type, created_at, deleted_at)"
+                    + " VALUES (6, 13, 'MISSION_CREATED', TIMESTAMP '2026-03-31 08:00:00', NULL)");
 
         jdbcTemplate.update(
                 "INSERT INTO customer (id, name, deleted_at) VALUES (101, '김민지', NULL)");
@@ -90,38 +122,45 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
 
         jdbcTemplate.update(
                 "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
-                    + " request_reason, resolved_by_id, resolved_at, created_at, deleted_at) VALUES"
-                    + " (83, 11, 101, 'NORMAL', 'APPROVED', '인강 시청 시간 연장을 요청했어요.', 201, TIMESTAMP"
-                    + " '2026-03-12 19:30:00', TIMESTAMP '2026-03-12 19:05:00', NULL)");
+                        + " request_reason, resolved_by_id, resolved_at, cancelled_at, created_at,"
+                        + " deleted_at) VALUES (70, 11, 101, 'NORMAL', 'APPROVED', '월초 예외를 요청했어요.',"
+                        + " 201, TIMESTAMP '2026-03-10 09:00:00', NULL, TIMESTAMP '2026-02-28"
+                        + " 19:00:00', NULL)");
         jdbcTemplate.update(
                 "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
-                    + " request_reason, resolved_by_id, resolved_at, created_at, deleted_at) VALUES"
-                    + " (87, 11, 101, 'NORMAL', 'APPROVED', '주말 사용 제한 완화를 요청했어요.', 201, TIMESTAMP"
-                    + " '2026-03-18 20:40:00', TIMESTAMP '2026-03-18 20:10:00', NULL)");
+                    + " request_reason, resolved_by_id, resolved_at, cancelled_at, created_at,"
+                    + " deleted_at) VALUES (83, 11, 101, 'NORMAL', 'APPROVED', '인강 시청 시간 연장을"
+                    + " 요청했어요.', 201, TIMESTAMP '2026-03-12 19:30:00', NULL, TIMESTAMP '2026-03-12"
+                    + " 19:05:00', NULL)");
         jdbcTemplate.update(
                 "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
-                    + " request_reason, resolved_by_id, resolved_at, created_at, deleted_at) VALUES"
-                    + " (91, 11, 101, 'NORMAL', 'APPROVED', '야간 차단 해제를 요청했어요.', 201, TIMESTAMP"
-                    + " '2026-03-21 15:00:00', TIMESTAMP '2026-03-21 14:32:00', NULL)");
+                    + " request_reason, resolved_by_id, resolved_at, cancelled_at, created_at,"
+                    + " deleted_at) VALUES (87, 11, 101, 'NORMAL', 'APPROVED', '주말 사용 제한 완화를"
+                    + " 요청했어요.', 201, TIMESTAMP '2026-03-24 20:40:00', NULL, TIMESTAMP '2026-03-24"
+                    + " 20:10:00', NULL)");
         jdbcTemplate.update(
                 "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
-                    + " request_reason, resolved_by_id, resolved_at, created_at, deleted_at) VALUES"
-                    + " (95, 11, 102, 'NORMAL', 'APPROVED', '월말 예외 사용을 요청했어요.', 201, TIMESTAMP"
-                    + " '2026-04-02 10:00:00', TIMESTAMP '2026-03-30 09:00:00', NULL)");
+                    + " request_reason, resolved_by_id, resolved_at, cancelled_at, created_at,"
+                    + " deleted_at) VALUES (95, 11, 102, 'NORMAL', 'APPROVED', '월말 예외 사용을 요청했어요.',"
+                    + " 201, TIMESTAMP '2026-04-02 10:00:00', NULL, TIMESTAMP '2026-03-30"
+                    + " 09:00:00', NULL)");
         jdbcTemplate.update(
                 "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
-                    + " request_reason, resolved_by_id, resolved_at, created_at, deleted_at) VALUES"
-                    + " (96, 11, 101, 'NORMAL', 'REJECTED', '게임 시간 연장을 요청했어요.', 201, TIMESTAMP"
-                    + " '2026-03-25 11:30:00', TIMESTAMP '2026-03-25 10:00:00', NULL)");
+                    + " request_reason, resolved_by_id, resolved_at, cancelled_at, created_at,"
+                    + " deleted_at) VALUES (96, 11, 101, 'NORMAL', 'REJECTED', '게임 시간 연장을 요청했어요.',"
+                    + " 201, TIMESTAMP '2026-03-25 11:30:00', NULL, TIMESTAMP '2026-03-25"
+                    + " 10:00:00', NULL)");
         jdbcTemplate.update(
                 "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
-                    + " request_reason, resolved_by_id, resolved_at, created_at, deleted_at) VALUES"
-                    + " (97, 11, 101, 'EMERGENCY', 'APPROVED', '긴급 데이터 충전을 요청했어요.', 201, TIMESTAMP"
-                    + " '2026-03-10 12:00:00', TIMESTAMP '2026-03-10 11:00:00', NULL)");
+                    + " request_reason, resolved_by_id, resolved_at, cancelled_at, created_at,"
+                    + " deleted_at) VALUES (97, 11, 101, 'EMERGENCY', 'APPROVED', '긴급 데이터 충전을"
+                    + " 요청했어요.', 201, TIMESTAMP '2026-03-10 12:00:00', NULL, TIMESTAMP '2026-03-10"
+                    + " 11:00:00', NULL)");
 
         MonthlyFamilyRecapSourceMetrics result = repository.aggregate(1L, LocalDate.of(2026, 3, 1));
 
         assertThat(result.fullWeekSnapshots()).hasSize(2);
+        assertThat(result.fullWeekSnapshots().get(0).approvedAppealCount()).isEqualTo(2);
         assertThat(result.totalQuotaBytes()).isEqualTo(9000L);
         assertThat(result.partialUsageMetrics().totalUsedBytes()).isEqualTo(600L);
         assertThat(result.partialUsageMetrics().usageBytesByWeekday())
@@ -130,13 +169,15 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
         assertThat(result.partialUsageMetrics().peakUsageCandidate().startHour()).isEqualTo(22);
         assertThat(result.partialUsageMetrics().peakUsageCandidate().peakBytes()).isEqualTo(500L);
 
-        assertThat(result.missionSummary().totalMissionCount()).isEqualTo(2);
-        assertThat(result.missionSummary().completedMissionCount()).isEqualTo(1);
+        assertThat(result.missionSummary().totalMissionCount()).isEqualTo(3);
+        assertThat(result.missionSummary().completedMissionCount()).isEqualTo(2);
         assertThat(result.missionSummary().rejectedRequestCount()).isEqualTo(1);
+        assertThat(result.missionCarryInCount()).isEqualTo(1);
 
-        assertThat(result.appealSummary().totalAppeals()).isEqualTo(5);
+        assertThat(result.appealSummary().totalAppeals()).isEqualTo(4);
         assertThat(result.appealSummary().approvedAppeals()).isEqualTo(3);
         assertThat(result.appealSummary().rejectedAppeals()).isEqualTo(1);
+        assertThat(result.appealCarryInCount()).isEqualTo(1);
 
         MonthlyAppealHighlights.TopSuccessfulRequester topRequester =
                 result.appealHighlights().topSuccessfulRequester();
@@ -145,7 +186,7 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
         assertThat(topRequester.approvedAppealCount()).isEqualTo(3);
         assertThat(topRequester.recentApprovedAppeals())
                 .extracting(MonthlyAppealHighlights.RecentApprovedAppeal::appealId)
-                .containsExactly(91L, 87L, 83L);
+                .containsExactly(87L, 83L, 70L);
 
         MonthlyAppealHighlights.TopAcceptedApprover topApprover =
                 result.appealHighlights().topAcceptedApprover();
@@ -153,7 +194,7 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
         assertThat(topApprover.approvedAppealCount()).isEqualTo(3);
         assertThat(topApprover.recentAcceptedAppeals())
                 .extracting(MonthlyAppealHighlights.RecentAcceptedAppeal::appealId)
-                .containsExactly(91L, 87L, 83L);
+                .containsExactly(87L, 83L, 70L);
     }
 
     @Test
@@ -167,6 +208,8 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
         assertThat(result.fullWeekSnapshots()).isEmpty();
         assertThat(result.totalQuotaBytes()).isEqualTo(7000L);
         assertThat(result.partialUsageMetrics().totalUsedBytes()).isZero();
+        assertThat(result.missionCarryInCount()).isZero();
+        assertThat(result.appealCarryInCount()).isZero();
         assertThat(result.appealHighlights().topSuccessfulRequester().requesterId()).isNull();
         assertThat(result.appealHighlights().topAcceptedApprover().approverId()).isNull();
     }
@@ -178,6 +221,18 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
         dataSource.setUsername("sa");
         dataSource.setPassword("");
         return dataSource;
+    }
+
+    private void dropTables() {
+        jdbcTemplate.execute("DROP TABLE IF EXISTS policy_appeal");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS policy_assignment");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS customer");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mission_log");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mission_request");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mission_item");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS usage_record");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS family_recap_weekly");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS family");
     }
 
     private void createTables() {
@@ -194,7 +249,10 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
                         + "peak_usage VARCHAR(1000), "
                         + "mission_created_count INT NOT NULL, "
                         + "mission_completed_count INT NOT NULL, "
-                        + "mission_rejected_count INT NOT NULL)");
+                        + "mission_rejected_count INT NOT NULL, "
+                        + "total_appeal_count INT NOT NULL, "
+                        + "approved_appeal_count INT NOT NULL, "
+                        + "rejected_appeal_count INT NOT NULL)");
         jdbcTemplate.execute(
                 "CREATE TABLE usage_record (id BIGINT PRIMARY KEY, family_id BIGINT NOT NULL,"
                         + " event_time TIMESTAMP NOT NULL, bytes_used BIGINT NOT NULL, deleted_at"
@@ -207,6 +265,10 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
                 "CREATE TABLE mission_request (id BIGINT PRIMARY KEY, mission_item_id BIGINT NOT"
                     + " NULL, status VARCHAR(20) NOT NULL, resolved_at TIMESTAMP NULL, deleted_at"
                     + " TIMESTAMP NULL)");
+        jdbcTemplate.execute(
+                "CREATE TABLE mission_log (id BIGINT PRIMARY KEY, mission_item_id BIGINT NOT NULL,"
+                        + " action_type VARCHAR(30) NOT NULL, created_at TIMESTAMP NOT NULL,"
+                        + " deleted_at TIMESTAMP NULL)");
         jdbcTemplate.execute(
                 "CREATE TABLE customer (id BIGINT PRIMARY KEY, name VARCHAR(100) NOT NULL,"
                         + " deleted_at TIMESTAMP NULL)");
@@ -223,6 +285,7 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
                         + "request_reason VARCHAR(500) NULL, "
                         + "resolved_by_id BIGINT NULL, "
                         + "resolved_at TIMESTAMP NULL, "
+                        + "cancelled_at TIMESTAMP NULL, "
                         + "created_at TIMESTAMP NOT NULL, "
                         + "deleted_at TIMESTAMP NULL)");
     }

--- a/src/test/java/com/template/worker/jobs/recap/weekly/query/WeeklyFamilyRecapAggregationRepositoryTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/weekly/query/WeeklyFamilyRecapAggregationRepositoryTest.java
@@ -1,0 +1,150 @@
+package com.template.worker.jobs.recap.weekly.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import com.template.worker.jobs.recap.weekly.model.WeeklyFamilyRecapSourceMetrics;
+
+class WeeklyFamilyRecapAggregationRepositoryTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private WeeklyFamilyRecapAggregationRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        DataSource dataSource = createDataSource();
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        repository =
+                new WeeklyFamilyRecapAggregationRepository(
+                        new NamedParameterJdbcTemplate(dataSource));
+
+        dropTables();
+        createTables();
+    }
+
+    @Test
+    @DisplayName("aggregate - appeal은 요청 주와 처리 주를 분리해서 집계한다")
+    void aggregate_countsAppealRequestedAndResolvedSeparately() {
+        jdbcTemplate.update(
+                "INSERT INTO family (id, total_quota_bytes, deleted_at) VALUES (1, 5000, NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO policy_assignment (id, family_id, deleted_at) VALUES (11, 1, NULL)");
+
+        jdbcTemplate.update(
+                "INSERT INTO usage_record (id, family_id, event_time, bytes_used, deleted_at)"
+                        + " VALUES (1, 1, TIMESTAMP '2026-03-10 10:00:00', 100, NULL)");
+
+        jdbcTemplate.update(
+                "INSERT INTO mission_item (id, family_id, status, completed_at, created_at,"
+                    + " deleted_at) VALUES (1, 1, 'ACTIVE', NULL, TIMESTAMP '2026-03-10 09:00:00',"
+                    + " NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO mission_item (id, family_id, status, completed_at, created_at,"
+                        + " deleted_at) VALUES (2, 1, 'COMPLETED', TIMESTAMP '2026-03-11 18:00:00',"
+                        + " TIMESTAMP '2026-03-05 09:00:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO mission_item (id, family_id, status, completed_at, created_at,"
+                    + " deleted_at) VALUES (3, 1, 'ACTIVE', NULL, TIMESTAMP '2026-03-15 08:00:00',"
+                    + " NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO mission_request (id, mission_item_id, status, resolved_at, deleted_at)"
+                        + " VALUES (1, 1, 'REJECTED', TIMESTAMP '2026-03-13 12:00:00', NULL)");
+
+        jdbcTemplate.update(
+                "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
+                    + " resolved_by_id, resolved_at, cancelled_at, created_at, deleted_at) VALUES"
+                    + " (1, 11, 101, 'NORMAL', 'APPROVED', 201, TIMESTAMP '2026-03-12 10:00:00',"
+                    + " NULL, TIMESTAMP '2026-03-10 09:00:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
+                    + " resolved_by_id, resolved_at, cancelled_at, created_at, deleted_at) VALUES"
+                    + " (2, 11, 101, 'NORMAL', 'APPROVED', 201, TIMESTAMP '2026-03-10 11:00:00',"
+                    + " NULL, TIMESTAMP '2026-03-08 09:00:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
+                    + " resolved_by_id, resolved_at, cancelled_at, created_at, deleted_at) VALUES"
+                    + " (3, 11, 101, 'NORMAL', 'REJECTED', 201, TIMESTAMP '2026-03-13 15:00:00',"
+                    + " NULL, TIMESTAMP '2026-03-11 09:00:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
+                    + " resolved_by_id, resolved_at, cancelled_at, created_at, deleted_at) VALUES"
+                    + " (4, 11, 101, 'NORMAL', 'PENDING', NULL, NULL, NULL, TIMESTAMP '2026-03-14"
+                    + " 09:00:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
+                    + " resolved_by_id, resolved_at, cancelled_at, created_at, deleted_at) VALUES"
+                    + " (5, 11, 101, 'NORMAL', 'CANCELLED', NULL, NULL, TIMESTAMP '2026-03-11"
+                    + " 16:00:00', TIMESTAMP '2026-03-09 10:00:00', NULL)");
+        jdbcTemplate.update(
+                "INSERT INTO policy_appeal (id, policy_assignment_id, requester_id, type, status,"
+                    + " resolved_by_id, resolved_at, cancelled_at, created_at, deleted_at) VALUES"
+                    + " (6, 11, 101, 'EMERGENCY', 'APPROVED', 201, TIMESTAMP '2026-03-10 12:00:00',"
+                    + " NULL, TIMESTAMP '2026-03-10 11:00:00', NULL)");
+
+        WeeklyFamilyRecapSourceMetrics result = repository.aggregate(1L, LocalDate.of(2026, 3, 9));
+
+        assertThat(result.totalUsedBytes()).isEqualTo(100L);
+        assertThat(result.totalQuotaBytes()).isEqualTo(5000L);
+        assertThat(result.missionCreatedCount()).isEqualTo(2);
+        assertThat(result.missionCompletedCount()).isEqualTo(1);
+        assertThat(result.missionRejectedCount()).isEqualTo(1);
+        assertThat(result.totalAppealCount()).isEqualTo(4);
+        assertThat(result.approvedAppealCount()).isEqualTo(2);
+        assertThat(result.rejectedAppealCount()).isEqualTo(1);
+    }
+
+    private DataSource createDataSource() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUrl("jdbc:h2:mem:weekly_recap_repo_test;MODE=MySQL;DB_CLOSE_DELAY=-1");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+        return dataSource;
+    }
+
+    private void dropTables() {
+        jdbcTemplate.execute("DROP TABLE IF EXISTS policy_appeal");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS policy_assignment");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mission_request");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mission_item");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS usage_record");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS family");
+    }
+
+    private void createTables() {
+        jdbcTemplate.execute(
+                "CREATE TABLE family (id BIGINT PRIMARY KEY, total_quota_bytes BIGINT NOT NULL,"
+                        + " deleted_at TIMESTAMP NULL)");
+        jdbcTemplate.execute(
+                "CREATE TABLE usage_record (id BIGINT PRIMARY KEY, family_id BIGINT NOT NULL,"
+                        + " event_time TIMESTAMP NOT NULL, bytes_used BIGINT NOT NULL, deleted_at"
+                        + " TIMESTAMP NULL)");
+        jdbcTemplate.execute(
+                "CREATE TABLE mission_item (id BIGINT PRIMARY KEY, family_id BIGINT NOT NULL,"
+                        + " status VARCHAR(20) NOT NULL, completed_at TIMESTAMP NULL, created_at"
+                        + " TIMESTAMP NOT NULL, deleted_at TIMESTAMP NULL)");
+        jdbcTemplate.execute(
+                "CREATE TABLE mission_request (id BIGINT PRIMARY KEY, mission_item_id BIGINT NOT"
+                    + " NULL, status VARCHAR(20) NOT NULL, resolved_at TIMESTAMP NULL, deleted_at"
+                    + " TIMESTAMP NULL)");
+        jdbcTemplate.execute(
+                "CREATE TABLE policy_assignment (id BIGINT PRIMARY KEY, family_id BIGINT NOT NULL,"
+                        + " deleted_at TIMESTAMP NULL)");
+        jdbcTemplate.execute(
+                "CREATE TABLE policy_appeal (id BIGINT PRIMARY KEY, policy_assignment_id BIGINT"
+                        + " NULL, requester_id BIGINT NOT NULL, type VARCHAR(20) NOT NULL, status"
+                        + " VARCHAR(20) NOT NULL, resolved_by_id BIGINT NULL, resolved_at TIMESTAMP"
+                        + " NULL, cancelled_at TIMESTAMP NULL, created_at TIMESTAMP NOT NULL,"
+                        + " deleted_at TIMESTAMP NULL)");
+    }
+}


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #9 
- jira: DABOM-386

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
- 월간 리캡의 partial week 사용량 누락을 보강해 `family_recap_monthly` 사용량 정합성을 높임
- mission/appeal summary를 weekly full week snapshot 합계 + partial raw 보강 구조로 정리함
- `appealHighlights`, `communicationScore`를 새 집계 의미와 월 경계 규칙에 맞춰 정합화함

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->

- 월간 사용량 보강 집계 추가
  - `family_recap_weekly` full week snapshot 합계에 좌/우 partial week raw `usage_record`를 보강
  - `usage_by_weekday`, `peak_usage`, `mostUsedWeekday` 계산에 partial raw 데이터를 반영
- 월간 mission/appeal summary 구조 변경
  - `missionSummary`를 weekly full week mission count + partial raw mission 집계로 계산
  - `appealSummary`를 weekly full week appeal count + partial raw appeal 집계로 계산
- 주간 appeal count 의미 정리
  - `totalAppealCount`는 주간 요청 건수
  - `approvedAppealCount`, `rejectedAppealCount`는 주간 승인/거절 처리 건수
- 월간 highlight 및 score 기준 변경
  - `appealHighlights`는 `resolved_at` 월 기준 승인 건으로 집계
  - `communicationScore`는 carry-in 포함 처리율/이행률 공식으로 계산
- 테스트 보강
  - `MonthlyFamilyRecapProcessorTest`
  - `MonthlyFamilyRecapAggregationRepositoryTest`
  - `WeeklyFamilyRecapAggregationRepositoryTest`
  - 기존 weekly processor/writer 테스트 기대값 동기화

## 📂 변경 범위

<!-- 변경된 레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| Job | api (controller/service/dto) | job config | step config | reader | processor | writer | global (config/launcher/listener) |
| :-: | :--------------------------: | :--------: | :---------: | :----: | :-------: | :----: | :-------------------------------: |
|   monthly  |                              |            |             |        |     x      |        |                                   |

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

- repository는 월간 지표를 `fullWeekSnapshots`, partial usage, mission/appeal summary, carry-in, highlights로 나눠 읽어온다.
- mission/appeal summary는 full week weekly snapshot을 우선 사용하고, 월 경계 partial week만 raw로 보강한다.
- highlights와 carry-in은 weekly count만으로 복원할 수 없어서 raw 조회를 유지한다.
- processor는 carry-in 포함 `communicationScore` 공식을 적용한다.
- weekly aggregation repository는 appeal 승인/거절 count를 `resolved_at` 주간 기준으로 계산한다.

## 월 경계 의미

- `appealSummary.totalAppeals`는 해당 월에 새로 요청된 `NORMAL` 이의제기 수다.
- `appealSummary.approvedAppeals`, `rejectedAppeals`는 해당 월에 승인 또는 거절 처리된 `NORMAL` 이의제기 수다.
- 그래서 `totalAppeals`와 `approvedAppeals + rejectedAppeals`는 항상 같지 않을 수 있다.
- 예를 들어 `2026-03-25`에 요청되고 `2026-04-01`에 승인된 건은 `3월 totalAppeals +1`, `4월 approvedAppeals +1`로 반영된다.
- mission도 같은 패턴이다. `totalMissionCount`는 해당 월 생성 건수이고 `completedMissionCount`, `rejectedRequestCount`는 해당 월 처리 이벤트 수다.
- 따라서 backlog를 많이 처리한 달에는 `approvedAppeals + rejectedAppeals > totalAppeals` 또는 `completedMissionCount > totalMissionCount`가 가능하다.
- 이 차이를 보정하기 위해 score 계산에는 carry-in을 포함한다.
- `appealCarryInCount`는 월 시작 이전 생성됐고 월 시작 이전에 해결 또는 취소되지 않은 `NORMAL` 이의제기 수다.
- `missionCarryInCount`는 월 시작 이전 생성됐고 월 시작 이전 완료 또는 취소 로그가 없는 미션 수다.
- 최종적으로 `appealBase = appealCarryInCount + totalAppeals`, `missionBase = missionCarryInCount + totalMissionCount`를 사용해 backlog 처리량도 점수에 반영한다.

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [ ] 전체 변경사항이 500줄을 넘지 않는가?

**배치 코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → BatchJobLauncher → Job → Step → Reader/Processor/Writer`)
- [x] 모든 Job에 `JobResultListener`를 등록했는가?
- [x] Reader/Processor/Writer가 각각 단일 책임만 수행하는가?
- [x] Job/Step 이름이 kebab-case인가?
- [x] 하나의 Config 파일에 하나의 Job/Step만 정의했는가?

**테스트**
- [x] 신규 배치 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
