### PR TITLE
[DABOM-472] 배치 재시도 정책 적용 및 최종 실패시 슬랙 알람 발송

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,27 @@
-FROM eclipse-temurin:17-jdk-alpine AS build
-WORKDIR /app
-COPY gradle gradle
-COPY gradlew build.gradle settings.gradle ./
-COPY src src
-RUN chmod +x gradlew && ./gradlew bootJar --no-daemon
+FROM eclipse-temurin:21-jdk AS builder
 
-FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app
-COPY --from=build /app/build/libs/*.jar app.jar
+
+# Gradle wrapper 복사
+COPY gradlew .
+COPY gradle gradle
+RUN chmod +x gradlew
+
+# 의존성 캐싱을 위해 build 파일 먼저 복사
+COPY build.gradle settings.gradle ./
+COPY config config
+RUN ./gradlew dependencies --no-daemon || true
+
+# 소스 복사 및 빌드
+COPY src src
+RUN ./gradlew bootJar -x checkstyleMain -x checkstyleTest -x spotlessCheck --no-daemon
+
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+COPY --from=builder /app/build/libs/*-SNAPSHOT.jar app.jar
+
+EXPOSE 8080
+
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       redis:
         condition: service_healthy
     environment:
-      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL:-https://hooks.slack.com/services/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}
+      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL:-}
 
 volumes:
   mysql_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,36 @@
 services:
-  postgres:
-    image: postgres:16-alpine
-    container_name: template-postgres
-    environment:
-      POSTGRES_DB: app
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+  mysql:
+    image: mysql:8.0
+    container_name: mysql
     ports:
-      - "5432:5432"
+      - "13306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: app_db
+      MYSQL_USER: app_user
+      MYSQL_PASSWORD: app_password
+      TZ: Asia/Seoul
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - mysql_data:/var/lib/mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 5s
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      interval: 10s
       timeout: 5s
       retries: 5
 
-  mongodb:
-    image: mongo:7-jammy
-    container_name: template-mongodb
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: mongo
-      MONGO_INITDB_ROOT_PASSWORD: mongo
-      MONGO_INITDB_DATABASE: app
+  redis:
+    image: redis:8
+    container_name: redis
     ports:
-      - "27017:27017"
+      - "6379:6379"
     volumes:
-      - mongo_data:/data/db
+      - redis_data:/data
     healthcheck:
-      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
-      interval: 5s
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
       timeout: 5s
       retries: 5
 
@@ -37,20 +38,13 @@ services:
     build: .
     container_name: template-worker
     depends_on:
-      postgres:
+      mysql:
         condition: service_healthy
-      mongodb:
+      redis:
         condition: service_healthy
     environment:
-      POSTGRES_HOST: postgres
-      POSTGRES_PORT: 5432
-      POSTGRES_DATABASE: app
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      MONGO_URI: mongodb://mongo:mongo@mongodb:27017/?authSource=admin
-      MONGO_DATABASE: app
-      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL:-}
+      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL:-https://hooks.slack.com/services/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}
 
 volumes:
-  postgres_data:
-  mongo_data:
+  mysql_data:
+  redis_data:

--- a/src/main/java/com/template/worker/global/alert/BatchAlertService.java
+++ b/src/main/java/com/template/worker/global/alert/BatchAlertService.java
@@ -1,7 +1,9 @@
 package com.template.worker.global.alert;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -44,36 +46,27 @@ public class BatchAlertService {
             String parameterSummary,
             String errorSummary,
             String technicalDetail) {
+        Map<String, String> details = new LinkedHashMap<>();
+        details.put("잡", sanitize(jobName));
+        details.put("실행 ID", jobExecutionId == null ? UNKNOWN_VALUE : jobExecutionId.toString());
+        details.put("파라미터", sanitize(parameterSummary));
+        details.put("상태", "FAILED");
+        details.put("원인 요약", sanitize(errorSummary));
+        details.put("원본 예외", sanitize(technicalDetail));
+
         // 운영자가 한눈에 보도록 요약/원본 예외를 멀티라인 메시지로 구성
-        sendAlert(
-                buildMultilineMessage(
-                        JOB_FAILURE_TITLE,
-                        "잡",
-                        sanitize(jobName),
-                        "실행 ID",
-                        jobExecutionId == null ? UNKNOWN_VALUE : jobExecutionId.toString(),
-                        "파라미터",
-                        sanitize(parameterSummary),
-                        "상태",
-                        "FAILED",
-                        "원인 요약",
-                        sanitize(errorSummary),
-                        "원본 예외",
-                        sanitize(technicalDetail)));
+        sendAlert(buildMultilineMessage(JOB_FAILURE_TITLE, details));
     }
 
     public void sendSchedulerFailureAlert(
             String schedulerName, String parameterSummary, String errorMessage) {
+        Map<String, String> details = new LinkedHashMap<>();
+        details.put("스케줄러", sanitize(schedulerName));
+        details.put("파라미터", sanitize(parameterSummary));
+        details.put("원인", sanitize(errorMessage));
+
         // 스케줄러 launch 단계 예외는 Job FAILED 알람과 구분해 별도 제목으로 보냄
-        sendAlert(
-                buildMultilineMessage(
-                        SCHEDULER_FAILURE_TITLE,
-                        "스케줄러",
-                        sanitize(schedulerName),
-                        "파라미터",
-                        sanitize(parameterSummary),
-                        "원인",
-                        sanitize(errorMessage)));
+        sendAlert(buildMultilineMessage(SCHEDULER_FAILURE_TITLE, details));
     }
 
     private void sendAlert(String message) {
@@ -106,16 +99,11 @@ public class BatchAlertService {
         return value.replace("\r\n", " ").replace("\n", " ").trim();
     }
 
-    private String buildMultilineMessage(String title, String... keyValues) {
-        // text payload만으로도 읽기 좋게 보이도록 bullet 형식으로 렌더링
+    private String buildMultilineMessage(String title, Map<String, String> keyValues) {
+        // 표시 순서를 유지한 key-value 맵을 bullet 형식으로 렌더링
         List<String> lines = new ArrayList<>();
         lines.add(title);
-
-        for (int index = 0; index < keyValues.length; index += 2) {
-            String key = keyValues[index];
-            String value = keyValues[index + 1];
-            lines.add(String.format("• %s: %s", key, value));
-        }
+        keyValues.forEach((key, value) -> lines.add(String.format("• %s: %s", key, value)));
 
         return String.join("\n", lines);
     }

--- a/src/main/java/com/template/worker/global/alert/BatchAlertService.java
+++ b/src/main/java/com/template/worker/global/alert/BatchAlertService.java
@@ -1,0 +1,124 @@
+package com.template.worker.global.alert;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class BatchAlertService {
+
+    // Slack Incoming Webhook으로 배치 실패 알람을 전송하는 공통 컴포넌트
+    private static final String UNKNOWN_VALUE = "unknown";
+    private static final String JOB_FAILURE_TITLE = "*DABOM Batch 실패*";
+    private static final String SCHEDULER_FAILURE_TITLE = "*DABOM Batch 스케줄러 실패*";
+
+    private final RestTemplate restTemplate;
+    private final String webhookUrl;
+
+    @Autowired
+    public BatchAlertService(
+            RestTemplateBuilder restTemplateBuilder,
+            @Value("${slack.webhook.url:}") String webhookUrl) {
+        this(restTemplateBuilder.build(), webhookUrl);
+    }
+
+    BatchAlertService(RestTemplate restTemplate, String webhookUrl) {
+        this.restTemplate = restTemplate;
+        this.webhookUrl = webhookUrl;
+    }
+
+    public void sendJobFailureAlert(
+            String jobName,
+            Long jobExecutionId,
+            String parameterSummary,
+            String errorSummary,
+            String technicalDetail) {
+        // 운영자가 한눈에 보도록 요약/원본 예외를 멀티라인 메시지로 구성
+        sendAlert(
+                buildMultilineMessage(
+                        JOB_FAILURE_TITLE,
+                        "잡",
+                        sanitize(jobName),
+                        "실행 ID",
+                        jobExecutionId == null ? UNKNOWN_VALUE : jobExecutionId.toString(),
+                        "파라미터",
+                        sanitize(parameterSummary),
+                        "상태",
+                        "FAILED",
+                        "원인 요약",
+                        sanitize(errorSummary),
+                        "원본 예외",
+                        sanitize(technicalDetail)));
+    }
+
+    public void sendSchedulerFailureAlert(
+            String schedulerName, String parameterSummary, String errorMessage) {
+        // 스케줄러 launch 단계 예외는 Job FAILED 알람과 구분해 별도 제목으로 보냄
+        sendAlert(
+                buildMultilineMessage(
+                        SCHEDULER_FAILURE_TITLE,
+                        "스케줄러",
+                        sanitize(schedulerName),
+                        "파라미터",
+                        sanitize(parameterSummary),
+                        "원인",
+                        sanitize(errorMessage)));
+    }
+
+    private void sendAlert(String message) {
+        if (!StringUtils.hasText(webhookUrl)) {
+            // 알람 설정이 비어 있어도 원래 배치 실패 흐름은 깨지지 않게 함
+            log.warn(
+                    "Skip batch alert because slack webhook url is not configured. message={}",
+                    message);
+            return;
+        }
+
+        try {
+            ResponseEntity<Void> response =
+                    restTemplate.postForEntity(
+                            webhookUrl, new SlackWebhookRequest(message), Void.class);
+            log.info(
+                    "Batch alert sent to Slack. statusCode={}, message={}",
+                    response.getStatusCode(),
+                    message);
+        } catch (RestClientException exception) {
+            log.error("Failed to send batch alert to Slack. message={}", message, exception);
+        }
+    }
+
+    private String sanitize(String value) {
+        // Slack 한 줄 필드가 깨지지 않도록 줄바꿈과 빈 문자열 정리
+        if (!StringUtils.hasText(value)) {
+            return UNKNOWN_VALUE;
+        }
+        return value.replace("\r\n", " ").replace("\n", " ").trim();
+    }
+
+    private String buildMultilineMessage(String title, String... keyValues) {
+        // text payload만으로도 읽기 좋게 보이도록 bullet 형식으로 렌더링
+        List<String> lines = new ArrayList<>();
+        lines.add(title);
+
+        for (int index = 0; index < keyValues.length; index += 2) {
+            String key = keyValues[index];
+            String value = keyValues[index + 1];
+            lines.add(String.format("• %s: %s", key, value));
+        }
+
+        return String.join("\n", lines);
+    }
+
+    private record SlackWebhookRequest(String text) {}
+}

--- a/src/main/java/com/template/worker/global/listener/JobFailureAlertListener.java
+++ b/src/main/java/com/template/worker/global/listener/JobFailureAlertListener.java
@@ -33,7 +33,9 @@ public class JobFailureAlertListener implements JobExecutionListener {
     private final BatchRetrySupport batchRetrySupport;
 
     @Override
-    public void beforeJob(JobExecution jobExecution) {}
+    public void beforeJob(JobExecution jobExecution) {
+        // 사전 처리 없음
+    }
 
     @Override
     public void afterJob(JobExecution jobExecution) {

--- a/src/main/java/com/template/worker/global/listener/JobFailureAlertListener.java
+++ b/src/main/java/com/template/worker/global/listener/JobFailureAlertListener.java
@@ -3,7 +3,6 @@ package com.template.worker.global.listener;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.lettuce.core.RedisCommandTimeoutException;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionListener;
@@ -16,6 +15,8 @@ import org.springframework.util.StringUtils;
 
 import com.template.worker.global.alert.BatchAlertService;
 import com.template.worker.global.retry.BatchRetrySupport;
+
+import io.lettuce.core.RedisCommandTimeoutException;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/template/worker/global/listener/JobFailureAlertListener.java
+++ b/src/main/java/com/template/worker/global/listener/JobFailureAlertListener.java
@@ -1,0 +1,173 @@
+package com.template.worker.global.listener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.template.worker.global.alert.BatchAlertService;
+import com.template.worker.global.retry.BatchRetrySupport;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JobFailureAlertListener implements JobExecutionListener {
+
+    // Lettuce/Spring Redis는 Redis timeout을 QueryTimeoutException으로 번역하기도 한다.
+    private static final String REDIS_TIMEOUT_MESSAGE = "Redis command timed out";
+    private static final String REDIS_COMMAND_TIMEOUT_EXCEPTION = "RedisCommandTimeoutException";
+    private static final String PARAM_TARGET_MONTH = "targetMonth";
+    private static final String PARAM_WEEK_START_DATE = "weekStartDate";
+    private static final String UNKNOWN_ERROR_SUMMARY = "알 수 없는 오류로 최종 실패";
+
+    private final BatchAlertService batchAlertService;
+    private final BatchRetrySupport batchRetrySupport;
+
+    @Override
+    public void beforeJob(JobExecution jobExecution) {}
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        // 재시도 중간 실패는 무시하고, 최종 FAILED인 경우에만 운영 알람을 보냄
+        if (jobExecution.getStatus() != BatchStatus.FAILED) {
+            return;
+        }
+
+        String jobName = jobExecution.getJobInstance().getJobName();
+        String parameterSummary = resolveParameterSummary(jobExecution.getJobParameters());
+        FailureDetail failureDetail = resolveFailureDetail(jobExecution);
+
+        batchAlertService.sendJobFailureAlert(
+                jobName,
+                jobExecution.getId(),
+                parameterSummary,
+                failureDetail.summary(),
+                failureDetail.technicalDetail());
+    }
+
+    private String resolveParameterSummary(JobParameters jobParameters) {
+        // 알람 본문에는 운영자가 자주 보는 핵심 파라미터만 노출
+        List<String> segments = new ArrayList<>();
+        appendIfPresent(segments, PARAM_TARGET_MONTH, jobParameters.getString(PARAM_TARGET_MONTH));
+        appendIfPresent(
+                segments, PARAM_WEEK_START_DATE, jobParameters.getString(PARAM_WEEK_START_DATE));
+
+        if (segments.isEmpty()) {
+            return "parameters=none";
+        }
+
+        return String.join(", ", segments);
+    }
+
+    private void appendIfPresent(List<String> segments, String key, String value) {
+        if (StringUtils.hasText(value)) {
+            segments.add(key + "=" + value);
+        }
+    }
+
+    private FailureDetail resolveFailureDetail(JobExecution jobExecution) {
+        // 최상위 예외와 root cause를 함께 봐야 retry wrapper와 실제 원인을 모두 판단할 수 있음
+        if (jobExecution.getAllFailureExceptions().isEmpty()) {
+            return new FailureDetail(UNKNOWN_ERROR_SUMMARY, "Unknown error");
+        }
+
+        Throwable exception = jobExecution.getAllFailureExceptions().get(0);
+        Throwable rootCause = findRootCause(exception);
+        String technicalDetail = buildTechnicalDetail(rootCause);
+        String summary = buildSummary(exception, rootCause);
+        return new FailureDetail(summary, technicalDetail);
+    }
+
+    private Throwable findRootCause(Throwable exception) {
+        // 알람 요약은 가장 안쪽 실제 예외를 기준으로 만듦
+        Throwable current = exception;
+        while (current.getCause() != null && current.getCause() != current) {
+            current = current.getCause();
+        }
+        return current;
+    }
+
+    private String buildSummary(Throwable exception, Throwable rootCause) {
+        // 같은 QueryTimeoutException이라도 DB/Redis 의미가 다를 수 있어 순서 분리
+        boolean retryExhausted = containsRetryExhaustedSignal(exception);
+
+        if (rootCause instanceof RedisConnectionFailureException) {
+            return retryExhausted
+                    ? String.format(
+                            "Redis 연결 실패로 재시도 %d회 후 최종 실패", batchRetrySupport.getRetryLimit())
+                    : "Redis 연결 실패";
+        }
+        if (isRedisTimeout(rootCause)) {
+            return retryExhausted
+                    ? String.format(
+                            "Redis 명령 타임아웃으로 재시도 %d회 후 최종 실패", batchRetrySupport.getRetryLimit())
+                    : "Redis 명령 타임아웃";
+        }
+        if (rootCause instanceof PessimisticLockingFailureException) {
+            return retryExhausted
+                    ? String.format("DB 데드락으로 재시도 %d회 후 최종 실패", batchRetrySupport.getRetryLimit())
+                    : "DB 데드락 발생";
+        }
+        if (rootCause instanceof QueryTimeoutException) {
+            return retryExhausted
+                    ? String.format(
+                            "DB 쿼리 타임아웃으로 재시도 %d회 후 최종 실패", batchRetrySupport.getRetryLimit())
+                    : "DB 쿼리 타임아웃";
+        }
+        if (retryExhausted) {
+            return String.format("재시도 %d회 후 최종 실패", batchRetrySupport.getRetryLimit());
+        }
+        if (StringUtils.hasText(rootCause.getMessage())) {
+            return rootCause.getMessage();
+        }
+        return UNKNOWN_ERROR_SUMMARY;
+    }
+
+    private boolean isRedisTimeout(Throwable exception) {
+        // Root cause가 QueryTimeoutException이 아니어도 RedisCommandTimeoutException이면 Redis timeout으로 봄
+        Throwable current = exception;
+        while (current != null) {
+            if (StringUtils.hasText(current.getMessage())
+                    && current.getMessage().contains(REDIS_TIMEOUT_MESSAGE)) {
+                return true;
+            }
+            if (REDIS_COMMAND_TIMEOUT_EXCEPTION.equals(current.getClass().getSimpleName())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private boolean containsRetryExhaustedSignal(Throwable exception) {
+        // Spring Batch retry wrapper 여부를 확인해 "재시도 n회 후 최종 실패" 문구를 붙임
+        Throwable current = exception;
+        while (current != null) {
+            if (StringUtils.hasText(current.getMessage())
+                    && current.getMessage().contains("Retry exhausted")) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private String buildTechnicalDetail(Throwable exception) {
+        // 운영 알람에는 검색 가능한 원본 타입/메시지를 함께 남김
+        if (StringUtils.hasText(exception.getMessage())) {
+            return exception.getClass().getSimpleName() + ": " + exception.getMessage();
+        }
+        return exception.getClass().getSimpleName();
+    }
+
+    private record FailureDetail(String summary, String technicalDetail) {}
+}

--- a/src/main/java/com/template/worker/global/listener/JobFailureAlertListener.java
+++ b/src/main/java/com/template/worker/global/listener/JobFailureAlertListener.java
@@ -3,6 +3,7 @@ package com.template.worker.global.listener;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.lettuce.core.RedisCommandTimeoutException;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionListener;
@@ -142,7 +143,7 @@ public class JobFailureAlertListener implements JobExecutionListener {
                     && current.getMessage().contains(REDIS_TIMEOUT_MESSAGE)) {
                 return true;
             }
-            if (REDIS_COMMAND_TIMEOUT_EXCEPTION.equals(current.getClass().getSimpleName())) {
+            if (current instanceof RedisCommandTimeoutException) {
                 return true;
             }
             current = current.getCause();

--- a/src/main/java/com/template/worker/global/retry/BatchRetrySupport.java
+++ b/src/main/java/com/template/worker/global/retry/BatchRetrySupport.java
@@ -25,8 +25,8 @@ public class BatchRetrySupport {
     private final long backOffMillis;
 
     public BatchRetrySupport(
-            @Value("${batch.retry.limit}") int retryLimit,
-            @Value("${batch.retry.backoff-millis}") long backOffMillis) {
+            @Value("${batch.retry.limit:10}") int retryLimit,
+            @Value("${batch.retry.backoff-millis:3000}") long backOffMillis) {
         Assert.isTrue(retryLimit > 0, "batch.retry.limit must be greater than zero");
         Assert.isTrue(backOffMillis >= 0L, "batch.retry.backoff-millis must be zero or greater");
         this.retryLimit = retryLimit;

--- a/src/main/java/com/template/worker/global/retry/BatchRetrySupport.java
+++ b/src/main/java/com/template/worker/global/retry/BatchRetrySupport.java
@@ -1,0 +1,95 @@
+package com.template.worker.global.retry;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.batch.core.step.builder.FaultTolerantStepBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import lombok.Getter;
+
+@Component
+@Getter
+public class BatchRetrySupport {
+
+    // Retry limit/backoff와 재시도 대상 예외를 한곳에서 관리해 Step/Tasklet 정책을 맞춤
+    private final int retryLimit;
+    private final long backOffMillis;
+
+    public BatchRetrySupport(
+            @Value("${batch.retry.limit}") int retryLimit,
+            @Value("${batch.retry.backoff-millis}") long backOffMillis) {
+        Assert.isTrue(retryLimit > 0, "batch.retry.limit must be greater than zero");
+        Assert.isTrue(backOffMillis >= 0L, "batch.retry.backoff-millis must be zero or greater");
+        this.retryLimit = retryLimit;
+        this.backOffMillis = backOffMillis;
+    }
+
+    public RetryTemplate createDbRetryTemplate() {
+        // Tasklet에서 DB 계열 일시 오류 재시도에 사용함
+        return createRetryTemplate(buildRetryableExceptions(false));
+    }
+
+    public RetryTemplate createRedisRetryTemplate() {
+        // Tasklet에서 Redis 포함 일시 오류 재시도에 사용함
+        return createRetryTemplate(buildRetryableExceptions(true));
+    }
+
+    public <I, O> FaultTolerantStepBuilder<I, O> applyDbRetry(
+            FaultTolerantStepBuilder<I, O> builder) {
+        return applyRetry(builder, false);
+    }
+
+    public <I, O> FaultTolerantStepBuilder<I, O> applyRedisRetry(
+            FaultTolerantStepBuilder<I, O> builder) {
+        return applyRetry(builder, true);
+    }
+
+    public FixedBackOffPolicy createBackOffPolicy() {
+        // Step/Tasklet 모두 같은 backoff 간격을 쓰도록 공통 정책을 만듦
+        FixedBackOffPolicy policy = new FixedBackOffPolicy();
+        policy.setBackOffPeriod(backOffMillis);
+        return policy;
+    }
+
+    private <I, O> FaultTolerantStepBuilder<I, O> applyRetry(
+            FaultTolerantStepBuilder<I, O> builder, boolean includeRedis) {
+        // Redis step도 reader 쪽 DB timeout 가능성이 있어 QueryTimeoutException은 공통으로 포함
+        builder.retry(PessimisticLockingFailureException.class).retry(QueryTimeoutException.class);
+
+        if (includeRedis) {
+            builder.retry(RedisConnectionFailureException.class);
+        }
+
+        return builder.retryLimit(retryLimit).backOffPolicy(createBackOffPolicy());
+    }
+
+    private RetryTemplate createRetryTemplate(Map<Class<? extends Throwable>, Boolean> retryable) {
+        // Tasklet은 Step faultTolerant를 쓸 수 없어서 RetryTemplate으로 같은 정책을 재사용
+        RetryTemplate retryTemplate = new RetryTemplate();
+        retryTemplate.setBackOffPolicy(createBackOffPolicy());
+        retryTemplate.setRetryPolicy(new SimpleRetryPolicy(retryLimit, retryable, true));
+        return retryTemplate;
+    }
+
+    private Map<Class<? extends Throwable>, Boolean> buildRetryableExceptions(
+            boolean includeRedis) {
+        Map<Class<? extends Throwable>, Boolean> retryable = new LinkedHashMap<>();
+        retryable.put(PessimisticLockingFailureException.class, true);
+        retryable.put(QueryTimeoutException.class, true);
+
+        if (includeRedis) {
+            retryable.put(RedisConnectionFailureException.class, true);
+        }
+
+        return retryable;
+    }
+}

--- a/src/main/java/com/template/worker/jobs/recap/monthly/job/MonthlyFamilyRecapJobConfig.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/job/MonthlyFamilyRecapJobConfig.java
@@ -6,6 +6,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.template.worker.global.listener.JobFailureAlertListener;
 import com.template.worker.global.listener.JobResultListener;
 import com.template.worker.jobs.recap.monthly.listener.MonthlyFamilyRecapJobListener;
 import com.template.worker.jobs.recap.monthly.step.AcquireMonthlyFamilyRecapLockStepConfig;
@@ -21,6 +22,7 @@ public class MonthlyFamilyRecapJobConfig {
 
     private final JobRepository jobRepository;
     private final JobResultListener jobResultListener;
+    private final JobFailureAlertListener jobFailureAlertListener;
     private final MonthlyFamilyRecapJobListener monthlyFamilyRecapJobListener;
     private final AcquireMonthlyFamilyRecapLockStepConfig acquireMonthlyFamilyRecapLockStepConfig;
     private final ProcessMonthlyFamilyRecapStepConfig processMonthlyFamilyRecapStepConfig;
@@ -31,6 +33,7 @@ public class MonthlyFamilyRecapJobConfig {
         // 락 획득 실패면 정상 종료하고 락 획득 성공 시 집계 체인을 실행
         return new JobBuilder(MonthlyFamilyRecapJobConstants.JOB_NAME, jobRepository)
                 .listener(jobResultListener)
+                .listener(jobFailureAlertListener)
                 .listener(monthlyFamilyRecapJobListener)
                 .start(acquireMonthlyFamilyRecapLockStepConfig.acquireMonthlyFamilyRecapLockStep())
                 .on(MonthlyFamilyRecapJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED)

--- a/src/main/java/com/template/worker/jobs/recap/monthly/listener/MonthlyFamilyRecapJobListener.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/listener/MonthlyFamilyRecapJobListener.java
@@ -61,12 +61,19 @@ public class MonthlyFamilyRecapJobListener implements JobExecutionListener {
                 jobContext.getString(MonthlyFamilyRecapJobConstants.JOB_CONTEXT_LOCK_KEY, null);
         String lockOwner =
                 jobContext.getString(MonthlyFamilyRecapJobConstants.JOB_CONTEXT_LOCK_OWNER, null);
-        boolean released = lockManager.releaseIfOwner(lockKey, lockOwner);
-        if (lockKey != null) {
-            log.info(
-                    "Monthly family recap final lock cleanup. lockKey={}, released={}",
+        try {
+            boolean released = lockManager.releaseIfOwner(lockKey, lockOwner);
+            if (lockKey != null) {
+                log.info(
+                        "Monthly family recap final lock cleanup. lockKey={}, released={}",
+                        lockKey,
+                        released);
+            }
+        } catch (Exception exception) {
+            log.error(
+                    "Monthly family recap final lock cleanup failed. lockKey={}",
                     lockKey,
-                    released);
+                    exception);
         }
     }
 

--- a/src/main/java/com/template/worker/jobs/recap/monthly/scheduler/MonthlyFamilyRecapScheduler.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/scheduler/MonthlyFamilyRecapScheduler.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.global.alert.BatchAlertService;
 import com.template.worker.global.launcher.BatchJobLauncher;
 import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobConstants;
 import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobParameterSupport;
@@ -24,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MonthlyFamilyRecapScheduler {
 
     private final BatchJobLauncher launcher;
+    private final BatchAlertService batchAlertService;
     private final MonthlyFamilyRecapJobParameterSupport parameterSupport;
 
     @Scheduled(
@@ -43,6 +45,10 @@ public class MonthlyFamilyRecapScheduler {
                     "Failed to run monthly family recap job by scheduler. targetMonth={}",
                     targetMonth,
                     exception);
+            batchAlertService.sendSchedulerFailureAlert(
+                    "monthly-family-recap-scheduler",
+                    "targetMonth=" + targetMonth,
+                    exception.getMessage());
         }
     }
 }

--- a/src/main/java/com/template/worker/jobs/recap/monthly/step/ProcessMonthlyFamilyRecapStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/step/ProcessMonthlyFamilyRecapStepConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import com.template.worker.global.retry.BatchRetrySupport;
 import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapRow;
 import com.template.worker.jobs.recap.monthly.processor.MonthlyFamilyRecapProcessor;
 import com.template.worker.jobs.recap.monthly.reader.MonthlyFamilyRecapFamilyReader;
@@ -26,16 +27,22 @@ public class ProcessMonthlyFamilyRecapStepConfig {
     private final MonthlyFamilyRecapProcessor processor;
     private final MonthlyFamilyRecapUpsertWriter writer;
     private final MonthlyFamilyRecapProperties properties;
+    private final BatchRetrySupport batchRetrySupport;
 
     @Bean
     public Step processMonthlyFamilyRecapStep() {
         // 활성 가족을 읽어 집계 후 즉시 업서트하는 청크 스텝
-        return new StepBuilder(
-                        MonthlyFamilyRecapJobConstants.STEP_PROCESS_MONTHLY_RECAP, jobRepository)
-                .<Long, MonthlyFamilyRecapRow>chunk(properties.getChunkSize(), transactionManager)
-                .reader(reader)
-                .processor(processor)
-                .writer(writer)
+        return batchRetrySupport
+                .applyDbRetry(
+                        new StepBuilder(
+                                        MonthlyFamilyRecapJobConstants.STEP_PROCESS_MONTHLY_RECAP,
+                                        jobRepository)
+                                .<Long, MonthlyFamilyRecapRow>chunk(
+                                        properties.getChunkSize(), transactionManager)
+                                .reader(reader)
+                                .processor(processor)
+                                .writer(writer)
+                                .faultTolerant())
                 .build();
     }
 }

--- a/src/main/java/com/template/worker/jobs/recap/weekly/job/WeeklyFamilyRecapJobConfig.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/job/WeeklyFamilyRecapJobConfig.java
@@ -6,6 +6,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.template.worker.global.listener.JobFailureAlertListener;
 import com.template.worker.global.listener.JobResultListener;
 import com.template.worker.jobs.recap.weekly.listener.WeeklyFamilyRecapJobListener;
 import com.template.worker.jobs.recap.weekly.step.AcquireWeeklyFamilyRecapLockStepConfig;
@@ -21,6 +22,7 @@ public class WeeklyFamilyRecapJobConfig {
 
     private final JobRepository jobRepository;
     private final JobResultListener jobResultListener;
+    private final JobFailureAlertListener jobFailureAlertListener;
     private final WeeklyFamilyRecapJobListener weeklyFamilyRecapJobListener;
     private final AcquireWeeklyFamilyRecapLockStepConfig acquireWeeklyFamilyRecapLockStepConfig;
     private final ProcessWeeklyFamilyRecapStepConfig processWeeklyFamilyRecapStepConfig;
@@ -31,6 +33,7 @@ public class WeeklyFamilyRecapJobConfig {
         // 락 획득 실패면 정상 종료하고 락 획득 성공 시 집계 체인을 실행
         return new JobBuilder(WeeklyFamilyRecapJobConstants.JOB_NAME, jobRepository)
                 .listener(jobResultListener)
+                .listener(jobFailureAlertListener)
                 .listener(weeklyFamilyRecapJobListener)
                 .start(acquireWeeklyFamilyRecapLockStepConfig.acquireWeeklyFamilyRecapLockStep())
                 .on(WeeklyFamilyRecapJobConstants.EXIT_STATUS_LOCK_NOT_ACQUIRED)

--- a/src/main/java/com/template/worker/jobs/recap/weekly/listener/WeeklyFamilyRecapJobListener.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/listener/WeeklyFamilyRecapJobListener.java
@@ -61,12 +61,19 @@ public class WeeklyFamilyRecapJobListener implements JobExecutionListener {
                 jobContext.getString(WeeklyFamilyRecapJobConstants.JOB_CONTEXT_LOCK_KEY, null);
         String lockOwner =
                 jobContext.getString(WeeklyFamilyRecapJobConstants.JOB_CONTEXT_LOCK_OWNER, null);
-        boolean released = lockManager.releaseIfOwner(lockKey, lockOwner);
-        if (lockKey != null) {
-            log.info(
-                    "Weekly family recap final lock cleanup. lockKey={}, released={}",
+        try {
+            boolean released = lockManager.releaseIfOwner(lockKey, lockOwner);
+            if (lockKey != null) {
+                log.info(
+                        "Weekly family recap final lock cleanup. lockKey={}, released={}",
+                        lockKey,
+                        released);
+            }
+        } catch (Exception exception) {
+            log.error(
+                    "Weekly family recap final lock cleanup failed. lockKey={}",
                     lockKey,
-                    released);
+                    exception);
         }
     }
 

--- a/src/main/java/com/template/worker/jobs/recap/weekly/scheduler/WeeklyFamilyRecapScheduler.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/scheduler/WeeklyFamilyRecapScheduler.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.global.alert.BatchAlertService;
 import com.template.worker.global.launcher.BatchJobLauncher;
 import com.template.worker.jobs.recap.weekly.support.WeekStartDateParameterSupport;
 import com.template.worker.jobs.recap.weekly.support.WeeklyFamilyRecapJobConstants;
@@ -24,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 public class WeeklyFamilyRecapScheduler {
 
     private final BatchJobLauncher launcher;
+    private final BatchAlertService batchAlertService;
     private final WeekStartDateParameterSupport parameterSupport;
 
     @Scheduled(
@@ -43,6 +45,10 @@ public class WeeklyFamilyRecapScheduler {
                     "Failed to run weekly family recap job by scheduler. weekStartDate={}",
                     weekStartDate,
                     exception);
+            batchAlertService.sendSchedulerFailureAlert(
+                    "weekly-family-recap-scheduler",
+                    "weekStartDate=" + weekStartDate,
+                    exception.getMessage());
         }
     }
 }

--- a/src/main/java/com/template/worker/jobs/recap/weekly/step/ProcessWeeklyFamilyRecapStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/step/ProcessWeeklyFamilyRecapStepConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import com.template.worker.global.retry.BatchRetrySupport;
 import com.template.worker.jobs.recap.weekly.model.WeeklyFamilyRecapRow;
 import com.template.worker.jobs.recap.weekly.processor.WeeklyFamilyRecapProcessor;
 import com.template.worker.jobs.recap.weekly.reader.WeeklyFamilyRecapFamilyReader;
@@ -26,16 +27,22 @@ public class ProcessWeeklyFamilyRecapStepConfig {
     private final WeeklyFamilyRecapProcessor processor;
     private final WeeklyFamilyRecapUpsertWriter writer;
     private final WeeklyFamilyRecapProperties properties;
+    private final BatchRetrySupport batchRetrySupport;
 
     @Bean
     public Step processWeeklyFamilyRecapStep() {
         // 활성 가족을 읽어 집계 후 즉시 업서트하는 청크 스텝
-        return new StepBuilder(
-                        WeeklyFamilyRecapJobConstants.STEP_PROCESS_WEEKLY_RECAP, jobRepository)
-                .<Long, WeeklyFamilyRecapRow>chunk(properties.getChunkSize(), transactionManager)
-                .reader(reader)
-                .processor(processor)
-                .writer(writer)
+        return batchRetrySupport
+                .applyDbRetry(
+                        new StepBuilder(
+                                        WeeklyFamilyRecapJobConstants.STEP_PROCESS_WEEKLY_RECAP,
+                                        jobRepository)
+                                .<Long, WeeklyFamilyRecapRow>chunk(
+                                        properties.getChunkSize(), transactionManager)
+                                .reader(reader)
+                                .processor(processor)
+                                .writer(writer)
+                                .faultTolerant())
                 .build();
     }
 }

--- a/src/main/java/com/template/worker/jobs/reconciliation/job/DbRedisReconciliationJobConfig.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/job/DbRedisReconciliationJobConfig.java
@@ -6,6 +6,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.template.worker.global.listener.JobFailureAlertListener;
 import com.template.worker.global.listener.JobResultListener;
 import com.template.worker.jobs.reconciliation.listener.DbRedisReconciliationJobListener;
 import com.template.worker.jobs.reconciliation.step.AcquireReconciliationLockStepConfig;
@@ -22,6 +23,7 @@ public class DbRedisReconciliationJobConfig {
 
     private final JobRepository jobRepository;
     private final JobResultListener jobResultListener;
+    private final JobFailureAlertListener jobFailureAlertListener;
     private final DbRedisReconciliationJobListener dbRedisReconciliationJobListener;
     private final AcquireReconciliationLockStepConfig acquireReconciliationLockStepConfig;
     private final InvalidateFamilyInfoAndRemainingStepConfig
@@ -33,6 +35,7 @@ public class DbRedisReconciliationJobConfig {
     public Job dbRedisReconciliationJob() {
         return new JobBuilder(DbRedisReconciliationJobConstants.JOB_NAME, jobRepository)
                 .listener(jobResultListener)
+                .listener(jobFailureAlertListener)
                 .listener(dbRedisReconciliationJobListener)
                 .start(acquireReconciliationLockStepConfig.acquireReconciliationLockStep())
                 // 락 미획득이면 정상 종료해 중복 실행을 방지함

--- a/src/main/java/com/template/worker/jobs/reconciliation/listener/DbRedisReconciliationJobListener.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/listener/DbRedisReconciliationJobListener.java
@@ -83,18 +83,25 @@ public class DbRedisReconciliationJobListener implements JobExecutionListener {
         String lockOwner =
                 jobContext.getString(
                         DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_OWNER, null);
-        boolean released = lockManager.releaseIfOwner(lockKey, lockOwner);
-        if (released) {
-            jobContext.putString(
-                    DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_RELEASED,
-                    String.valueOf(true));
-        }
+        try {
+            boolean released = lockManager.releaseIfOwner(lockKey, lockOwner);
+            if (released) {
+                jobContext.putString(
+                        DbRedisReconciliationJobConstants.JOB_CONTEXT_LOCK_RELEASED,
+                        String.valueOf(true));
+            }
 
-        if (lockKey != null) {
-            log.info(
-                    "DB-Redis reconciliation final lock cleanup. lockKey={}, released={}",
+            if (lockKey != null) {
+                log.info(
+                        "DB-Redis reconciliation final lock cleanup. lockKey={}, released={}",
+                        lockKey,
+                        released);
+            }
+        } catch (Exception exception) {
+            log.error(
+                    "DB-Redis reconciliation final lock cleanup failed. lockKey={}",
                     lockKey,
-                    released);
+                    exception);
         }
     }
 

--- a/src/main/java/com/template/worker/jobs/reconciliation/scheduler/DbRedisReconciliationScheduler.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/scheduler/DbRedisReconciliationScheduler.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.global.alert.BatchAlertService;
 import com.template.worker.global.launcher.BatchJobLauncher;
 import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
 
@@ -24,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 public class DbRedisReconciliationScheduler {
 
     private final BatchJobLauncher launcher;
+    private final BatchAlertService batchAlertService;
 
     @Scheduled(
             cron = "${batch.schedules.db-redis-reconciliation.cron:0 0 3 * * *}",
@@ -46,6 +48,10 @@ public class DbRedisReconciliationScheduler {
                     "Failed to run DB-Redis reconciliation job by scheduler. targetMonth={}",
                     targetMonth,
                     exception);
+            batchAlertService.sendSchedulerFailureAlert(
+                    "db-redis-reconciliation-scheduler",
+                    "targetMonth=" + targetMonth,
+                    exception.getMessage());
         }
     }
 }

--- a/src/main/java/com/template/worker/jobs/reconciliation/step/InvalidateCustomerMonthlyUsageStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/step/InvalidateCustomerMonthlyUsageStepConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import com.template.worker.global.retry.BatchRetrySupport;
 import com.template.worker.jobs.reconciliation.model.FamilyMemberReconciliationTarget;
 import com.template.worker.jobs.reconciliation.reader.ReconciliationFamilyMemberReader;
 import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
@@ -24,17 +25,23 @@ public class InvalidateCustomerMonthlyUsageStepConfig {
     private final ReconciliationFamilyMemberReader reader;
     private final ReconciliationCustomerMonthlyUsageInvalidationWriter writer;
     private final DbRedisReconciliationProperties properties;
+    private final BatchRetrySupport batchRetrySupport;
 
     @Bean
     public Step invalidateCustomerMonthlyUsageStep() {
         // family_member reader + monthly usage invalidation writer의 Chunk Step 구성
-        return new StepBuilder(
-                        DbRedisReconciliationJobConstants.STEP_INVALIDATE_CUSTOMER_MONTHLY_USAGE,
-                        jobRepository)
-                .<FamilyMemberReconciliationTarget, FamilyMemberReconciliationTarget>chunk(
-                        properties.getRedisChunkSize(), transactionManager)
-                .reader(reader)
-                .writer(writer)
+        return batchRetrySupport
+                .applyRedisRetry(
+                        new StepBuilder(
+                                        DbRedisReconciliationJobConstants
+                                                .STEP_INVALIDATE_CUSTOMER_MONTHLY_USAGE,
+                                        jobRepository)
+                                .<FamilyMemberReconciliationTarget,
+                                        FamilyMemberReconciliationTarget>
+                                        chunk(properties.getRedisChunkSize(), transactionManager)
+                                .reader(reader)
+                                .writer(writer)
+                                .faultTolerant())
                 .build();
     }
 }

--- a/src/main/java/com/template/worker/jobs/reconciliation/step/InvalidateFamilyInfoAndRemainingStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/reconciliation/step/InvalidateFamilyInfoAndRemainingStepConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import com.template.worker.global.retry.BatchRetrySupport;
 import com.template.worker.jobs.reconciliation.reader.ReconciliationFamilyReader;
 import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
 import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationProperties;
@@ -23,16 +24,22 @@ public class InvalidateFamilyInfoAndRemainingStepConfig {
     private final ReconciliationFamilyReader reader;
     private final ReconciliationFamilyKeyInvalidationWriter writer;
     private final DbRedisReconciliationProperties properties;
+    private final BatchRetrySupport batchRetrySupport;
 
     @Bean
     public Step invalidateFamilyInfoAndRemainingStep() {
         // family id reader + info/remaining invalidation writer의 Chunk Step 구성
-        return new StepBuilder(
-                        DbRedisReconciliationJobConstants.STEP_INVALIDATE_FAMILY_INFO_AND_REMAINING,
-                        jobRepository)
-                .<Long, Long>chunk(properties.getRedisChunkSize(), transactionManager)
-                .reader(reader)
-                .writer(writer)
+        return batchRetrySupport
+                .applyRedisRetry(
+                        new StepBuilder(
+                                        DbRedisReconciliationJobConstants
+                                                .STEP_INVALIDATE_FAMILY_INFO_AND_REMAINING,
+                                        jobRepository)
+                                .<Long, Long>chunk(
+                                        properties.getRedisChunkSize(), transactionManager)
+                                .reader(reader)
+                                .writer(writer)
+                                .faultTolerant())
                 .build();
     }
 }

--- a/src/main/java/com/template/worker/jobs/usageprecreate/job/MonthlyUsagePrecreateJobConfig.java
+++ b/src/main/java/com/template/worker/jobs/usageprecreate/job/MonthlyUsagePrecreateJobConfig.java
@@ -6,6 +6,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.template.worker.global.listener.JobFailureAlertListener;
 import com.template.worker.global.listener.JobResultListener;
 import com.template.worker.jobs.usageprecreate.listener.MonthlyUsagePrecreateJobListener;
 import com.template.worker.jobs.usageprecreate.step.AcquireMonthlyUsagePrecreateLockStepConfig;
@@ -22,6 +23,7 @@ public class MonthlyUsagePrecreateJobConfig {
 
     private final JobRepository jobRepository;
     private final JobResultListener jobResultListener;
+    private final JobFailureAlertListener jobFailureAlertListener;
     private final MonthlyUsagePrecreateJobListener jobListener;
     private final AcquireMonthlyUsagePrecreateLockStepConfig acquireLockStepConfig;
     private final PrecreateCustomerQuotaStepConfig precreateCustomerQuotaStepConfig;
@@ -32,6 +34,7 @@ public class MonthlyUsagePrecreateJobConfig {
     public Job monthlyUsagePrecreateJob() {
         return new JobBuilder(MonthlyUsagePrecreateJobConstants.JOB_NAME, jobRepository)
                 .listener(jobResultListener)
+                .listener(jobFailureAlertListener)
                 .listener(jobListener)
                 .start(acquireLockStepConfig.acquireMonthlyUsagePrecreateLockStep())
                 // 락 미획득이면 정상 종료해 중복 실행을 방지

--- a/src/main/java/com/template/worker/jobs/usageprecreate/listener/MonthlyUsagePrecreateJobListener.java
+++ b/src/main/java/com/template/worker/jobs/usageprecreate/listener/MonthlyUsagePrecreateJobListener.java
@@ -73,12 +73,19 @@ public class MonthlyUsagePrecreateJobListener implements JobExecutionListener {
         String lockOwner =
                 jobContext.getString(
                         MonthlyUsagePrecreateJobConstants.JOB_CONTEXT_LOCK_OWNER, null);
-        boolean released = lockManager.releaseIfOwner(lockKey, lockOwner);
-        if (lockKey != null) {
-            log.info(
-                    "Monthly usage precreate final lock cleanup. lockKey={}, released={}",
+        try {
+            boolean released = lockManager.releaseIfOwner(lockKey, lockOwner);
+            if (lockKey != null) {
+                log.info(
+                        "Monthly usage precreate final lock cleanup. lockKey={}, released={}",
+                        lockKey,
+                        released);
+            }
+        } catch (Exception exception) {
+            log.error(
+                    "Monthly usage precreate final lock cleanup failed. lockKey={}",
                     lockKey,
-                    released);
+                    exception);
         }
     }
 }

--- a/src/main/java/com/template/worker/jobs/usageprecreate/scheduler/MonthlyUsagePrecreateScheduler.java
+++ b/src/main/java/com/template/worker/jobs/usageprecreate/scheduler/MonthlyUsagePrecreateScheduler.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.global.alert.BatchAlertService;
 import com.template.worker.global.launcher.BatchJobLauncher;
 import com.template.worker.jobs.usageprecreate.support.MonthlyUsagePrecreateJobConstants;
 import com.template.worker.jobs.usageprecreate.support.MonthlyUsagePrecreateJobParameterSupport;
@@ -24,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MonthlyUsagePrecreateScheduler {
 
     private final BatchJobLauncher launcher;
+    private final BatchAlertService batchAlertService;
     private final MonthlyUsagePrecreateJobParameterSupport parameterSupport;
 
     @Scheduled(
@@ -49,6 +51,10 @@ public class MonthlyUsagePrecreateScheduler {
                     "Failed to run monthly usage precreate job by scheduler. targetMonth={}",
                     targetMonth,
                     exception);
+            batchAlertService.sendSchedulerFailureAlert(
+                    "monthly-usage-precreate-scheduler",
+                    "targetMonth=" + targetMonth,
+                    exception.getMessage());
         }
     }
 }

--- a/src/main/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateCustomerQuotaTasklet.java
+++ b/src/main/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateCustomerQuotaTasklet.java
@@ -14,6 +14,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.global.retry.BatchRetrySupport;
 import com.template.worker.jobs.usageprecreate.support.MonthlyUsagePrecreateJobConstants;
 import com.template.worker.jobs.usageprecreate.support.MonthlyUsagePrecreateJobParameterSupport;
 
@@ -82,6 +83,7 @@ public class PrecreateCustomerQuotaTasklet implements Tasklet, StepExecutionList
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
     private final MonthlyUsagePrecreateJobParameterSupport parameterSupport;
+    private final BatchRetrySupport batchRetrySupport;
 
     private LocalDate targetMonth;
 
@@ -98,7 +100,12 @@ public class PrecreateCustomerQuotaTasklet implements Tasklet, StepExecutionList
                 new MapSqlParameterSource().addValue("targetMonth", Date.valueOf(targetMonth));
 
         // 대상 월 row가 없는 구성원만 멱등적으로 선생성
-        int insertedCount = jdbcTemplate.update(INSERT_CUSTOMER_QUOTA_SQL, params);
+        int insertedCount =
+                batchRetrySupport
+                        .createDbRetryTemplate()
+                        .execute(
+                                retryContext ->
+                                        jdbcTemplate.update(INSERT_CUSTOMER_QUOTA_SQL, params));
 
         StepExecution stepExecution = contribution.getStepExecution();
         stepExecution

--- a/src/main/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateFamilyQuotaTasklet.java
+++ b/src/main/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateFamilyQuotaTasklet.java
@@ -14,6 +14,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.global.retry.BatchRetrySupport;
 import com.template.worker.jobs.usageprecreate.support.MonthlyUsagePrecreateJobConstants;
 import com.template.worker.jobs.usageprecreate.support.MonthlyUsagePrecreateJobParameterSupport;
 
@@ -93,6 +94,7 @@ public class PrecreateFamilyQuotaTasklet implements Tasklet, StepExecutionListen
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
     private final MonthlyUsagePrecreateJobParameterSupport parameterSupport;
+    private final BatchRetrySupport batchRetrySupport;
 
     private LocalDate targetMonth;
 
@@ -109,12 +111,24 @@ public class PrecreateFamilyQuotaTasklet implements Tasklet, StepExecutionListen
                 new MapSqlParameterSource().addValue("targetMonth", Date.valueOf(targetMonth));
 
         // 최신 스냅샷이 전혀 없는 가족 수를 먼저 계산해 skip 집계에 사용
-        Long skippedCount =
-                jdbcTemplate.queryForObject(COUNT_SKIPPED_FAMILY_QUOTA_SQL, params, Long.class);
-        long resolvedSkippedCount = skippedCount == null ? 0L : skippedCount;
-
-        // 최신 스냅샷이 있는 가족만 대상 월 row를 멱등적으로 선생성
-        int insertedCount = jdbcTemplate.update(INSERT_FAMILY_QUOTA_SQL, params);
+        PrecreateFamilyQuotaResult result =
+                batchRetrySupport
+                        .createDbRetryTemplate()
+                        .execute(
+                                retryContext -> {
+                                    Long skippedCount =
+                                            jdbcTemplate.queryForObject(
+                                                    COUNT_SKIPPED_FAMILY_QUOTA_SQL,
+                                                    params,
+                                                    Long.class);
+                                    long resolvedSkippedCount =
+                                            skippedCount == null ? 0L : skippedCount;
+                                    // 최신 스냅샷이 있는 가족만 대상 월 row를 멱등적으로 선생성
+                                    int insertedCount =
+                                            jdbcTemplate.update(INSERT_FAMILY_QUOTA_SQL, params);
+                                    return new PrecreateFamilyQuotaResult(
+                                            insertedCount, resolvedSkippedCount);
+                                });
 
         StepExecution stepExecution = contribution.getStepExecution();
         stepExecution
@@ -122,26 +136,28 @@ public class PrecreateFamilyQuotaTasklet implements Tasklet, StepExecutionListen
                 .getExecutionContext()
                 .putLong(
                         MonthlyUsagePrecreateJobConstants.JOB_CONTEXT_PRECREATED_FAMILY_QUOTA_COUNT,
-                        insertedCount);
+                        result.insertedCount());
         stepExecution
                 .getJobExecution()
                 .getExecutionContext()
                 .putLong(
                         MonthlyUsagePrecreateJobConstants.JOB_CONTEXT_SKIPPED_FAMILY_QUOTA_COUNT,
-                        resolvedSkippedCount);
+                        result.skippedCount());
 
-        if (resolvedSkippedCount > 0) {
+        if (result.skippedCount() > 0) {
             log.warn(
                     "Skipped family_quota precreate because latest snapshot was not found."
                             + " targetMonth={}, skippedCount={}",
                     targetMonth,
-                    resolvedSkippedCount);
+                    result.skippedCount());
         }
         log.info(
                 "Precreated family_quota rows for targetMonth. targetMonth={}, insertedCount={}",
                 targetMonth,
-                insertedCount);
+                result.insertedCount());
 
         return RepeatStatus.FINISHED;
     }
+
+    private record PrecreateFamilyQuotaResult(int insertedCount, long skippedCount) {}
 }

--- a/src/main/java/com/template/worker/jobs/usagereset/job/MonthlyUsageResetJobConfig.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/job/MonthlyUsageResetJobConfig.java
@@ -6,6 +6,7 @@ import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.template.worker.global.listener.JobFailureAlertListener;
 import com.template.worker.global.listener.JobResultListener;
 import com.template.worker.jobs.usagereset.listener.MonthlyUsageResetJobListener;
 import com.template.worker.jobs.usagereset.step.AcquireMonthlyResetLockStepConfig;
@@ -21,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 public class MonthlyUsageResetJobConfig {
     private final JobRepository jobRepository;
     private final JobResultListener jobResultListener;
+    private final JobFailureAlertListener jobFailureAlertListener;
     private final MonthlyUsageResetJobListener monthlyUsageResetJobListener;
     private final AcquireMonthlyResetLockStepConfig acquireMonthlyResetLockStepConfig;
     private final ResetRedisFamilyKeysStepConfig resetRedisFamilyKeysStepConfig;
@@ -31,6 +33,7 @@ public class MonthlyUsageResetJobConfig {
     public Job monthlyUsageResetJob() {
         return new JobBuilder(MonthlyUsageResetJobConstants.JOB_NAME, jobRepository)
                 .listener(jobResultListener)
+                .listener(jobFailureAlertListener)
                 .listener(monthlyUsageResetJobListener)
                 .start(acquireMonthlyResetLockStepConfig.acquireMonthlyResetLockStep())
                 // 락 미획득이면 정상 종료해 중복 실행을 방지함

--- a/src/main/java/com/template/worker/jobs/usagereset/listener/MonthlyUsageResetJobListener.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/listener/MonthlyUsageResetJobListener.java
@@ -69,12 +69,19 @@ public class MonthlyUsageResetJobListener implements JobExecutionListener {
                 jobContext.getString(MonthlyUsageResetJobConstants.JOB_CONTEXT_LOCK_KEY, null);
         String lockOwner =
                 jobContext.getString(MonthlyUsageResetJobConstants.JOB_CONTEXT_LOCK_OWNER, null);
-        boolean released = monthlyResetLockManager.releaseIfOwner(lockKey, lockOwner);
-        if (lockKey != null) {
-            log.info(
-                    "Monthly usage reset final lock cleanup. lockKey={}, released={}",
+        try {
+            boolean released = monthlyResetLockManager.releaseIfOwner(lockKey, lockOwner);
+            if (lockKey != null) {
+                log.info(
+                        "Monthly usage reset final lock cleanup. lockKey={}, released={}",
+                        lockKey,
+                        released);
+            }
+        } catch (Exception exception) {
+            log.error(
+                    "Monthly usage reset final lock cleanup failed. lockKey={}",
                     lockKey,
-                    released);
+                    exception);
         }
     }
 

--- a/src/main/java/com/template/worker/jobs/usagereset/scheduler/MonthlyUsageResetScheduler.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/scheduler/MonthlyUsageResetScheduler.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.global.alert.BatchAlertService;
 import com.template.worker.global.launcher.BatchJobLauncher;
 import com.template.worker.jobs.usagereset.support.MonthlyUsageResetJobConstants;
 
@@ -24,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MonthlyUsageResetScheduler {
 
     private final BatchJobLauncher launcher;
+    private final BatchAlertService batchAlertService;
 
     @Scheduled(
             cron = "${batch.schedules.monthly-usage-reset.cron:0 1 0 1 * *}",
@@ -46,6 +48,10 @@ public class MonthlyUsageResetScheduler {
                     "Failed to run monthly usage reset job by scheduler. targetMonth={}",
                     targetMonth,
                     exception);
+            batchAlertService.sendSchedulerFailureAlert(
+                    "monthly-usage-reset-scheduler",
+                    "targetMonth=" + targetMonth,
+                    exception.getMessage());
         }
     }
 }

--- a/src/main/java/com/template/worker/jobs/usagereset/step/ResetRedisCustomerMonthlyUsageStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/step/ResetRedisCustomerMonthlyUsageStepConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import com.template.worker.global.retry.BatchRetrySupport;
 import com.template.worker.jobs.usagereset.model.FamilyMemberUsageResetTarget;
 import com.template.worker.jobs.usagereset.reader.ActiveFamilyMemberReader;
 import com.template.worker.jobs.usagereset.support.MonthlyUsageResetJobConstants;
@@ -24,17 +25,22 @@ public class ResetRedisCustomerMonthlyUsageStepConfig {
     private final ActiveFamilyMemberReader reader;
     private final CustomerMonthlyUsageResetWriter writer;
     private final MonthlyUsageResetProperties properties;
+    private final BatchRetrySupport batchRetrySupport;
 
     @Bean
     public Step resetRedisCustomerMonthlyUsageStep() {
         // family_member reader + monthly usage reset writer의 Chunk Step 구성
-        return new StepBuilder(
-                        MonthlyUsageResetJobConstants.STEP_RESET_REDIS_CUSTOMER_MONTHLY_USAGE,
-                        jobRepository)
-                .<FamilyMemberUsageResetTarget, FamilyMemberUsageResetTarget>chunk(
-                        properties.getRedisChunkSize(), transactionManager)
-                .reader(reader)
-                .writer(writer)
+        return batchRetrySupport
+                .applyRedisRetry(
+                        new StepBuilder(
+                                        MonthlyUsageResetJobConstants
+                                                .STEP_RESET_REDIS_CUSTOMER_MONTHLY_USAGE,
+                                        jobRepository)
+                                .<FamilyMemberUsageResetTarget, FamilyMemberUsageResetTarget>chunk(
+                                        properties.getRedisChunkSize(), transactionManager)
+                                .reader(reader)
+                                .writer(writer)
+                                .faultTolerant())
                 .build();
     }
 }

--- a/src/main/java/com/template/worker/jobs/usagereset/step/ResetRedisFamilyKeysStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/usagereset/step/ResetRedisFamilyKeysStepConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import com.template.worker.global.retry.BatchRetrySupport;
 import com.template.worker.jobs.usagereset.reader.ActiveFamilyReader;
 import com.template.worker.jobs.usagereset.support.MonthlyUsageResetJobConstants;
 import com.template.worker.jobs.usagereset.support.MonthlyUsageResetProperties;
@@ -23,15 +24,21 @@ public class ResetRedisFamilyKeysStepConfig {
     private final ActiveFamilyReader reader;
     private final FamilyRedisResetWriter writer;
     private final MonthlyUsageResetProperties properties;
+    private final BatchRetrySupport batchRetrySupport;
 
     @Bean
     public Step resetRedisFamilyKeysStep() {
         // family id reader + redis delete writer의 Chunk Step 구성
-        return new StepBuilder(
-                        MonthlyUsageResetJobConstants.STEP_RESET_REDIS_FAMILY_KEYS, jobRepository)
-                .<Long, Long>chunk(properties.getRedisChunkSize(), transactionManager)
-                .reader(reader)
-                .writer(writer)
+        return batchRetrySupport
+                .applyRedisRetry(
+                        new StepBuilder(
+                                        MonthlyUsageResetJobConstants.STEP_RESET_REDIS_FAMILY_KEYS,
+                                        jobRepository)
+                                .<Long, Long>chunk(
+                                        properties.getRedisChunkSize(), transactionManager)
+                                .reader(reader)
+                                .writer(writer)
+                                .faultTolerant())
                 .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,7 +49,7 @@ logging:
 
 slack:
   webhook:
-    url: ${SLACK_WEBHOOK_URL:https://hooks.slack.com/services/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}
+    url: ${SLACK_WEBHOOK_URL:}
 
 ---
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,6 +47,10 @@ logging:
     org.springframework.batch: INFO
     com.template.worker: INFO
 
+slack:
+  webhook:
+    url: ${SLACK_WEBHOOK_URL:https://hooks.slack.com/services/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}
+
 ---
 
 spring:

--- a/src/main/resources/batch.yml
+++ b/src/main/resources/batch.yml
@@ -7,6 +7,10 @@ spring:
       initialize-schema: always
 
 batch:
+  retry:
+    limit: ${BATCH_RETRY_LIMIT:3}
+    backoff-millis: ${BATCH_RETRY_BACKOFF_MILLIS:3000}
+
   schedules:
     weekly-family-recap:
       enabled: ${BATCH_WEEKLY_FAMILY_RECAP_ENABLED:false}

--- a/src/test/java/com/template/worker/global/alert/BatchAlertServiceTest.java
+++ b/src/test/java/com/template/worker/global/alert/BatchAlertServiceTest.java
@@ -1,0 +1,92 @@
+package com.template.worker.global.alert;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+class BatchAlertServiceTest {
+
+    private static final String WEBHOOK_URL = "https://hooks.slack.com/services/test";
+
+    @Test
+    @DisplayName("sendJobFailureAlert - webhook 이 있으면 Slack payload를 POST 한다")
+    void sendJobFailureAlert_postsSlackPayloadWhenWebhookConfigured() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+        BatchAlertService batchAlertService = new BatchAlertService(restTemplate, WEBHOOK_URL);
+
+        server.expect(requestTo(WEBHOOK_URL))
+                .andExpect(method(POST))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().string(containsString("\"text\":")))
+                .andExpect(content().string(containsString("*DABOM Batch 실패*")))
+                .andExpect(content().string(containsString("• 잡: monthly-usage-reset-job")))
+                .andExpect(content().string(containsString("• 파라미터: targetMonth=2026-03-01")))
+                .andExpect(content().string(containsString("• 원인 요약: Redis 연결 실패로 재시도 3회 후 최종 실패")))
+                .andExpect(
+                        content()
+                                .string(containsString("• 원본 예외: RedisConnectionFailureException")))
+                .andRespond(withSuccess());
+
+        batchAlertService.sendJobFailureAlert(
+                "monthly-usage-reset-job",
+                10L,
+                "targetMonth=2026-03-01",
+                "Redis 연결 실패로 재시도 3회 후 최종 실패",
+                "RedisConnectionFailureException: Unable to connect to Redis");
+
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("sendJobFailureAlert - webhook 이 비어 있으면 예외 없이 건너뛴다")
+    void sendJobFailureAlert_skipsWhenWebhookIsBlank() {
+        BatchAlertService batchAlertService = new BatchAlertService(new RestTemplate(), " ");
+
+        assertThatCode(
+                        () ->
+                                batchAlertService.sendJobFailureAlert(
+                                        "monthly-usage-reset-job",
+                                        10L,
+                                        "targetMonth=2026-03-01",
+                                        "Redis 연결 실패",
+                                        "RedisConnectionFailureException: boom"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("sendSchedulerFailureAlert - Slack 호출 실패를 삼키고 로그만 남긴다")
+    void sendSchedulerFailureAlert_swallowsSlackException() {
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        BatchAlertService batchAlertService = new BatchAlertService(restTemplate, WEBHOOK_URL);
+        doThrow(new RestClientException("failed") {})
+                .when(restTemplate)
+                .postForEntity(eq(WEBHOOK_URL), any(), eq(Void.class));
+
+        assertThatCode(
+                        () ->
+                                batchAlertService.sendSchedulerFailureAlert(
+                                        "weekly-family-recap-scheduler",
+                                        "weekStartDate=2026-03-09",
+                                        "failed"))
+                .doesNotThrowAnyException();
+
+        verify(restTemplate).postForEntity(eq(WEBHOOK_URL), any(), eq(Void.class));
+    }
+}

--- a/src/test/java/com/template/worker/global/listener/JobFailureAlertListenerTest.java
+++ b/src/test/java/com/template/worker/global/listener/JobFailureAlertListenerTest.java
@@ -1,0 +1,143 @@
+package com.template.worker.global.listener;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.data.redis.RedisConnectionFailureException;
+
+import com.template.worker.global.alert.BatchAlertService;
+import com.template.worker.global.retry.BatchRetrySupport;
+
+import io.lettuce.core.RedisCommandTimeoutException;
+
+@ExtendWith(MockitoExtension.class)
+class JobFailureAlertListenerTest {
+
+    @Mock private BatchAlertService batchAlertService;
+    @Mock private BatchRetrySupport batchRetrySupport;
+
+    @InjectMocks private JobFailureAlertListener jobFailureAlertListener;
+
+    @Test
+    @DisplayName("afterJob - FAILED 상태면 핵심 파라미터와 함께 Slack 알람을 보낸다")
+    void afterJob_sendsAlertWhenJobFailed() {
+        JobInstance jobInstance = new JobInstance(1L, "monthlyUsageResetJob");
+        JobExecution jobExecution =
+                new JobExecution(
+                        jobInstance,
+                        new JobParametersBuilder()
+                                .addString("targetMonth", "2026-03-01")
+                                .toJobParameters());
+        jobExecution.setStatus(BatchStatus.FAILED);
+        jobExecution.addFailureException(
+                new IllegalStateException(
+                        "Retry exhausted after last attempt in recovery path, but exception is not"
+                                + " skippable.",
+                        new RedisConnectionFailureException("Unable to connect to Redis")));
+        org.mockito.Mockito.when(batchRetrySupport.getRetryLimit()).thenReturn(3);
+
+        jobFailureAlertListener.afterJob(jobExecution);
+
+        verify(batchAlertService)
+                .sendJobFailureAlert(
+                        eq("monthlyUsageResetJob"),
+                        isNull(),
+                        eq("targetMonth=2026-03-01"),
+                        eq("Redis 연결 실패로 재시도 3회 후 최종 실패"),
+                        eq("RedisConnectionFailureException: Unable to connect to Redis"));
+    }
+
+    @Test
+    @DisplayName("afterJob - COMPLETED 상태면 Slack 알람을 보내지 않는다")
+    void afterJob_doesNotSendAlertWhenJobCompleted() {
+        JobInstance jobInstance = new JobInstance(1L, "monthlyUsageResetJob");
+        JobExecution jobExecution =
+                new JobExecution(
+                        jobInstance,
+                        new JobParametersBuilder()
+                                .addString("targetMonth", "2026-03-01")
+                                .toJobParameters());
+        jobExecution.setStatus(BatchStatus.COMPLETED);
+
+        jobFailureAlertListener.afterJob(jobExecution);
+
+        verify(batchAlertService, never())
+                .sendJobFailureAlert(anyString(), any(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("afterJob - Redis command timed out 은 Redis 명령 타임아웃으로 요약한다")
+    void afterJob_summarizesRedisTimeoutAsRedisFailure() {
+        JobInstance jobInstance = new JobInstance(2L, "db-redis-reconciliation-job");
+        JobExecution jobExecution =
+                new JobExecution(
+                        jobInstance,
+                        new JobParametersBuilder()
+                                .addString("targetMonth", "2026-03-01")
+                                .toJobParameters());
+        jobExecution.setStatus(BatchStatus.FAILED);
+        jobExecution.addFailureException(
+                new IllegalStateException(
+                        "Retry exhausted after last attempt in recovery path, but exception is not"
+                                + " skippable.",
+                        new QueryTimeoutException("Redis command timed out")));
+        org.mockito.Mockito.when(batchRetrySupport.getRetryLimit()).thenReturn(3);
+
+        jobFailureAlertListener.afterJob(jobExecution);
+
+        verify(batchAlertService)
+                .sendJobFailureAlert(
+                        eq("db-redis-reconciliation-job"),
+                        isNull(),
+                        eq("targetMonth=2026-03-01"),
+                        eq("Redis 명령 타임아웃으로 재시도 3회 후 최종 실패"),
+                        eq("QueryTimeoutException: Redis command timed out"));
+    }
+
+    @Test
+    @DisplayName("afterJob - root cause 가 RedisCommandTimeoutException 이어도 Redis 명령 타임아웃으로 요약한다")
+    void afterJob_summarizesDirectRedisCommandTimeoutAsRedisFailure() {
+        JobInstance jobInstance = new JobInstance(3L, "db-redis-reconciliation-job");
+        JobExecution jobExecution =
+                new JobExecution(
+                        jobInstance,
+                        new JobParametersBuilder()
+                                .addString("targetMonth", "2026-03-01")
+                                .toJobParameters());
+        jobExecution.setStatus(BatchStatus.FAILED);
+        jobExecution.addFailureException(
+                new IllegalStateException(
+                        "Retry exhausted after last attempt in recovery path, but exception is not"
+                                + " skippable.",
+                        new QueryTimeoutException(
+                                "Redis command timed out",
+                                new RedisCommandTimeoutException(
+                                        "Command timed out after 1 minute(s)"))));
+        org.mockito.Mockito.when(batchRetrySupport.getRetryLimit()).thenReturn(3);
+
+        jobFailureAlertListener.afterJob(jobExecution);
+
+        verify(batchAlertService)
+                .sendJobFailureAlert(
+                        eq("db-redis-reconciliation-job"),
+                        isNull(),
+                        eq("targetMonth=2026-03-01"),
+                        eq("Redis 명령 타임아웃으로 재시도 3회 후 최종 실패"),
+                        eq("RedisCommandTimeoutException: Command timed out after 1 minute(s)"));
+    }
+}

--- a/src/test/java/com/template/worker/global/retry/BatchRetrySupportTest.java
+++ b/src/test/java/com/template/worker/global/retry/BatchRetrySupportTest.java
@@ -41,15 +41,7 @@ class BatchRetrySupportTest {
         BatchRetrySupport batchRetrySupport = new BatchRetrySupport(3, 0L);
         AtomicInteger attempts = new AtomicInteger();
 
-        assertThatThrownBy(
-                        () ->
-                                batchRetrySupport
-                                        .createDbRetryTemplate()
-                                        .execute(
-                                                retryContext -> {
-                                                    attempts.incrementAndGet();
-                                                    throw new IllegalArgumentException("bad");
-                                                }))
+        assertThatThrownBy(() -> executeNonRetryableFailure(batchRetrySupport, attempts))
                 .isInstanceOf(IllegalArgumentException.class);
 
         assertThat(attempts).hasValue(1);
@@ -72,5 +64,16 @@ class BatchRetrySupportTest {
                         });
 
         assertThat(attempts).hasValue(3);
+    }
+
+    private void executeNonRetryableFailure(
+            BatchRetrySupport batchRetrySupport, AtomicInteger attempts) {
+        batchRetrySupport
+                .createDbRetryTemplate()
+                .execute(
+                        retryContext -> {
+                            attempts.incrementAndGet();
+                            throw new IllegalArgumentException("bad");
+                        });
     }
 }

--- a/src/test/java/com/template/worker/global/retry/BatchRetrySupportTest.java
+++ b/src/test/java/com/template/worker/global/retry/BatchRetrySupportTest.java
@@ -1,0 +1,76 @@
+package com.template.worker.global.retry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.data.redis.RedisConnectionFailureException;
+
+class BatchRetrySupportTest {
+
+    @Test
+    @DisplayName("createDbRetryTemplate - QueryTimeoutException 은 설정 횟수까지 재시도한다")
+    void createDbRetryTemplate_retriesQueryTimeoutException() {
+        BatchRetrySupport batchRetrySupport = new BatchRetrySupport(3, 0L);
+        AtomicInteger attempts = new AtomicInteger();
+
+        String result =
+                batchRetrySupport
+                        .createDbRetryTemplate()
+                        .execute(
+                                retryContext -> {
+                                    if (attempts.incrementAndGet() < 3) {
+                                        throw new QueryTimeoutException("timeout");
+                                    }
+                                    return "success";
+                                });
+
+        assertThat(result).isEqualTo("success");
+        assertThat(attempts).hasValue(3);
+        assertThat(batchRetrySupport.getRetryLimit()).isEqualTo(3);
+        assertThat(batchRetrySupport.getBackOffMillis()).isZero();
+    }
+
+    @Test
+    @DisplayName("createDbRetryTemplate - 비재시도 예외는 즉시 전파한다")
+    void createDbRetryTemplate_doesNotRetryNonRetryableException() {
+        BatchRetrySupport batchRetrySupport = new BatchRetrySupport(3, 0L);
+        AtomicInteger attempts = new AtomicInteger();
+
+        assertThatThrownBy(
+                        () ->
+                                batchRetrySupport
+                                        .createDbRetryTemplate()
+                                        .execute(
+                                                retryContext -> {
+                                                    attempts.incrementAndGet();
+                                                    throw new IllegalArgumentException("bad");
+                                                }))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThat(attempts).hasValue(1);
+    }
+
+    @Test
+    @DisplayName("createRedisRetryTemplate - RedisConnectionFailureException 은 설정 횟수까지 재시도한다")
+    void createRedisRetryTemplate_retriesRedisConnectionFailureException() {
+        BatchRetrySupport batchRetrySupport = new BatchRetrySupport(3, 0L);
+        AtomicInteger attempts = new AtomicInteger();
+
+        batchRetrySupport
+                .createRedisRetryTemplate()
+                .execute(
+                        retryContext -> {
+                            if (attempts.incrementAndGet() < 3) {
+                                throw new RedisConnectionFailureException("redis");
+                            }
+                            return null;
+                        });
+
+        assertThat(attempts).hasValue(3);
+    }
+}

--- a/src/test/java/com/template/worker/jobs/recap/monthly/scheduler/MonthlyFamilyRecapSchedulerTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/monthly/scheduler/MonthlyFamilyRecapSchedulerTest.java
@@ -1,0 +1,45 @@
+package com.template.worker.jobs.recap.monthly.scheduler;
+
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.template.worker.global.alert.BatchAlertService;
+import com.template.worker.global.launcher.BatchJobLauncher;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobConstants;
+import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobParameterSupport;
+
+@ExtendWith(MockitoExtension.class)
+class MonthlyFamilyRecapSchedulerTest {
+
+    @Mock private BatchJobLauncher launcher;
+    @Mock private BatchAlertService batchAlertService;
+    @Mock private MonthlyFamilyRecapJobParameterSupport parameterSupport;
+
+    @Test
+    @DisplayName("runMonthlyFamilyRecapJob - launcher 예외가 나면 Slack 알람을 보낸다")
+    void runMonthlyFamilyRecapJob_sendsAlertWhenLauncherThrows() throws Exception {
+        when(parameterSupport.defaultTargetMonth()).thenReturn(LocalDate.of(2026, 3, 1));
+        MonthlyFamilyRecapScheduler scheduler =
+                new MonthlyFamilyRecapScheduler(launcher, batchAlertService, parameterSupport);
+        doThrow(new RuntimeException("boom"))
+                .when(launcher)
+                .run(eq(MonthlyFamilyRecapJobConstants.JOB_NAME), anyMap());
+
+        scheduler.runMonthlyFamilyRecapJob();
+
+        verify(batchAlertService)
+                .sendSchedulerFailureAlert(
+                        "monthly-family-recap-scheduler", "targetMonth=2026-03-01", "boom");
+    }
+}

--- a/src/test/java/com/template/worker/jobs/recap/weekly/scheduler/WeeklyFamilyRecapSchedulerTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/weekly/scheduler/WeeklyFamilyRecapSchedulerTest.java
@@ -1,0 +1,45 @@
+package com.template.worker.jobs.recap.weekly.scheduler;
+
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.template.worker.global.alert.BatchAlertService;
+import com.template.worker.global.launcher.BatchJobLauncher;
+import com.template.worker.jobs.recap.weekly.support.WeekStartDateParameterSupport;
+import com.template.worker.jobs.recap.weekly.support.WeeklyFamilyRecapJobConstants;
+
+@ExtendWith(MockitoExtension.class)
+class WeeklyFamilyRecapSchedulerTest {
+
+    @Mock private BatchJobLauncher launcher;
+    @Mock private BatchAlertService batchAlertService;
+    @Mock private WeekStartDateParameterSupport parameterSupport;
+
+    @Test
+    @DisplayName("runWeeklyFamilyRecapJob - launcher 예외가 나면 Slack 알람을 보낸다")
+    void runWeeklyFamilyRecapJob_sendsAlertWhenLauncherThrows() throws Exception {
+        when(parameterSupport.defaultWeekStartDate()).thenReturn(LocalDate.of(2026, 3, 9));
+        WeeklyFamilyRecapScheduler scheduler =
+                new WeeklyFamilyRecapScheduler(launcher, batchAlertService, parameterSupport);
+        doThrow(new RuntimeException("boom"))
+                .when(launcher)
+                .run(eq(WeeklyFamilyRecapJobConstants.JOB_NAME), anyMap());
+
+        scheduler.runWeeklyFamilyRecapJob();
+
+        verify(batchAlertService)
+                .sendSchedulerFailureAlert(
+                        "weekly-family-recap-scheduler", "weekStartDate=2026-03-09", "boom");
+    }
+}

--- a/src/test/java/com/template/worker/jobs/recap/weekly/step/ProcessWeeklyFamilyRecapStepConfigTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/weekly/step/ProcessWeeklyFamilyRecapStepConfigTest.java
@@ -1,0 +1,139 @@
+package com.template.worker.jobs.recap.weekly.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
+import org.springframework.dao.DeadlockLoserDataAccessException;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.template.worker.global.retry.BatchRetrySupport;
+import com.template.worker.jobs.recap.weekly.model.WeeklyFamilyRecapRow;
+import com.template.worker.jobs.recap.weekly.processor.WeeklyFamilyRecapProcessor;
+import com.template.worker.jobs.recap.weekly.reader.WeeklyFamilyRecapFamilyReader;
+import com.template.worker.jobs.recap.weekly.support.WeeklyFamilyRecapProperties;
+import com.template.worker.jobs.recap.weekly.writer.WeeklyFamilyRecapUpsertWriter;
+
+class ProcessWeeklyFamilyRecapStepConfigTest {
+
+    @Test
+    @DisplayName("processWeeklyFamilyRecapStep - Deadlock 이 두 번 나도 세 번째에 성공한다")
+    void processWeeklyFamilyRecapStep_retriesDbFailuresThenCompletes() throws Exception {
+        JobRepository jobRepository = mock(JobRepository.class);
+        PlatformTransactionManager transactionManager = new ResourcelessTransactionManager();
+        WeeklyFamilyRecapFamilyReader reader = mock(WeeklyFamilyRecapFamilyReader.class);
+        WeeklyFamilyRecapProcessor processor = mock(WeeklyFamilyRecapProcessor.class);
+        WeeklyFamilyRecapUpsertWriter writer = mock(WeeklyFamilyRecapUpsertWriter.class);
+        WeeklyFamilyRecapProperties properties = new WeeklyFamilyRecapProperties();
+        properties.setChunkSize(2);
+
+        ProcessWeeklyFamilyRecapStepConfig stepConfig =
+                new ProcessWeeklyFamilyRecapStepConfig(
+                        jobRepository,
+                        transactionManager,
+                        reader,
+                        processor,
+                        writer,
+                        properties,
+                        new BatchRetrySupport(3, 0L));
+
+        when(reader.read()).thenReturn(10L, null);
+        when(processor.process(10L)).thenReturn(createRow());
+
+        AtomicInteger attempts = new AtomicInteger();
+        doAnswer(
+                        invocation -> {
+                            if (attempts.incrementAndGet() < 3) {
+                                throw new DeadlockLoserDataAccessException("deadlock", null);
+                            }
+                            return null;
+                        })
+                .when(writer)
+                .write(any());
+
+        Step step = stepConfig.processWeeklyFamilyRecapStep();
+        StepExecution stepExecution = createStepExecution("process-weekly-family-recap-step");
+
+        step.execute(stepExecution);
+
+        assertThat(stepExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(attempts).hasValue(3);
+    }
+
+    @Test
+    @DisplayName("processWeeklyFamilyRecapStep - Deadlock 이 한도를 넘으면 FAILED 처리된다")
+    void processWeeklyFamilyRecapStep_failsAfterRetryLimitExceeded() throws Exception {
+        JobRepository jobRepository = mock(JobRepository.class);
+        PlatformTransactionManager transactionManager = new ResourcelessTransactionManager();
+        WeeklyFamilyRecapFamilyReader reader = mock(WeeklyFamilyRecapFamilyReader.class);
+        WeeklyFamilyRecapProcessor processor = mock(WeeklyFamilyRecapProcessor.class);
+        WeeklyFamilyRecapUpsertWriter writer = mock(WeeklyFamilyRecapUpsertWriter.class);
+        WeeklyFamilyRecapProperties properties = new WeeklyFamilyRecapProperties();
+        properties.setChunkSize(2);
+
+        ProcessWeeklyFamilyRecapStepConfig stepConfig =
+                new ProcessWeeklyFamilyRecapStepConfig(
+                        jobRepository,
+                        transactionManager,
+                        reader,
+                        processor,
+                        writer,
+                        properties,
+                        new BatchRetrySupport(3, 0L));
+
+        when(reader.read()).thenReturn(10L, null);
+        when(processor.process(10L)).thenReturn(createRow());
+        doThrow(new DeadlockLoserDataAccessException("deadlock", null)).when(writer).write(any());
+
+        Step step = stepConfig.processWeeklyFamilyRecapStep();
+        StepExecution stepExecution = createStepExecution("process-weekly-family-recap-step");
+
+        step.execute(stepExecution);
+
+        assertThat(stepExecution.getStatus()).isEqualTo(BatchStatus.FAILED);
+    }
+
+    private WeeklyFamilyRecapRow createRow() {
+        return new WeeklyFamilyRecapRow(
+                10L,
+                LocalDate.of(2026, 3, 9),
+                100L,
+                1000L,
+                new BigDecimal("10.00"),
+                "{}",
+                "{}",
+                1,
+                1,
+                0,
+                1,
+                1,
+                0);
+    }
+
+    private StepExecution createStepExecution(String stepName) {
+        JobExecution jobExecution =
+                new JobExecution(
+                        new JobInstance(1L, "weeklyFamilyRecapJob"),
+                        new JobParametersBuilder()
+                                .addString("weekStartDate", "2026-03-09")
+                                .toJobParameters());
+        return new StepExecution(stepName, jobExecution);
+    }
+}

--- a/src/test/java/com/template/worker/jobs/recap/weekly/step/ProcessWeeklyFamilyRecapStepConfigTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/weekly/step/ProcessWeeklyFamilyRecapStepConfigTest.java
@@ -21,7 +21,7 @@ import org.springframework.batch.core.Step;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
-import org.springframework.dao.DeadlockLoserDataAccessException;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import com.template.worker.global.retry.BatchRetrySupport;
@@ -61,7 +61,7 @@ class ProcessWeeklyFamilyRecapStepConfigTest {
         doAnswer(
                         invocation -> {
                             if (attempts.incrementAndGet() < 3) {
-                                throw new DeadlockLoserDataAccessException("deadlock", null);
+                                throw new PessimisticLockingFailureException("deadlock", null);
                             }
                             return null;
                         })
@@ -100,7 +100,7 @@ class ProcessWeeklyFamilyRecapStepConfigTest {
 
         when(reader.read()).thenReturn(10L, null);
         when(processor.process(10L)).thenReturn(createRow());
-        doThrow(new DeadlockLoserDataAccessException("deadlock", null)).when(writer).write(any());
+        doThrow(new PessimisticLockingFailureException("deadlock", null)).when(writer).write(any());
 
         Step step = stepConfig.processWeeklyFamilyRecapStep();
         StepExecution stepExecution = createStepExecution("process-weekly-family-recap-step");

--- a/src/test/java/com/template/worker/jobs/reconciliation/listener/DbRedisReconciliationJobListenerTest.java
+++ b/src/test/java/com/template/worker/jobs/reconciliation/listener/DbRedisReconciliationJobListenerTest.java
@@ -1,0 +1,49 @@
+package com.template.worker.jobs.reconciliation.listener;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.dao.QueryTimeoutException;
+
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationLockManager;
+
+@ExtendWith(MockitoExtension.class)
+class DbRedisReconciliationJobListenerTest {
+
+    @Mock private DbRedisReconciliationLockManager lockManager;
+
+    @InjectMocks private DbRedisReconciliationJobListener jobListener;
+
+    @Test
+    @DisplayName("afterJob - 최종 락 정리 예외가 나도 후속 리스너를 막지 않도록 예외를 삼킨다")
+    void afterJob_swallowsCleanupException() {
+        JobExecution jobExecution =
+                new JobExecution(
+                        new JobInstance(1L, "db-redis-reconciliation-job"),
+                        new JobParametersBuilder()
+                                .addString("targetMonth", "2026-03-01")
+                                .toJobParameters());
+        jobExecution.setStatus(BatchStatus.FAILED);
+        jobExecution.getExecutionContext().putString("targetMonth", "2026-03-01");
+        jobExecution
+                .getExecutionContext()
+                .putString("lockKey", "batch:lock:reconciliation:2026-03-01");
+        jobExecution.getExecutionContext().putString("lockOwner", "owner");
+
+        doThrow(new QueryTimeoutException("Redis command timed out"))
+                .when(lockManager)
+                .releaseIfOwner("batch:lock:reconciliation:2026-03-01", "owner");
+
+        assertThatCode(() -> jobListener.afterJob(jobExecution)).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/template/worker/jobs/reconciliation/scheduler/DbRedisReconciliationSchedulerTest.java
+++ b/src/test/java/com/template/worker/jobs/reconciliation/scheduler/DbRedisReconciliationSchedulerTest.java
@@ -1,0 +1,42 @@
+package com.template.worker.jobs.reconciliation.scheduler;
+
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.template.worker.global.alert.BatchAlertService;
+import com.template.worker.global.launcher.BatchJobLauncher;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationJobConstants;
+
+@ExtendWith(MockitoExtension.class)
+class DbRedisReconciliationSchedulerTest {
+
+    @Mock private BatchJobLauncher launcher;
+    @Mock private BatchAlertService batchAlertService;
+
+    @Test
+    @DisplayName("runDbRedisReconciliationJob - launcher 예외가 나면 Slack 알람을 보낸다")
+    void runDbRedisReconciliationJob_sendsAlertWhenLauncherThrows() throws Exception {
+        DbRedisReconciliationScheduler scheduler =
+                new DbRedisReconciliationScheduler(launcher, batchAlertService);
+        doThrow(new RuntimeException("boom"))
+                .when(launcher)
+                .run(eq(DbRedisReconciliationJobConstants.JOB_NAME), anyMap());
+
+        scheduler.runDbRedisReconciliationJob();
+
+        verify(batchAlertService)
+                .sendSchedulerFailureAlert(
+                        eq("db-redis-reconciliation-scheduler"),
+                        argThat(value -> value.startsWith("targetMonth=")),
+                        eq("boom"));
+    }
+}

--- a/src/test/java/com/template/worker/jobs/reconciliation/step/InvalidateFamilyInfoAndRemainingStepConfigTest.java
+++ b/src/test/java/com/template/worker/jobs/reconciliation/step/InvalidateFamilyInfoAndRemainingStepConfigTest.java
@@ -1,0 +1,113 @@
+package com.template.worker.jobs.reconciliation.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobInstance;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.support.transaction.ResourcelessTransactionManager;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import com.template.worker.global.retry.BatchRetrySupport;
+import com.template.worker.jobs.reconciliation.reader.ReconciliationFamilyReader;
+import com.template.worker.jobs.reconciliation.support.DbRedisReconciliationProperties;
+import com.template.worker.jobs.reconciliation.writer.ReconciliationFamilyKeyInvalidationWriter;
+
+class InvalidateFamilyInfoAndRemainingStepConfigTest {
+
+    @Test
+    @DisplayName("invalidateFamilyInfoAndRemainingStep - Redis 오류가 두 번 나도 세 번째에 성공한다")
+    void invalidateFamilyInfoAndRemainingStep_retriesRedisFailuresThenCompletes() throws Exception {
+        JobRepository jobRepository = mock(JobRepository.class);
+        PlatformTransactionManager transactionManager = new ResourcelessTransactionManager();
+        ReconciliationFamilyReader reader = mock(ReconciliationFamilyReader.class);
+        ReconciliationFamilyKeyInvalidationWriter writer =
+                mock(ReconciliationFamilyKeyInvalidationWriter.class);
+        DbRedisReconciliationProperties properties = new DbRedisReconciliationProperties();
+        properties.setRedisChunkSize(2);
+
+        InvalidateFamilyInfoAndRemainingStepConfig stepConfig =
+                new InvalidateFamilyInfoAndRemainingStepConfig(
+                        jobRepository,
+                        transactionManager,
+                        reader,
+                        writer,
+                        properties,
+                        new BatchRetrySupport(3, 0L));
+
+        when(reader.read()).thenReturn(10L, 11L, null);
+        AtomicInteger attempts = new AtomicInteger();
+        doAnswer(
+                        invocation -> {
+                            if (attempts.incrementAndGet() < 3) {
+                                throw new RedisConnectionFailureException("redis");
+                            }
+                            return null;
+                        })
+                .when(writer)
+                .write(any());
+
+        Step step = stepConfig.invalidateFamilyInfoAndRemainingStep();
+        StepExecution stepExecution = createStepExecution("invalidate-family-info-step");
+
+        step.execute(stepExecution);
+
+        assertThat(stepExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(attempts).hasValue(3);
+    }
+
+    @Test
+    @DisplayName("invalidateFamilyInfoAndRemainingStep - Redis 오류가 한도를 넘으면 FAILED 처리된다")
+    void invalidateFamilyInfoAndRemainingStep_failsAfterRetryLimitExceeded() throws Exception {
+        JobRepository jobRepository = mock(JobRepository.class);
+        PlatformTransactionManager transactionManager = new ResourcelessTransactionManager();
+        ReconciliationFamilyReader reader = mock(ReconciliationFamilyReader.class);
+        ReconciliationFamilyKeyInvalidationWriter writer =
+                mock(ReconciliationFamilyKeyInvalidationWriter.class);
+        DbRedisReconciliationProperties properties = new DbRedisReconciliationProperties();
+        properties.setRedisChunkSize(2);
+
+        InvalidateFamilyInfoAndRemainingStepConfig stepConfig =
+                new InvalidateFamilyInfoAndRemainingStepConfig(
+                        jobRepository,
+                        transactionManager,
+                        reader,
+                        writer,
+                        properties,
+                        new BatchRetrySupport(3, 0L));
+
+        when(reader.read()).thenReturn(10L, null);
+        doThrow(new RedisConnectionFailureException("redis")).when(writer).write(any());
+
+        Step step = stepConfig.invalidateFamilyInfoAndRemainingStep();
+        StepExecution stepExecution = createStepExecution("invalidate-family-info-step");
+
+        step.execute(stepExecution);
+
+        assertThat(stepExecution.getStatus()).isEqualTo(BatchStatus.FAILED);
+    }
+
+    private StepExecution createStepExecution(String stepName) {
+        JobExecution jobExecution =
+                new JobExecution(
+                        new JobInstance(1L, "dbRedisReconciliationJob"),
+                        new JobParametersBuilder()
+                                .addString("targetMonth", "2026-03-01")
+                                .toJobParameters());
+        return new StepExecution(stepName, jobExecution);
+    }
+}

--- a/src/test/java/com/template/worker/jobs/usageprecreate/scheduler/MonthlyUsagePrecreateSchedulerTest.java
+++ b/src/test/java/com/template/worker/jobs/usageprecreate/scheduler/MonthlyUsagePrecreateSchedulerTest.java
@@ -2,6 +2,8 @@ package com.template.worker.jobs.usageprecreate.scheduler;
 
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -17,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.template.worker.global.alert.BatchAlertService;
 import com.template.worker.global.launcher.BatchJobLauncher;
 import com.template.worker.jobs.common.support.TargetMonthParameterSupport;
 import com.template.worker.jobs.usageprecreate.support.MonthlyUsagePrecreateJobConstants;
@@ -26,6 +29,7 @@ import com.template.worker.jobs.usageprecreate.support.MonthlyUsagePrecreateJobP
 class MonthlyUsagePrecreateSchedulerTest {
 
     @Mock private BatchJobLauncher launcher;
+    @Mock private BatchAlertService batchAlertService;
 
     @Test
     @DisplayName("runMonthlyUsagePrecreateJob - 월말이면 다음 달 1일을 targetMonth로 실행한다")
@@ -36,7 +40,7 @@ class MonthlyUsagePrecreateSchedulerTest {
                 new MonthlyUsagePrecreateJobParameterSupport(
                         new TargetMonthParameterSupport(), clock);
         MonthlyUsagePrecreateScheduler scheduler =
-                new MonthlyUsagePrecreateScheduler(launcher, parameterSupport);
+                new MonthlyUsagePrecreateScheduler(launcher, batchAlertService, parameterSupport);
 
         scheduler.runMonthlyUsagePrecreateJob();
 
@@ -55,11 +59,32 @@ class MonthlyUsagePrecreateSchedulerTest {
                 new MonthlyUsagePrecreateJobParameterSupport(
                         new TargetMonthParameterSupport(), clock);
         MonthlyUsagePrecreateScheduler scheduler =
-                new MonthlyUsagePrecreateScheduler(launcher, parameterSupport);
+                new MonthlyUsagePrecreateScheduler(launcher, batchAlertService, parameterSupport);
 
         scheduler.runMonthlyUsagePrecreateJob();
 
         verify(launcher, never()).run(anyString(), anyMap());
+    }
+
+    @Test
+    @DisplayName("runMonthlyUsagePrecreateJob - launcher 예외가 나면 Slack 알람을 보낸다")
+    void runMonthlyUsagePrecreateJob_sendsAlertWhenLauncherThrows() throws Exception {
+        Clock clock =
+                fixedClockAt(ZonedDateTime.of(2026, 3, 31, 23, 30, 0, 0, ZoneId.of("Asia/Seoul")));
+        MonthlyUsagePrecreateJobParameterSupport parameterSupport =
+                new MonthlyUsagePrecreateJobParameterSupport(
+                        new TargetMonthParameterSupport(), clock);
+        MonthlyUsagePrecreateScheduler scheduler =
+                new MonthlyUsagePrecreateScheduler(launcher, batchAlertService, parameterSupport);
+        doThrow(new RuntimeException("boom"))
+                .when(launcher)
+                .run(eq(MonthlyUsagePrecreateJobConstants.JOB_NAME), anyMap());
+
+        scheduler.runMonthlyUsagePrecreateJob();
+
+        verify(batchAlertService)
+                .sendSchedulerFailureAlert(
+                        "monthly-usage-precreate-scheduler", "targetMonth=2026-04-01", "boom");
     }
 
     private Clock fixedClockAt(ZonedDateTime dateTime) {

--- a/src/test/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateCustomerQuotaTaskletTest.java
+++ b/src/test/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateCustomerQuotaTaskletTest.java
@@ -61,7 +61,7 @@ class PrecreateCustomerQuotaTaskletTest {
 
     @Test
     @DisplayName("execute - 최신 snapshot의 monthly limit만 이어받고 차단 상태는 초기화한다")
-    void execute_copiesOnlyMonthlyLimitAndResetsBlockState() throws Exception {
+    void execute_copiesOnlyMonthlyLimitAndResetsBlockState() {
         jdbcTemplate.update(
                 "INSERT INTO family_member (id, family_id, customer_id, deleted_at) VALUES (1, 10,"
                         + " 100, NULL)");
@@ -122,7 +122,7 @@ class PrecreateCustomerQuotaTaskletTest {
 
     @Test
     @DisplayName("execute - 대상 월 row가 이미 있으면 중복 생성하지 않는다")
-    void execute_doesNotCreateDuplicateTargetMonthRow() throws Exception {
+    void execute_doesNotCreateDuplicateTargetMonthRow() {
         jdbcTemplate.update(
                 "INSERT INTO family_member (id, family_id, customer_id, deleted_at) VALUES (1, 10,"
                         + " 100, NULL)");
@@ -157,7 +157,7 @@ class PrecreateCustomerQuotaTaskletTest {
 
     @Test
     @DisplayName("execute - 최신 snapshot이 없어도 기본값으로 생성한다")
-    void execute_createsDefaultRowWhenSnapshotDoesNotExist() throws Exception {
+    void execute_createsDefaultRowWhenSnapshotDoesNotExist() {
         jdbcTemplate.update(
                 "INSERT INTO family_member (id, family_id, customer_id, deleted_at) VALUES (1, 10,"
                         + " 100, NULL)");
@@ -199,7 +199,7 @@ class PrecreateCustomerQuotaTaskletTest {
 
     @Test
     @DisplayName("execute - QueryTimeoutException 이 두 번 나도 세 번째에 성공한다")
-    void execute_retriesQueryTimeoutExceptionThenSucceeds() throws Exception {
+    void execute_retriesQueryTimeoutExceptionThenSucceeds() {
         NamedParameterJdbcTemplate namedParameterJdbcTemplate =
                 mock(NamedParameterJdbcTemplate.class);
         PrecreateCustomerQuotaTasklet retryTasklet =
@@ -244,8 +244,7 @@ class PrecreateCustomerQuotaTaskletTest {
     }
 
     private void executeCustomerTasklet(
-            PrecreateCustomerQuotaTasklet retryTasklet, StepExecution stepExecution)
-            throws Exception {
+            PrecreateCustomerQuotaTasklet retryTasklet, StepExecution stepExecution) {
         retryTasklet.execute(
                 new StepContribution(stepExecution),
                 new ChunkContext(new StepContext(stepExecution)));

--- a/src/test/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateCustomerQuotaTaskletTest.java
+++ b/src/test/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateCustomerQuotaTaskletTest.java
@@ -1,7 +1,12 @@
 package com.template.worker.jobs.usageprecreate.tasklet;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
@@ -22,10 +27,13 @@ import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.dao.QueryTimeoutException;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
+import com.template.worker.global.retry.BatchRetrySupport;
 import com.template.worker.jobs.usageprecreate.support.MonthlyUsagePrecreateJobConstants;
 import com.template.worker.jobs.usageprecreate.support.MonthlyUsagePrecreateJobParameterSupport;
 
@@ -43,7 +51,9 @@ class PrecreateCustomerQuotaTaskletTest {
         jdbcTemplate = new JdbcTemplate(dataSource);
         tasklet =
                 new PrecreateCustomerQuotaTasklet(
-                        new NamedParameterJdbcTemplate(dataSource), parameterSupport);
+                        new NamedParameterJdbcTemplate(dataSource),
+                        parameterSupport,
+                        new BatchRetrySupport(3, 0L));
 
         dropTables();
         createTables();
@@ -185,6 +195,56 @@ class PrecreateCustomerQuotaTaskletTest {
                                     + " AND family_id = 10 AND current_month = DATE '2026-04-01'",
                                 String.class))
                 .isNull();
+    }
+
+    @Test
+    @DisplayName("execute - QueryTimeoutException 이 두 번 나도 세 번째에 성공한다")
+    void execute_retriesQueryTimeoutExceptionThenSucceeds() throws Exception {
+        NamedParameterJdbcTemplate namedParameterJdbcTemplate =
+                mock(NamedParameterJdbcTemplate.class);
+        PrecreateCustomerQuotaTasklet retryTasklet =
+                new PrecreateCustomerQuotaTasklet(
+                        namedParameterJdbcTemplate, parameterSupport, new BatchRetrySupport(3, 0L));
+        StepExecution stepExecution = createStepExecution(LocalDate.of(2026, 4, 1));
+
+        when(namedParameterJdbcTemplate.update(anyString(), any(MapSqlParameterSource.class)))
+                .thenThrow(new QueryTimeoutException("timeout"))
+                .thenThrow(new QueryTimeoutException("timeout"))
+                .thenReturn(1);
+
+        retryTasklet.beforeStep(stepExecution);
+        retryTasklet.execute(
+                new StepContribution(stepExecution),
+                new ChunkContext(new StepContext(stepExecution)));
+
+        verify(namedParameterJdbcTemplate, times(3))
+                .update(anyString(), any(MapSqlParameterSource.class));
+    }
+
+    @Test
+    @DisplayName("execute - QueryTimeoutException 이 재시도 한도를 넘으면 예외를 전파한다")
+    void execute_throwsWhenQueryTimeoutExceedsRetryLimit() {
+        NamedParameterJdbcTemplate namedParameterJdbcTemplate =
+                mock(NamedParameterJdbcTemplate.class);
+        PrecreateCustomerQuotaTasklet retryTasklet =
+                new PrecreateCustomerQuotaTasklet(
+                        namedParameterJdbcTemplate, parameterSupport, new BatchRetrySupport(3, 0L));
+        StepExecution stepExecution = createStepExecution(LocalDate.of(2026, 4, 1));
+
+        when(namedParameterJdbcTemplate.update(anyString(), any(MapSqlParameterSource.class)))
+                .thenThrow(new QueryTimeoutException("timeout"));
+
+        retryTasklet.beforeStep(stepExecution);
+
+        assertThatThrownBy(
+                        () ->
+                                retryTasklet.execute(
+                                        new StepContribution(stepExecution),
+                                        new ChunkContext(new StepContext(stepExecution))))
+                .isInstanceOf(QueryTimeoutException.class);
+
+        verify(namedParameterJdbcTemplate, times(3))
+                .update(anyString(), any(MapSqlParameterSource.class));
     }
 
     private StepExecution createStepExecution(LocalDate targetMonth) {

--- a/src/test/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateCustomerQuotaTaskletTest.java
+++ b/src/test/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateCustomerQuotaTaskletTest.java
@@ -236,15 +236,19 @@ class PrecreateCustomerQuotaTaskletTest {
 
         retryTasklet.beforeStep(stepExecution);
 
-        assertThatThrownBy(
-                        () ->
-                                retryTasklet.execute(
-                                        new StepContribution(stepExecution),
-                                        new ChunkContext(new StepContext(stepExecution))))
+        assertThatThrownBy(() -> executeCustomerTasklet(retryTasklet, stepExecution))
                 .isInstanceOf(QueryTimeoutException.class);
 
         verify(namedParameterJdbcTemplate, times(3))
                 .update(anyString(), any(MapSqlParameterSource.class));
+    }
+
+    private void executeCustomerTasklet(
+            PrecreateCustomerQuotaTasklet retryTasklet, StepExecution stepExecution)
+            throws Exception {
+        retryTasklet.execute(
+                new StepContribution(stepExecution),
+                new ChunkContext(new StepContext(stepExecution)));
     }
 
     private StepExecution createStepExecution(LocalDate targetMonth) {

--- a/src/test/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateFamilyQuotaTaskletTest.java
+++ b/src/test/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateFamilyQuotaTaskletTest.java
@@ -1,7 +1,13 @@
 package com.template.worker.jobs.usageprecreate.tasklet;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
@@ -22,10 +28,13 @@ import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.scope.context.StepContext;
+import org.springframework.dao.DeadlockLoserDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
+import com.template.worker.global.retry.BatchRetrySupport;
 import com.template.worker.jobs.usageprecreate.support.MonthlyUsagePrecreateJobConstants;
 import com.template.worker.jobs.usageprecreate.support.MonthlyUsagePrecreateJobParameterSupport;
 
@@ -43,7 +52,9 @@ class PrecreateFamilyQuotaTaskletTest {
         jdbcTemplate = new JdbcTemplate(dataSource);
         tasklet =
                 new PrecreateFamilyQuotaTasklet(
-                        new NamedParameterJdbcTemplate(dataSource), parameterSupport);
+                        new NamedParameterJdbcTemplate(dataSource),
+                        parameterSupport,
+                        new BatchRetrySupport(3, 0L));
 
         dropTables();
         createTables();
@@ -166,6 +177,61 @@ class PrecreateFamilyQuotaTaskletTest {
                                         MonthlyUsagePrecreateJobConstants
                                                 .JOB_CONTEXT_SKIPPED_FAMILY_QUOTA_COUNT))
                 .isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("execute - Deadlock 예외가 두 번 나도 세 번째에 성공한다")
+    void execute_retriesDeadlockThenSucceeds() throws Exception {
+        NamedParameterJdbcTemplate namedParameterJdbcTemplate =
+                mock(NamedParameterJdbcTemplate.class);
+        PrecreateFamilyQuotaTasklet retryTasklet =
+                new PrecreateFamilyQuotaTasklet(
+                        namedParameterJdbcTemplate, parameterSupport, new BatchRetrySupport(3, 0L));
+        StepExecution stepExecution = createStepExecution(LocalDate.of(2026, 4, 1));
+
+        when(namedParameterJdbcTemplate.queryForObject(
+                        anyString(), any(MapSqlParameterSource.class), eq(Long.class)))
+                .thenThrow(new DeadlockLoserDataAccessException("deadlock", null))
+                .thenThrow(new DeadlockLoserDataAccessException("deadlock", null))
+                .thenReturn(0L);
+        when(namedParameterJdbcTemplate.update(anyString(), any(MapSqlParameterSource.class)))
+                .thenReturn(1);
+
+        retryTasklet.beforeStep(stepExecution);
+        retryTasklet.execute(
+                new StepContribution(stepExecution),
+                new ChunkContext(new StepContext(stepExecution)));
+
+        verify(namedParameterJdbcTemplate, times(3))
+                .queryForObject(anyString(), any(MapSqlParameterSource.class), eq(Long.class));
+        verify(namedParameterJdbcTemplate).update(anyString(), any(MapSqlParameterSource.class));
+    }
+
+    @Test
+    @DisplayName("execute - Deadlock 예외가 재시도 한도를 넘으면 예외를 전파한다")
+    void execute_throwsWhenDeadlockExceedsRetryLimit() {
+        NamedParameterJdbcTemplate namedParameterJdbcTemplate =
+                mock(NamedParameterJdbcTemplate.class);
+        PrecreateFamilyQuotaTasklet retryTasklet =
+                new PrecreateFamilyQuotaTasklet(
+                        namedParameterJdbcTemplate, parameterSupport, new BatchRetrySupport(3, 0L));
+        StepExecution stepExecution = createStepExecution(LocalDate.of(2026, 4, 1));
+
+        when(namedParameterJdbcTemplate.queryForObject(
+                        anyString(), any(MapSqlParameterSource.class), eq(Long.class)))
+                .thenThrow(new DeadlockLoserDataAccessException("deadlock", null));
+
+        retryTasklet.beforeStep(stepExecution);
+
+        assertThatThrownBy(
+                        () ->
+                                retryTasklet.execute(
+                                        new StepContribution(stepExecution),
+                                        new ChunkContext(new StepContext(stepExecution))))
+                .isInstanceOf(DeadlockLoserDataAccessException.class);
+
+        verify(namedParameterJdbcTemplate, times(3))
+                .queryForObject(anyString(), any(MapSqlParameterSource.class), eq(Long.class));
     }
 
     private StepExecution createStepExecution(LocalDate targetMonth) {

--- a/src/test/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateFamilyQuotaTaskletTest.java
+++ b/src/test/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateFamilyQuotaTaskletTest.java
@@ -62,7 +62,7 @@ class PrecreateFamilyQuotaTaskletTest {
 
     @Test
     @DisplayName("execute - 최신 snapshot의 total quota를 이어받고 used bytes는 0으로 생성한다")
-    void execute_copiesLatestQuotaSnapshot() throws Exception {
+    void execute_copiesLatestQuotaSnapshot() {
         jdbcTemplate.update("INSERT INTO family (id, deleted_at) VALUES (10, NULL)");
         jdbcTemplate.update(
                 "INSERT INTO family_quota (id, family_id, current_month, total_quota_bytes,"
@@ -114,7 +114,7 @@ class PrecreateFamilyQuotaTaskletTest {
 
     @Test
     @DisplayName("execute - 대상 월 row가 이미 있으면 중복 생성하지 않는다")
-    void execute_doesNotCreateDuplicateTargetMonthRow() throws Exception {
+    void execute_doesNotCreateDuplicateTargetMonthRow() {
         jdbcTemplate.update("INSERT INTO family (id, deleted_at) VALUES (10, NULL)");
         jdbcTemplate.update(
                 "INSERT INTO family_quota (id, family_id, current_month, total_quota_bytes,"
@@ -146,7 +146,7 @@ class PrecreateFamilyQuotaTaskletTest {
 
     @Test
     @DisplayName("execute - 최신 snapshot이 없으면 건너뛰고 skip count를 남긴다")
-    void execute_skipsFamilyWhenSnapshotDoesNotExist() throws Exception {
+    void execute_skipsFamilyWhenSnapshotDoesNotExist() {
         jdbcTemplate.update("INSERT INTO family (id, deleted_at) VALUES (10, NULL)");
 
         StepExecution stepExecution = createStepExecution(LocalDate.of(2026, 4, 1));
@@ -181,7 +181,7 @@ class PrecreateFamilyQuotaTaskletTest {
 
     @Test
     @DisplayName("execute - Deadlock 예외가 두 번 나도 세 번째에 성공한다")
-    void execute_retriesDeadlockThenSucceeds() throws Exception {
+    void execute_retriesDeadlockThenSucceeds() {
         NamedParameterJdbcTemplate namedParameterJdbcTemplate =
                 mock(NamedParameterJdbcTemplate.class);
         PrecreateFamilyQuotaTasklet retryTasklet =
@@ -231,8 +231,7 @@ class PrecreateFamilyQuotaTaskletTest {
     }
 
     private void executeFamilyTasklet(
-            PrecreateFamilyQuotaTasklet retryTasklet, StepExecution stepExecution)
-            throws Exception {
+            PrecreateFamilyQuotaTasklet retryTasklet, StepExecution stepExecution) {
         retryTasklet.execute(
                 new StepContribution(stepExecution),
                 new ChunkContext(new StepContext(stepExecution)));

--- a/src/test/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateFamilyQuotaTaskletTest.java
+++ b/src/test/java/com/template/worker/jobs/usageprecreate/tasklet/PrecreateFamilyQuotaTaskletTest.java
@@ -28,7 +28,7 @@ import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.batch.core.scope.context.StepContext;
-import org.springframework.dao.DeadlockLoserDataAccessException;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -191,8 +191,8 @@ class PrecreateFamilyQuotaTaskletTest {
 
         when(namedParameterJdbcTemplate.queryForObject(
                         anyString(), any(MapSqlParameterSource.class), eq(Long.class)))
-                .thenThrow(new DeadlockLoserDataAccessException("deadlock", null))
-                .thenThrow(new DeadlockLoserDataAccessException("deadlock", null))
+                .thenThrow(new PessimisticLockingFailureException("deadlock", null))
+                .thenThrow(new PessimisticLockingFailureException("deadlock", null))
                 .thenReturn(0L);
         when(namedParameterJdbcTemplate.update(anyString(), any(MapSqlParameterSource.class)))
                 .thenReturn(1);
@@ -219,19 +219,23 @@ class PrecreateFamilyQuotaTaskletTest {
 
         when(namedParameterJdbcTemplate.queryForObject(
                         anyString(), any(MapSqlParameterSource.class), eq(Long.class)))
-                .thenThrow(new DeadlockLoserDataAccessException("deadlock", null));
+                .thenThrow(new PessimisticLockingFailureException("deadlock", null));
 
         retryTasklet.beforeStep(stepExecution);
 
-        assertThatThrownBy(
-                        () ->
-                                retryTasklet.execute(
-                                        new StepContribution(stepExecution),
-                                        new ChunkContext(new StepContext(stepExecution))))
-                .isInstanceOf(DeadlockLoserDataAccessException.class);
+        assertThatThrownBy(() -> executeFamilyTasklet(retryTasklet, stepExecution))
+                .isInstanceOf(PessimisticLockingFailureException.class);
 
         verify(namedParameterJdbcTemplate, times(3))
                 .queryForObject(anyString(), any(MapSqlParameterSource.class), eq(Long.class));
+    }
+
+    private void executeFamilyTasklet(
+            PrecreateFamilyQuotaTasklet retryTasklet, StepExecution stepExecution)
+            throws Exception {
+        retryTasklet.execute(
+                new StepContribution(stepExecution),
+                new ChunkContext(new StepContext(stepExecution)));
     }
 
     private StepExecution createStepExecution(LocalDate targetMonth) {

--- a/src/test/java/com/template/worker/jobs/usagereset/scheduler/MonthlyUsageResetSchedulerTest.java
+++ b/src/test/java/com/template/worker/jobs/usagereset/scheduler/MonthlyUsageResetSchedulerTest.java
@@ -1,0 +1,42 @@
+package com.template.worker.jobs.usagereset.scheduler;
+
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.template.worker.global.alert.BatchAlertService;
+import com.template.worker.global.launcher.BatchJobLauncher;
+import com.template.worker.jobs.usagereset.support.MonthlyUsageResetJobConstants;
+
+@ExtendWith(MockitoExtension.class)
+class MonthlyUsageResetSchedulerTest {
+
+    @Mock private BatchJobLauncher launcher;
+    @Mock private BatchAlertService batchAlertService;
+
+    @Test
+    @DisplayName("runMonthlyUsageResetJob - launcher 예외가 나면 Slack 알람을 보낸다")
+    void runMonthlyUsageResetJob_sendsAlertWhenLauncherThrows() throws Exception {
+        MonthlyUsageResetScheduler scheduler =
+                new MonthlyUsageResetScheduler(launcher, batchAlertService);
+        doThrow(new RuntimeException("boom"))
+                .when(launcher)
+                .run(eq(MonthlyUsageResetJobConstants.JOB_NAME), anyMap());
+
+        scheduler.runMonthlyUsageResetJob();
+
+        verify(batchAlertService)
+                .sendSchedulerFailureAlert(
+                        eq("monthly-usage-reset-scheduler"),
+                        argThat(value -> value.startsWith("targetMonth=")),
+                        eq("boom"));
+    }
+}


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #17 
- jira: DABOM-472

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
- `dabom-batch-core` 주요 배치 잡에 Slack 실패 알람을 연동해 최종 실패를 빠르게 인지할 수 있게 한다.
- Redis/DB 일시 장애에 대해 Step/Tasklet 재시도를 적용해 일회성 인프라 오류로 인한 배치 실패를 줄인다.
- 운영 알람 문구를 root cause 기준으로 정리해 장애 유형을 사람이 바로 읽을 수 있게 만든다.

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->

- 공통 알람 인프라 추가
  - `BatchAlertService` 추가: Slack webhook 전송, 멀티라인 메시지 포맷, 알람 미설정/전송 실패 안전 처리
  - `JobFailureAlertListener` 추가: `FAILED` Job만 감지해 파라미터/요약/원본 예외와 함께 알람 발송
- 재시도 공통 지원 추가
  - `BatchRetrySupport` 추가: retry limit/backoff, Step fault-tolerant 설정, Tasklet용 `RetryTemplate` 공통화
  - `batch.yml`, `application.yml`에 Slack/retry 설정 추가
- 운영 배치 연동
  - `monthly-usage-reset`, `monthly-usage-precreate`, `db-redis-reconciliation`, `weekly-family-recap`, `monthly-family-recap` Job에 실패 알람 listener 등록
  - 5개 스케줄러 catch 블록에 Slack 알람 연동
  - reconciliation/recap/reset chunk step에 retry 적용
  - `monthly-usage-precreate` tasklet 2개에 내부 retry 적용
- 운영 안정화 보강
  - 각 Job의 final lock cleanup listener에서 Redis 예외가 나도 후속 알람 리스너를 막지 않도록 예외를 삼키고 로그만 남기게 수정
  - Redis timeout/connection failure를 구분해 한글 요약 알람이 나가도록 root cause 분기 보강
- 테스트 추가/보강
  - Slack 알람 서비스/리스너 테스트 추가
  - 스케줄러 실패 알람 테스트 추가
  - Tasklet retry 테스트 추가
  - representative chunk-step retry 테스트 추가
  - cleanup listener 예외 삼킴 테스트 추가

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```java
private String buildSummary(Throwable exception, Throwable rootCause) {
    boolean retryExhausted = containsRetryExhaustedSignal(exception);

    if (rootCause instanceof RedisConnectionFailureException) {
        return retryExhausted
                ? String.format("Redis 연결 실패로 재시도 %d회 후 최종 실패", batchRetrySupport.getRetryLimit())
                : "Redis 연결 실패";
    }
    if (isRedisTimeout(rootCause)) {
        return retryExhausted
                ? String.format("Redis 명령 타임아웃으로 재시도 %d회 후 최종 실패", batchRetrySupport.getRetryLimit())
                : "Redis 명령 타임아웃";
    }
    // ...
}
```

- 알람 요약은 Spring Batch wrapper 예외가 아니라 root cause 기준으로 만든다.
- Redis timeout은 Spring이 `QueryTimeoutException`으로 번역할 수 있어 DB timeout과 별도 분기한다.
- final lock cleanup은 운영 보조 로직으로 취급해 실패해도 최종 실패 알람을 막지 않게 한다.

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- 알람은 “최종 실패”만 보내도록 했습니다. retry 중간 실패나 lock not acquired 정상 종료에는 알람이 나가지 않는 점을 중심으로 봐주시면 좋겠습니다.
- Redis timeout이 `QueryTimeoutException`으로 번역되는 케이스를 별도 처리했습니다. 예외 요약 분기가 과한지 여부도 같이 확인 부탁드립니다.
---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [ ] 전체 변경사항이 500줄을 넘지 않는가?

**배치 코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → BatchJobLauncher → Job → Step → Reader/Processor/Writer`)
- [x] 모든 Job에 `JobResultListener`를 등록했는가?
- [x] Reader/Processor/Writer가 각각 단일 책임만 수행하는가?
- [x] Job/Step 이름이 kebab-case인가?
- [x] 하나의 Config 파일에 하나의 Job/Step만 정의했는가?

**테스트**
- [x] 신규 배치 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
