### PR TITLE
[DABOM-514] recap-job 성능 개선

### DIFF
--- a/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
@@ -64,7 +64,8 @@ public class MonthlyFamilyRecapProcessor
                 .collect(Collectors.toList());
     }
 
-    private MonthlyFamilyRecapRow toRow(Long familyId, MonthlyFamilyRecapSourceMetrics sourceMetrics) {
+    private MonthlyFamilyRecapRow toRow(
+            Long familyId, MonthlyFamilyRecapSourceMetrics sourceMetrics) {
         // writer 진입 전에 집계값 검증
         validateSourceMetrics(familyId, sourceMetrics);
 

--- a/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.StepExecutionListener;
@@ -51,10 +52,19 @@ public class MonthlyFamilyRecapProcessor
 
     @Override
     public MonthlyFamilyRecapRow process(Long familyId) {
-        // 가족별 원본 집계값 조회
-        MonthlyFamilyRecapSourceMetrics sourceMetrics =
-                aggregationRepository.aggregate(familyId, targetMonth);
+        return toRow(familyId, aggregationRepository.aggregate(familyId, targetMonth));
+    }
 
+    public List<MonthlyFamilyRecapRow> processAll(List<Long> familyIds) {
+        Map<Long, MonthlyFamilyRecapSourceMetrics> sourceMetricsByFamily =
+                aggregationRepository.aggregate(familyIds, targetMonth);
+
+        return familyIds.stream()
+                .map(familyId -> toRow(familyId, sourceMetricsByFamily.get(familyId)))
+                .collect(Collectors.toList());
+    }
+
+    private MonthlyFamilyRecapRow toRow(Long familyId, MonthlyFamilyRecapSourceMetrics sourceMetrics) {
         // writer 진입 전에 집계값 검증
         validateSourceMetrics(familyId, sourceMetrics);
 

--- a/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/processor/MonthlyFamilyRecapProcessor.java
@@ -6,7 +6,6 @@ import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.StepExecutionListener;
@@ -61,7 +60,7 @@ public class MonthlyFamilyRecapProcessor
 
         return familyIds.stream()
                 .map(familyId -> toRow(familyId, sourceMetricsByFamily.get(familyId)))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private MonthlyFamilyRecapRow toRow(

--- a/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
@@ -517,13 +517,11 @@ public class MonthlyFamilyRecapAggregationRepository {
         List<DateRange> ranges = resolvePartialRanges(targetMonth);
         MapSqlParameterSource params = new MapSqlParameterSource().addValue("familyIds", familyIds);
         addTimestamp(
-                params,
-                "leftRangeStart",
-                ranges.size() > 0 ? ranges.get(0).startInclusive() : null);
+                params, "leftRangeStart", ranges.isEmpty() ? null : ranges.get(0).startInclusive());
         addTimestamp(
                 params,
                 "leftRangeEndExclusive",
-                ranges.size() > 0 ? ranges.get(0).endExclusive() : null);
+                ranges.isEmpty() ? null : ranges.get(0).endExclusive());
         addTimestamp(
                 params,
                 "rightRangeStart",

--- a/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
@@ -36,8 +36,10 @@ public class MonthlyFamilyRecapAggregationRepository {
 
     private static final DateTimeFormatter ISO_DATE_TIME = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
     private static final String APPROVED_APPEAL_COUNT = "approved_appeal_count";
-    private static final String PARTIAL_EVENT_TIME_CONDITION = buildPartialRangeCondition("event_time");
-    private static final String PARTIAL_CREATED_AT_CONDITION = buildPartialRangeCondition("created_at");
+    private static final String PARTIAL_EVENT_TIME_CONDITION =
+            buildPartialRangeCondition("event_time");
+    private static final String PARTIAL_CREATED_AT_CONDITION =
+            buildPartialRangeCondition("created_at");
     private static final String PARTIAL_COMPLETED_AT_CONDITION =
             buildPartialRangeCondition("completed_at");
     private static final String PARTIAL_MR_RESOLVED_AT_CONDITION =
@@ -276,7 +278,9 @@ public class MonthlyFamilyRecapAggregationRepository {
                         .addValue("familyIds", familyIds)
                         .addValue("monthStartDate", Date.valueOf(targetMonth))
                         .addValue("monthEndExclusiveDate", Date.valueOf(monthEndExclusiveDate))
-                        .addValue("lastFullWeekStartDate", Date.valueOf(monthEndExclusiveDate.minusDays(7)))
+                        .addValue(
+                                "lastFullWeekStartDate",
+                                Date.valueOf(monthEndExclusiveDate.minusDays(7)))
                         .addValue("overlapStartDate", Date.valueOf(targetMonth.minusDays(6)))
                         .addValue("monthStart", Timestamp.valueOf(monthStart))
                         .addValue("monthEndExclusive", Timestamp.valueOf(monthEndExclusive));
@@ -334,7 +338,8 @@ public class MonthlyFamilyRecapAggregationRepository {
 
     private void applyFullWeekSnapshots(
             MapSqlParameterSource params, Map<Long, MutableMonthlyMetrics> metricsByFamily) {
-        jdbcTemplate.queryForList(READ_FULL_WEEKLY_RECAP_ROWS_SQL, params)
+        jdbcTemplate
+                .queryForList(READ_FULL_WEEKLY_RECAP_ROWS_SQL, params)
                 .forEach(
                         row ->
                                 metricsByFamily
@@ -357,7 +362,8 @@ public class MonthlyFamilyRecapAggregationRepository {
 
     private void applyQuotaSnapshot(
             MapSqlParameterSource params, Map<Long, MutableMonthlyMetrics> metricsByFamily) {
-        jdbcTemplate.queryForList(READ_WEEKLY_QUOTA_ROWS_SQL, params)
+        jdbcTemplate
+                .queryForList(READ_WEEKLY_QUOTA_ROWS_SQL, params)
                 .forEach(
                         row -> {
                             MutableMonthlyMetrics metrics =
@@ -371,7 +377,8 @@ public class MonthlyFamilyRecapAggregationRepository {
 
     private void applyFallbackFamilyQuota(
             MapSqlParameterSource params, Map<Long, MutableMonthlyMetrics> metricsByFamily) {
-        jdbcTemplate.queryForList(READ_FAMILY_QUOTA_BYTES_SQL, params)
+        jdbcTemplate
+                .queryForList(READ_FAMILY_QUOTA_BYTES_SQL, params)
                 .forEach(
                         row -> {
                             MutableMonthlyMetrics metrics =
@@ -385,15 +392,16 @@ public class MonthlyFamilyRecapAggregationRepository {
 
     private void applyPartialUsage(
             MapSqlParameterSource params, Map<Long, MutableMonthlyMetrics> metricsByFamily) {
-        jdbcTemplate.queryForList(READ_TOTAL_USED_BYTES_IN_RANGE_SQL, params)
+        jdbcTemplate
+                .queryForList(READ_TOTAL_USED_BYTES_IN_RANGE_SQL, params)
                 .forEach(
                         row ->
-                                metricsByFamily
-                                                .get(toLong(row.get("family_id")))
+                                metricsByFamily.get(toLong(row.get("family_id")))
                                                 .partialTotalUsedBytes +=
                                         toLong(row.get("total_used_bytes")));
 
-        jdbcTemplate.queryForList(READ_USAGE_BY_WEEKDAY_IN_RANGE_SQL, params)
+        jdbcTemplate
+                .queryForList(READ_USAGE_BY_WEEKDAY_IN_RANGE_SQL, params)
                 .forEach(
                         row -> {
                             MutableMonthlyMetrics metrics =
@@ -405,7 +413,8 @@ public class MonthlyFamilyRecapAggregationRepository {
                                             + toLong(row.get("total_bytes")));
                         });
 
-        jdbcTemplate.queryForList(READ_USAGE_BY_HOUR_IN_RANGE_SQL, params)
+        jdbcTemplate
+                .queryForList(READ_USAGE_BY_HOUR_IN_RANGE_SQL, params)
                 .forEach(
                         row -> {
                             MutableMonthlyMetrics metrics =
@@ -464,7 +473,8 @@ public class MonthlyFamilyRecapAggregationRepository {
 
     private void applyApprovedAppealEvents(
             MapSqlParameterSource params, Map<Long, MutableMonthlyMetrics> metricsByFamily) {
-        jdbcTemplate.queryForList(READ_APPROVED_APPEAL_EVENTS_SQL, params)
+        jdbcTemplate
+                .queryForList(READ_APPROVED_APPEAL_EVENTS_SQL, params)
                 .forEach(
                         row ->
                                 metricsByFamily
@@ -488,7 +498,8 @@ public class MonthlyFamilyRecapAggregationRepository {
             MapSqlParameterSource params,
             Map<Long, MutableMonthlyMetrics> metricsByFamily,
             ObjIntConsumer<MutableMonthlyMetrics> countSetter) {
-        jdbcTemplate.queryForList(sql, params)
+        jdbcTemplate
+                .queryForList(sql, params)
                 .forEach(
                         row ->
                                 countSetter.accept(
@@ -497,18 +508,26 @@ public class MonthlyFamilyRecapAggregationRepository {
     }
 
     private boolean hasPartialRange(MapSqlParameterSource params) {
-        return params.getValue("leftRangeStart") != null || params.getValue("rightRangeStart") != null;
+        return params.getValue("leftRangeStart") != null
+                || params.getValue("rightRangeStart") != null;
     }
 
-    private MapSqlParameterSource buildPartialRangeParams(List<Long> familyIds, LocalDate targetMonth) {
+    private MapSqlParameterSource buildPartialRangeParams(
+            List<Long> familyIds, LocalDate targetMonth) {
         List<DateRange> ranges = resolvePartialRanges(targetMonth);
         MapSqlParameterSource params = new MapSqlParameterSource().addValue("familyIds", familyIds);
-        addTimestamp(params, "leftRangeStart", ranges.size() > 0 ? ranges.get(0).startInclusive() : null);
+        addTimestamp(
+                params,
+                "leftRangeStart",
+                ranges.size() > 0 ? ranges.get(0).startInclusive() : null);
         addTimestamp(
                 params,
                 "leftRangeEndExclusive",
                 ranges.size() > 0 ? ranges.get(0).endExclusive() : null);
-        addTimestamp(params, "rightRangeStart", ranges.size() > 1 ? ranges.get(1).startInclusive() : null);
+        addTimestamp(
+                params,
+                "rightRangeStart",
+                ranges.size() > 1 ? ranges.get(1).startInclusive() : null);
         addTimestamp(
                 params,
                 "rightRangeEndExclusive",
@@ -526,7 +545,9 @@ public class MonthlyFamilyRecapAggregationRepository {
 
         List<DateRange> ranges = new ArrayList<>();
         if (monthStartDate.isBefore(firstFullWeekStart)) {
-            ranges.add(new DateRange(monthStartDate.atStartOfDay(), firstFullWeekStart.atStartOfDay()));
+            ranges.add(
+                    new DateRange(
+                            monthStartDate.atStartOfDay(), firstFullWeekStart.atStartOfDay()));
         }
         if (rightPartialWeekStart.isBefore(monthEndExclusiveDate)) {
             ranges.add(
@@ -674,7 +695,8 @@ public class MonthlyFamilyRecapAggregationRepository {
             MonthlyUsagePeakCandidate peakCandidate = MonthlyUsagePeakCandidate.empty();
             for (Map.Entry<Integer, Long> entry : partialUsageByHour.entrySet()) {
                 MonthlyUsagePeakCandidate candidate =
-                        new MonthlyUsagePeakCandidate(entry.getKey(), entry.getKey() + 1, entry.getValue());
+                        new MonthlyUsagePeakCandidate(
+                                entry.getKey(), entry.getKey() + 1, entry.getValue());
                 if (candidate.isBetterThan(peakCandidate)) {
                     peakCandidate = candidate;
                 }
@@ -694,7 +716,8 @@ public class MonthlyFamilyRecapAggregationRepository {
                 completedMissionCount += snapshot.missionCompletedCount();
                 rejectedRequestCount += snapshot.missionRejectedCount();
             }
-            return new MonthlyMissionSummary(totalMissionCount, completedMissionCount, rejectedRequestCount);
+            return new MonthlyMissionSummary(
+                    totalMissionCount, completedMissionCount, rejectedRequestCount);
         }
 
         private MonthlyAppealSummary toAppealSummary() {
@@ -710,7 +733,8 @@ public class MonthlyFamilyRecapAggregationRepository {
         }
 
         private MonthlyAppealHighlights toAppealHighlights() {
-            return new MonthlyAppealHighlights(buildTopSuccessfulRequester(), buildTopAcceptedApprover());
+            return new MonthlyAppealHighlights(
+                    buildTopSuccessfulRequester(), buildTopAcceptedApprover());
         }
 
         private MonthlyAppealHighlights.TopSuccessfulRequester buildTopSuccessfulRequester() {
@@ -719,7 +743,8 @@ public class MonthlyFamilyRecapAggregationRepository {
                 if (event.requesterId() == null) {
                     continue;
                 }
-                summaries.computeIfAbsent(
+                summaries
+                        .computeIfAbsent(
                                 event.requesterId(),
                                 requesterId ->
                                         new AppealActorSummary(
@@ -739,7 +764,9 @@ public class MonthlyFamilyRecapAggregationRepository {
                                             summary.actorName,
                                             summary.events.size(),
                                             summary.events.stream()
-                                                    .sorted(AppealActorSummary.RECENT_APPROVED_COMPARATOR)
+                                                    .sorted(
+                                                            AppealActorSummary
+                                                                    .RECENT_APPROVED_COMPARATOR)
                                                     .limit(3)
                                                     .map(
                                                             event ->
@@ -760,7 +787,8 @@ public class MonthlyFamilyRecapAggregationRepository {
                 if (event.approverId() == null) {
                     continue;
                 }
-                summaries.computeIfAbsent(
+                summaries
+                        .computeIfAbsent(
                                 event.approverId(),
                                 approverId ->
                                         new AppealActorSummary(
@@ -780,7 +808,9 @@ public class MonthlyFamilyRecapAggregationRepository {
                                             summary.actorName,
                                             summary.events.size(),
                                             summary.events.stream()
-                                                    .sorted(AppealActorSummary.RECENT_ACCEPTED_COMPARATOR)
+                                                    .sorted(
+                                                            AppealActorSummary
+                                                                    .RECENT_ACCEPTED_COMPARATOR)
                                                     .limit(3)
                                                     .map(
                                                             event ->
@@ -816,28 +846,41 @@ public class MonthlyFamilyRecapAggregationRepository {
         private static final Comparator<AppealActorSummary> REQUESTER_COMPARATOR =
                 Comparator.comparingInt(AppealActorSummary::count)
                         .reversed()
-                        .thenComparing(AppealActorSummary::latestResolvedAt, Comparator.reverseOrder())
-                        .thenComparing(AppealActorSummary::actorId, Comparator.nullsLast(Long::compareTo));
+                        .thenComparing(
+                                AppealActorSummary::latestResolvedAt, Comparator.reverseOrder())
+                        .thenComparing(
+                                AppealActorSummary::actorId, Comparator.nullsLast(Long::compareTo));
 
         private static final Comparator<AppealActorSummary> APPROVER_COMPARATOR =
                 Comparator.comparingInt(AppealActorSummary::count)
                         .reversed()
-                        .thenComparing(AppealActorSummary::latestResolvedAt, Comparator.reverseOrder())
-                        .thenComparing(AppealActorSummary::actorId, Comparator.nullsLast(Long::compareTo));
+                        .thenComparing(
+                                AppealActorSummary::latestResolvedAt, Comparator.reverseOrder())
+                        .thenComparing(
+                                AppealActorSummary::actorId, Comparator.nullsLast(Long::compareTo));
 
         private static final Comparator<ApprovedAppealEvent> RECENT_APPROVED_COMPARATOR =
-                Comparator.comparing(ApprovedAppealEvent::resolvedAt, Comparator.nullsLast(Comparator.reverseOrder()))
-                        .thenComparing(ApprovedAppealEvent::appealId, Comparator.nullsLast(Comparator.reverseOrder()));
+                Comparator.comparing(
+                                ApprovedAppealEvent::resolvedAt,
+                                Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(
+                                ApprovedAppealEvent::appealId,
+                                Comparator.nullsLast(Comparator.reverseOrder()));
 
         private static final Comparator<ApprovedAppealEvent> RECENT_ACCEPTED_COMPARATOR =
-                Comparator.comparing(ApprovedAppealEvent::resolvedAt, Comparator.nullsLast(Comparator.reverseOrder()))
-                        .thenComparing(ApprovedAppealEvent::appealId, Comparator.nullsLast(Comparator.reverseOrder()));
+                Comparator.comparing(
+                                ApprovedAppealEvent::resolvedAt,
+                                Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(
+                                ApprovedAppealEvent::appealId,
+                                Comparator.nullsLast(Comparator.reverseOrder()));
 
         private final Long actorId;
         private final String actorName;
         private final List<ApprovedAppealEvent> events;
 
-        private AppealActorSummary(Long actorId, String actorName, List<ApprovedAppealEvent> events) {
+        private AppealActorSummary(
+                Long actorId, String actorName, List<ApprovedAppealEvent> events) {
             this.actorId = actorId;
             this.actorName = actorName;
             this.events = events;

--- a/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
@@ -2,17 +2,20 @@ package com.template.worker.jobs.recap.monthly.query;
 
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.sql.Types;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.ObjIntConsumer;
 
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
@@ -32,132 +35,131 @@ import lombok.RequiredArgsConstructor;
 public class MonthlyFamilyRecapAggregationRepository {
 
     private static final DateTimeFormatter ISO_DATE_TIME = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-
     private static final String APPROVED_APPEAL_COUNT = "approved_appeal_count";
+    private static final String PARTIAL_EVENT_TIME_CONDITION = buildPartialRangeCondition("event_time");
+    private static final String PARTIAL_CREATED_AT_CONDITION = buildPartialRangeCondition("created_at");
+    private static final String PARTIAL_COMPLETED_AT_CONDITION =
+            buildPartialRangeCondition("completed_at");
+    private static final String PARTIAL_MR_RESOLVED_AT_CONDITION =
+            buildPartialRangeCondition("mr.resolved_at");
+    private static final String PARTIAL_APPEAL_CREATED_AT_CONDITION =
+            buildPartialRangeCondition("pa.created_at");
+    private static final String PARTIAL_APPEAL_RESOLVED_AT_CONDITION =
+            buildPartialRangeCondition("pa.resolved_at");
 
-    // 월 내부 full week에 해당하는 weekly recap 스냅샷을 조회
     private static final String READ_FULL_WEEKLY_RECAP_ROWS_SQL =
             """
-            SELECT week_start_date,
-                   total_used_bytes,
-                   total_quota_bytes,
-                   usage_by_weekday,
-                   peak_usage,
-                   mission_created_count,
-                   mission_completed_count,
-                   mission_rejected_count,
-                   total_appeal_count,
-                   approved_appeal_count,
+            SELECT family_id, week_start_date, total_used_bytes, total_quota_bytes, usage_by_weekday,
+                   peak_usage, mission_created_count, mission_completed_count,
+                   mission_rejected_count, total_appeal_count, approved_appeal_count,
                    rejected_appeal_count
             FROM family_recap_weekly
-            WHERE family_id = :familyId
+            WHERE family_id IN (:familyIds)
               AND week_start_date >= :monthStartDate
               AND week_start_date <= :lastFullWeekStartDate
-            ORDER BY week_start_date ASC
+            ORDER BY family_id ASC, week_start_date ASC
             """;
 
-    // 월과 겹치는 가장 최근 weekly recap의 quota 스냅샷을 조회
-    private static final String READ_LATEST_QUOTA_SNAPSHOT_FROM_WEEKLY_SQL =
+    private static final String READ_WEEKLY_QUOTA_ROWS_SQL =
             """
-            SELECT total_quota_bytes
+            SELECT family_id, week_start_date, total_quota_bytes
             FROM family_recap_weekly
-            WHERE family_id = :familyId
+            WHERE family_id IN (:familyIds)
               AND week_start_date < :monthEndExclusiveDate
               AND week_start_date >= :overlapStartDate
-            ORDER BY week_start_date DESC
-            LIMIT 1
+            ORDER BY family_id ASC, week_start_date DESC
             """;
 
-    // 주간 quota 스냅샷이 없을 때 `targetMonth` family_quota를 fallback으로 조회
     private static final String READ_FAMILY_QUOTA_BYTES_SQL =
             """
-            SELECT total_quota_bytes
+            SELECT family_id, total_quota_bytes
             FROM family_quota
-            WHERE family_id = :familyId
+            WHERE family_id IN (:familyIds)
               AND current_month = :monthStartDate
               AND deleted_at IS NULL
             """;
 
-    // 부분 주간 구간의 총 사용량을 집계
     private static final String READ_TOTAL_USED_BYTES_IN_RANGE_SQL =
             """
-            SELECT COALESCE(SUM(bytes_used), 0)
+            SELECT family_id, COALESCE(SUM(bytes_used), 0) AS total_used_bytes
             FROM usage_record
-            WHERE family_id = :familyId
-              AND event_time >= :rangeStart
-              AND event_time < :rangeEndExclusive
+            WHERE family_id IN (:familyIds)
+              AND """
+                    + PARTIAL_EVENT_TIME_CONDITION
+                    + """
               AND deleted_at IS NULL
+            GROUP BY family_id
             """;
 
-    // 부분 주간 구간의 요일별 사용량을 집계
     private static final String READ_USAGE_BY_WEEKDAY_IN_RANGE_SQL =
             """
-            SELECT DAYOFWEEK(event_time) AS day_of_week,
-                   COALESCE(SUM(bytes_used), 0) AS total_bytes
+            SELECT family_id, DAYOFWEEK(event_time) AS day_of_week, COALESCE(SUM(bytes_used), 0) AS total_bytes
             FROM usage_record
-            WHERE family_id = :familyId
-              AND event_time >= :rangeStart
-              AND event_time < :rangeEndExclusive
+            WHERE family_id IN (:familyIds)
+              AND """
+                    + PARTIAL_EVENT_TIME_CONDITION
+                    + """
               AND deleted_at IS NULL
-            GROUP BY DAYOFWEEK(event_time)
+            GROUP BY family_id, DAYOFWEEK(event_time)
             """;
 
-    // 부분 주간 구간의 시간대별 사용량을 집계
     private static final String READ_USAGE_BY_HOUR_IN_RANGE_SQL =
             """
-            SELECT HOUR(event_time) AS start_hour,
-                   COALESCE(SUM(bytes_used), 0) AS total_bytes
+            SELECT family_id, HOUR(event_time) AS start_hour, COALESCE(SUM(bytes_used), 0) AS total_bytes
             FROM usage_record
-            WHERE family_id = :familyId
-              AND event_time >= :rangeStart
-              AND event_time < :rangeEndExclusive
+            WHERE family_id IN (:familyIds)
+              AND """
+                    + PARTIAL_EVENT_TIME_CONDITION
+                    + """
               AND deleted_at IS NULL
-            GROUP BY HOUR(event_time)
+            GROUP BY family_id, HOUR(event_time)
             """;
 
-    // 부분 주간 구간에 생성된 미션 수를 집계
     private static final String READ_MISSION_CREATED_COUNT_IN_RANGE_SQL =
             """
-            SELECT COUNT(*)
+            SELECT family_id, COUNT(*) AS mission_created_count
             FROM mission_item
-            WHERE family_id = :familyId
-              AND created_at >= :rangeStart
-              AND created_at < :rangeEndExclusive
+            WHERE family_id IN (:familyIds)
+              AND """
+                    + PARTIAL_CREATED_AT_CONDITION
+                    + """
               AND deleted_at IS NULL
+            GROUP BY family_id
             """;
 
-    // 부분 주간 구간에 완료된 미션 수를 집계
     private static final String READ_MISSION_COMPLETED_COUNT_IN_RANGE_SQL =
             """
-            SELECT COUNT(*)
+            SELECT family_id, COUNT(*) AS mission_completed_count
             FROM mission_item
-            WHERE family_id = :familyId
+            WHERE family_id IN (:familyIds)
               AND status = 'COMPLETED'
-              AND completed_at >= :rangeStart
-              AND completed_at < :rangeEndExclusive
+              AND """
+                    + PARTIAL_COMPLETED_AT_CONDITION
+                    + """
               AND deleted_at IS NULL
+            GROUP BY family_id
             """;
 
-    // 부분 주간 구간에 반려된 미션 요청 수를 집계
     private static final String READ_MISSION_REJECTED_COUNT_IN_RANGE_SQL =
             """
-            SELECT COUNT(*)
+            SELECT mi.family_id, COUNT(*) AS mission_rejected_count
             FROM mission_request mr
             JOIN mission_item mi ON mr.mission_item_id = mi.id
-            WHERE mi.family_id = :familyId
+            WHERE mi.family_id IN (:familyIds)
               AND mr.status = 'REJECTED'
-              AND mr.resolved_at >= :rangeStart
-              AND mr.resolved_at < :rangeEndExclusive
+              AND """
+                    + PARTIAL_MR_RESOLVED_AT_CONDITION
+                    + """
               AND mr.deleted_at IS NULL
               AND mi.deleted_at IS NULL
+            GROUP BY mi.family_id
             """;
 
-    // 월 시작 시점까지 미완료로 남아 있는 미션 수를 집계
     private static final String READ_MISSION_CARRY_IN_COUNT_SQL =
             """
-            SELECT COUNT(*)
+            SELECT mi.family_id, COUNT(*) AS mission_carry_in_count
             FROM mission_item mi
-            WHERE mi.family_id = :familyId
+            WHERE mi.family_id IN (:familyIds)
               AND mi.created_at < :monthStart
               AND mi.deleted_at IS NULL
               AND NOT EXISTS (
@@ -168,279 +170,350 @@ public class MonthlyFamilyRecapAggregationRepository {
                     AND ml.created_at < :monthStart
                     AND ml.deleted_at IS NULL
               )
+            GROUP BY mi.family_id
             """;
 
-    // 부분 주간 구간에 생성된 NORMAL 이의제기 수를 집계
     private static final String READ_TOTAL_APPEAL_COUNT_IN_RANGE_SQL =
             """
-            SELECT COUNT(*)
+            SELECT pas.family_id, COUNT(*) AS total_appeal_count
             FROM policy_appeal pa
             JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
-            WHERE pas.family_id = :familyId
+            WHERE pas.family_id IN (:familyIds)
               AND pa.type = 'NORMAL'
-              AND pa.created_at >= :rangeStart
-              AND pa.created_at < :rangeEndExclusive
+              AND """
+                    + PARTIAL_APPEAL_CREATED_AT_CONDITION
+                    + """
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
+            GROUP BY pas.family_id
             """;
 
-    // 부분 주간 구간에 승인된 NORMAL 이의제기 수를 집계
     private static final String READ_APPROVED_APPEAL_COUNT_IN_RANGE_SQL =
             """
-            SELECT COUNT(*)
+            SELECT pas.family_id, COUNT(*) AS approved_appeal_count
             FROM policy_appeal pa
             JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
-            WHERE pas.family_id = :familyId
+            WHERE pas.family_id IN (:familyIds)
               AND pa.type = 'NORMAL'
               AND pa.status = 'APPROVED'
-              AND pa.resolved_at >= :rangeStart
-              AND pa.resolved_at < :rangeEndExclusive
+              AND """
+                    + PARTIAL_APPEAL_RESOLVED_AT_CONDITION
+                    + """
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
+            GROUP BY pas.family_id
             """;
 
-    // 부분 주간 구간에 반려된 NORMAL 이의제기 수를 집계
     private static final String READ_REJECTED_APPEAL_COUNT_IN_RANGE_SQL =
             """
-            SELECT COUNT(*)
+            SELECT pas.family_id, COUNT(*) AS rejected_appeal_count
             FROM policy_appeal pa
             JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
-            WHERE pas.family_id = :familyId
+            WHERE pas.family_id IN (:familyIds)
               AND pa.type = 'NORMAL'
               AND pa.status = 'REJECTED'
-              AND pa.resolved_at >= :rangeStart
-              AND pa.resolved_at < :rangeEndExclusive
+              AND """
+                    + PARTIAL_APPEAL_RESOLVED_AT_CONDITION
+                    + """
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
+            GROUP BY pas.family_id
             """;
 
-    // 월 시작 시점에 미해결 상태로 이어진 NORMAL 이의제기 수를 집계
     private static final String READ_APPEAL_CARRY_IN_COUNT_SQL =
             """
-            SELECT COUNT(*)
+            SELECT pas.family_id, COUNT(*) AS appeal_carry_in_count
             FROM policy_appeal pa
             JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
-            WHERE pas.family_id = :familyId
+            WHERE pas.family_id IN (:familyIds)
               AND pa.type = 'NORMAL'
               AND pa.created_at < :monthStart
               AND (pa.resolved_at IS NULL OR pa.resolved_at >= :monthStart)
               AND (pa.cancelled_at IS NULL OR pa.cancelled_at >= :monthStart)
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
+            GROUP BY pas.family_id
             """;
 
-    // 월간 승인 이의제기를 가장 많이 만든 requester를 조회
-    private static final String READ_TOP_SUCCESSFUL_REQUESTER_SQL =
+    private static final String READ_APPROVED_APPEAL_EVENTS_SQL =
             """
-            SELECT pa.requester_id AS requester_id,
-                   requester.name AS requester_name,
-                   COUNT(*) AS approved_appeal_count,
-                   MAX(pa.resolved_at) AS latest_resolved_at
+            SELECT pas.family_id, pa.id AS appeal_id, pa.requester_id, requester.name AS requester_name,
+                   pa.resolved_by_id AS approver_id, approver.name AS approver_name, pa.request_reason,
+                   pa.created_at AS requested_at, pa.resolved_at
             FROM policy_appeal pa
             JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
-            JOIN customer requester ON pa.requester_id = requester.id
-            WHERE pas.family_id = :familyId
+            LEFT JOIN customer requester ON pa.requester_id = requester.id AND requester.deleted_at IS NULL
+            LEFT JOIN customer approver ON pa.resolved_by_id = approver.id AND approver.deleted_at IS NULL
+            WHERE pas.family_id IN (:familyIds)
               AND pa.type = 'NORMAL'
               AND pa.status = 'APPROVED'
               AND pa.resolved_at >= :monthStart
               AND pa.resolved_at < :monthEndExclusive
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
-              AND requester.deleted_at IS NULL
-            GROUP BY pa.requester_id, requester.name
-            ORDER BY approved_appeal_count DESC, latest_resolved_at DESC, requester_id ASC
-            LIMIT 1
-            """;
-
-    // 대표 requester의 최근 승인 이의제기 3건을 조회
-    private static final String READ_RECENT_APPROVED_APPEALS_SQL =
-            """
-            SELECT pa.id AS appeal_id,
-                   pa.resolved_by_id AS approver_id,
-                   approver.name AS approver_name,
-                   pa.request_reason,
-                   pa.created_at AS requested_at
-            FROM policy_appeal pa
-            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
-            LEFT JOIN customer approver
-              ON pa.resolved_by_id = approver.id
-             AND approver.deleted_at IS NULL
-            WHERE pas.family_id = :familyId
-              AND pa.requester_id = :requesterId
-              AND pa.type = 'NORMAL'
-              AND pa.status = 'APPROVED'
-              AND pa.resolved_at >= :monthStart
-              AND pa.resolved_at < :monthEndExclusive
-              AND pa.deleted_at IS NULL
-              AND pas.deleted_at IS NULL
-            ORDER BY pa.resolved_at DESC, pa.id DESC
-            LIMIT 3
-            """;
-
-    // 월간 승인 이의제기를 가장 많이 수락한 approver를 조회
-    private static final String READ_TOP_ACCEPTED_APPROVER_SQL =
-            """
-            SELECT pa.resolved_by_id AS approver_id,
-                   approver.name AS approver_name,
-                   COUNT(*) AS approved_appeal_count,
-                   MAX(pa.resolved_at) AS latest_resolved_at
-            FROM policy_appeal pa
-            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
-            JOIN customer approver ON pa.resolved_by_id = approver.id
-            WHERE pas.family_id = :familyId
-              AND pa.type = 'NORMAL'
-              AND pa.status = 'APPROVED'
-              AND pa.resolved_by_id IS NOT NULL
-              AND pa.resolved_at >= :monthStart
-              AND pa.resolved_at < :monthEndExclusive
-              AND pa.deleted_at IS NULL
-              AND pas.deleted_at IS NULL
-              AND approver.deleted_at IS NULL
-            GROUP BY pa.resolved_by_id, approver.name
-            ORDER BY approved_appeal_count DESC, latest_resolved_at DESC, approver_id ASC
-            LIMIT 1
-            """;
-
-    // 대표 approver가 최근 수락한 이의제기 3건을 조회
-    private static final String READ_RECENT_ACCEPTED_APPEALS_SQL =
-            """
-            SELECT pa.id AS appeal_id,
-                   pa.requester_id,
-                   requester.name AS requester_name,
-                   pa.request_reason,
-                   pa.resolved_at
-            FROM policy_appeal pa
-            JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
-            LEFT JOIN customer requester
-              ON pa.requester_id = requester.id
-             AND requester.deleted_at IS NULL
-            WHERE pas.family_id = :familyId
-              AND pa.resolved_by_id = :approverId
-              AND pa.type = 'NORMAL'
-              AND pa.status = 'APPROVED'
-              AND pa.resolved_at >= :monthStart
-              AND pa.resolved_at < :monthEndExclusive
-              AND pa.deleted_at IS NULL
-              AND pas.deleted_at IS NULL
-            ORDER BY pa.resolved_at DESC, pa.id DESC
-            LIMIT 3
+            ORDER BY pas.family_id ASC, pa.resolved_at DESC, pa.id DESC
             """;
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
     public MonthlyFamilyRecapSourceMetrics aggregate(Long familyId, LocalDate targetMonth) {
+        return aggregate(List.of(familyId), targetMonth).get(familyId);
+    }
+
+    public Map<Long, MonthlyFamilyRecapSourceMetrics> aggregate(
+            List<Long> familyIds, LocalDate targetMonth) {
+        if (familyIds.isEmpty()) {
+            return Map.of();
+        }
+
         LocalDate monthEndExclusiveDate = targetMonth.plusMonths(1);
         LocalDateTime monthStart = targetMonth.atStartOfDay();
         LocalDateTime monthEndExclusive = monthEndExclusiveDate.atStartOfDay();
 
-        // full week 조회와 carry-in 조회에 함께 쓰는 월 경계값
+        Map<Long, MutableMonthlyMetrics> metricsByFamily = initMetrics(familyIds);
         MapSqlParameterSource monthlyParams =
                 new MapSqlParameterSource()
-                        .addValue("familyId", familyId)
+                        .addValue("familyIds", familyIds)
                         .addValue("monthStartDate", Date.valueOf(targetMonth))
                         .addValue("monthEndExclusiveDate", Date.valueOf(monthEndExclusiveDate))
-                        // 월 안에 완전히 들어오는 마지막 주 시작일
-                        .addValue(
-                                "lastFullWeekStartDate",
-                                Date.valueOf(monthEndExclusiveDate.minusDays(7)))
-                        // 월과 겹칠 수 있는 최근 weekly snapshot 탐색 시작점
+                        .addValue("lastFullWeekStartDate", Date.valueOf(monthEndExclusiveDate.minusDays(7)))
                         .addValue("overlapStartDate", Date.valueOf(targetMonth.minusDays(6)))
                         .addValue("monthStart", Timestamp.valueOf(monthStart))
                         .addValue("monthEndExclusive", Timestamp.valueOf(monthEndExclusive));
 
-        List<Map<String, Object>> fullWeekRows =
-                jdbcTemplate.queryForList(READ_FULL_WEEKLY_RECAP_ROWS_SQL, monthlyParams);
-        // 월 내부 full week row만 weekly 합산에 사용
-        List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots = readFullWeekSnapshots(fullWeekRows);
+        applyFullWeekSnapshots(monthlyParams, metricsByFamily);
+        applyQuotaSnapshot(monthlyParams, metricsByFamily);
+        applyFallbackFamilyQuota(monthlyParams, metricsByFamily);
 
-        return new MonthlyFamilyRecapSourceMetrics(
-                fullWeekSnapshots,
-                readQuotaSnapshot(monthlyParams),
-                readPartialUsageMetrics(familyId, targetMonth),
-                readMissionSummary(familyId, targetMonth, fullWeekSnapshots),
-                readAppealSummary(familyId, targetMonth, fullWeekSnapshots),
-                readMissionCarryInCount(monthlyParams),
-                readAppealCarryInCount(monthlyParams),
-                readAppealHighlights(monthlyParams));
+        MapSqlParameterSource partialRangeParams = buildPartialRangeParams(familyIds, targetMonth);
+        if (hasPartialRange(partialRangeParams)) {
+            applyPartialUsage(partialRangeParams, metricsByFamily);
+            applyPartialMissionSummary(partialRangeParams, metricsByFamily);
+            applyPartialAppealSummary(partialRangeParams, metricsByFamily);
+        }
+
+        applyCount(
+                READ_MISSION_CARRY_IN_COUNT_SQL,
+                "mission_carry_in_count",
+                monthlyParams,
+                metricsByFamily,
+                MutableMonthlyMetrics::setMissionCarryInCount);
+        applyCount(
+                READ_APPEAL_CARRY_IN_COUNT_SQL,
+                "appeal_carry_in_count",
+                monthlyParams,
+                metricsByFamily,
+                MutableMonthlyMetrics::setAppealCarryInCount);
+        applyApprovedAppealEvents(monthlyParams, metricsByFamily);
+
+        Map<Long, MonthlyFamilyRecapSourceMetrics> result = new LinkedHashMap<>();
+        for (Long familyId : familyIds) {
+            MutableMonthlyMetrics metrics = metricsByFamily.get(familyId);
+            result.put(
+                    familyId,
+                    new MonthlyFamilyRecapSourceMetrics(
+                            List.copyOf(metrics.fullWeekSnapshots),
+                            metrics.totalQuotaBytes,
+                            metrics.toPartialUsageMetrics(),
+                            metrics.toMissionSummary(),
+                            metrics.toAppealSummary(),
+                            metrics.missionCarryInCount,
+                            metrics.appealCarryInCount,
+                            metrics.toAppealHighlights()));
+        }
+        return result;
     }
 
-    private List<MonthlyWeeklyRecapSnapshot> readFullWeekSnapshots(List<Map<String, Object>> rows) {
-        return rows.stream()
-                .map(
+    private Map<Long, MutableMonthlyMetrics> initMetrics(List<Long> familyIds) {
+        Map<Long, MutableMonthlyMetrics> metricsByFamily = new LinkedHashMap<>();
+        for (Long familyId : familyIds) {
+            metricsByFamily.put(familyId, new MutableMonthlyMetrics());
+        }
+        return metricsByFamily;
+    }
+
+    private void applyFullWeekSnapshots(
+            MapSqlParameterSource params, Map<Long, MutableMonthlyMetrics> metricsByFamily) {
+        jdbcTemplate.queryForList(READ_FULL_WEEKLY_RECAP_ROWS_SQL, params)
+                .forEach(
                         row ->
-                                new MonthlyWeeklyRecapSnapshot(
-                                        toLocalDate(row.get("week_start_date")),
-                                        toLong(row.get("total_used_bytes")),
-                                        toLong(row.get("total_quota_bytes")),
-                                        toJsonString(row.get("usage_by_weekday")),
-                                        toJsonString(row.get("peak_usage")),
-                                        toInt(row.get("mission_created_count")),
-                                        toInt(row.get("mission_completed_count")),
-                                        toInt(row.get("mission_rejected_count")),
-                                        toInt(row.get("total_appeal_count")),
-                                        toInt(row.get(APPROVED_APPEAL_COUNT)),
-                                        toInt(row.get("rejected_appeal_count"))))
-                .toList();
+                                metricsByFamily
+                                        .get(toLong(row.get("family_id")))
+                                        .fullWeekSnapshots
+                                        .add(
+                                                new MonthlyWeeklyRecapSnapshot(
+                                                        toLocalDate(row.get("week_start_date")),
+                                                        toLong(row.get("total_used_bytes")),
+                                                        toLong(row.get("total_quota_bytes")),
+                                                        toJsonString(row.get("usage_by_weekday")),
+                                                        toJsonString(row.get("peak_usage")),
+                                                        toInt(row.get("mission_created_count")),
+                                                        toInt(row.get("mission_completed_count")),
+                                                        toInt(row.get("mission_rejected_count")),
+                                                        toInt(row.get("total_appeal_count")),
+                                                        toInt(row.get(APPROVED_APPEAL_COUNT)),
+                                                        toInt(row.get("rejected_appeal_count")))));
     }
 
-    private long readQuotaSnapshot(MapSqlParameterSource params) {
-        // quota는 합산하지 않고 월과 겹치는 가장 최근 주간 스냅샷 1건만 사용함
-        Long quotaFromWeekly = readNullableLong(READ_LATEST_QUOTA_SNAPSHOT_FROM_WEEKLY_SQL, params);
-        if (quotaFromWeekly != null) {
-            return quotaFromWeekly;
-        }
-
-        // 주간 스냅샷이 없으면 targetMonth family_quota로 fallback함
-        Long quotaFromFamily = readNullableLong(READ_FAMILY_QUOTA_BYTES_SQL, params);
-        return quotaFromFamily == null ? 0L : quotaFromFamily;
+    private void applyQuotaSnapshot(
+            MapSqlParameterSource params, Map<Long, MutableMonthlyMetrics> metricsByFamily) {
+        jdbcTemplate.queryForList(READ_WEEKLY_QUOTA_ROWS_SQL, params)
+                .forEach(
+                        row -> {
+                            MutableMonthlyMetrics metrics =
+                                    metricsByFamily.get(toLong(row.get("family_id")));
+                            if (!metrics.quotaResolved) {
+                                metrics.totalQuotaBytes = toLong(row.get("total_quota_bytes"));
+                                metrics.quotaResolved = true;
+                            }
+                        });
     }
 
-    private MonthlyUsageSupplementMetrics readPartialUsageMetrics(
-            Long familyId, LocalDate targetMonth) {
-        List<DateRange> partialRanges = resolvePartialRanges(targetMonth);
-        if (partialRanges.isEmpty()) {
-            return MonthlyUsageSupplementMetrics.empty();
-        }
+    private void applyFallbackFamilyQuota(
+            MapSqlParameterSource params, Map<Long, MutableMonthlyMetrics> metricsByFamily) {
+        jdbcTemplate.queryForList(READ_FAMILY_QUOTA_BYTES_SQL, params)
+                .forEach(
+                        row -> {
+                            MutableMonthlyMetrics metrics =
+                                    metricsByFamily.get(toLong(row.get("family_id")));
+                            if (!metrics.quotaResolved) {
+                                metrics.totalQuotaBytes = toLong(row.get("total_quota_bytes"));
+                                metrics.quotaResolved = true;
+                            }
+                        });
+    }
 
-        long totalUsedBytes = 0L;
-        Map<String, Long> usageBytesByWeekday = initWeekdayUsageMap();
-        Map<Integer, Long> usageBytesByHour = new LinkedHashMap<>();
+    private void applyPartialUsage(
+            MapSqlParameterSource params, Map<Long, MutableMonthlyMetrics> metricsByFamily) {
+        jdbcTemplate.queryForList(READ_TOTAL_USED_BYTES_IN_RANGE_SQL, params)
+                .forEach(
+                        row ->
+                                metricsByFamily
+                                                .get(toLong(row.get("family_id")))
+                                                .partialTotalUsedBytes +=
+                                        toLong(row.get("total_used_bytes")));
 
-        // 월 경계를 걸치는 좌/우 partial week만 raw 사용량으로 보강
-        for (DateRange range : partialRanges) {
-            MapSqlParameterSource rangeParams = buildRangeParams(familyId, range);
+        jdbcTemplate.queryForList(READ_USAGE_BY_WEEKDAY_IN_RANGE_SQL, params)
+                .forEach(
+                        row -> {
+                            MutableMonthlyMetrics metrics =
+                                    metricsByFamily.get(toLong(row.get("family_id")));
+                            String weekday = resolveWeekdayKey(toInt(row.get("day_of_week")));
+                            metrics.partialUsageByWeekday.put(
+                                    weekday,
+                                    metrics.partialUsageByWeekday.getOrDefault(weekday, 0L)
+                                            + toLong(row.get("total_bytes")));
+                        });
 
-            totalUsedBytes += readLong(READ_TOTAL_USED_BYTES_IN_RANGE_SQL, rangeParams);
+        jdbcTemplate.queryForList(READ_USAGE_BY_HOUR_IN_RANGE_SQL, params)
+                .forEach(
+                        row -> {
+                            MutableMonthlyMetrics metrics =
+                                    metricsByFamily.get(toLong(row.get("family_id")));
+                            int startHour = toInt(row.get("start_hour"));
+                            metrics.partialUsageByHour.put(
+                                    startHour,
+                                    metrics.partialUsageByHour.getOrDefault(startHour, 0L)
+                                            + toLong(row.get("total_bytes")));
+                        });
+    }
 
-            for (Map<String, Object> row :
-                    jdbcTemplate.queryForList(READ_USAGE_BY_WEEKDAY_IN_RANGE_SQL, rangeParams)) {
-                String weekday = resolveWeekdayKey(toInt(row.get("day_of_week")));
-                long bytes = toLong(row.get("total_bytes"));
-                usageBytesByWeekday.put(
-                        weekday, usageBytesByWeekday.getOrDefault(weekday, 0L) + bytes);
-            }
+    private void applyPartialMissionSummary(
+            MapSqlParameterSource params, Map<Long, MutableMonthlyMetrics> metricsByFamily) {
+        applyCount(
+                READ_MISSION_CREATED_COUNT_IN_RANGE_SQL,
+                "mission_created_count",
+                params,
+                metricsByFamily,
+                MutableMonthlyMetrics::setPartialMissionCreatedCount);
+        applyCount(
+                READ_MISSION_COMPLETED_COUNT_IN_RANGE_SQL,
+                "mission_completed_count",
+                params,
+                metricsByFamily,
+                MutableMonthlyMetrics::setPartialMissionCompletedCount);
+        applyCount(
+                READ_MISSION_REJECTED_COUNT_IN_RANGE_SQL,
+                "mission_rejected_count",
+                params,
+                metricsByFamily,
+                MutableMonthlyMetrics::setPartialMissionRejectedCount);
+    }
 
-            for (Map<String, Object> row :
-                    jdbcTemplate.queryForList(READ_USAGE_BY_HOUR_IN_RANGE_SQL, rangeParams)) {
-                int startHour = toInt(row.get("start_hour"));
-                long bytes = toLong(row.get("total_bytes"));
-                usageBytesByHour.put(
-                        startHour, usageBytesByHour.getOrDefault(startHour, 0L) + bytes);
-            }
-        }
+    private void applyPartialAppealSummary(
+            MapSqlParameterSource params, Map<Long, MutableMonthlyMetrics> metricsByFamily) {
+        applyCount(
+                READ_TOTAL_APPEAL_COUNT_IN_RANGE_SQL,
+                "total_appeal_count",
+                params,
+                metricsByFamily,
+                MutableMonthlyMetrics::setPartialTotalAppeals);
+        applyCount(
+                READ_APPROVED_APPEAL_COUNT_IN_RANGE_SQL,
+                APPROVED_APPEAL_COUNT,
+                params,
+                metricsByFamily,
+                MutableMonthlyMetrics::setPartialApprovedAppeals);
+        applyCount(
+                READ_REJECTED_APPEAL_COUNT_IN_RANGE_SQL,
+                "rejected_appeal_count",
+                params,
+                metricsByFamily,
+                MutableMonthlyMetrics::setPartialRejectedAppeals);
+    }
 
-        MonthlyUsagePeakCandidate peakUsageCandidate = MonthlyUsagePeakCandidate.empty();
-        for (Map.Entry<Integer, Long> entry : usageBytesByHour.entrySet()) {
-            MonthlyUsagePeakCandidate candidate =
-                    new MonthlyUsagePeakCandidate(
-                            entry.getKey(), entry.getKey() + 1, entry.getValue());
-            if (candidate.isBetterThan(peakUsageCandidate)) {
-                peakUsageCandidate = candidate;
-            }
-        }
+    private void applyApprovedAppealEvents(
+            MapSqlParameterSource params, Map<Long, MutableMonthlyMetrics> metricsByFamily) {
+        jdbcTemplate.queryForList(READ_APPROVED_APPEAL_EVENTS_SQL, params)
+                .forEach(
+                        row ->
+                                metricsByFamily
+                                        .get(toLong(row.get("family_id")))
+                                        .approvedAppealEvents
+                                        .add(
+                                                new ApprovedAppealEvent(
+                                                        toLongObject(row.get("appeal_id")),
+                                                        toLongObject(row.get("requester_id")),
+                                                        toNullableString(row.get("requester_name")),
+                                                        toLongObject(row.get("approver_id")),
+                                                        toNullableString(row.get("approver_name")),
+                                                        toNullableString(row.get("request_reason")),
+                                                        toIsoDateTime(row.get("requested_at")),
+                                                        toTimestamp(row.get("resolved_at")))));
+    }
 
-        return new MonthlyUsageSupplementMetrics(
-                totalUsedBytes, usageBytesByWeekday, peakUsageCandidate);
+    private void applyCount(
+            String sql,
+            String countColumn,
+            MapSqlParameterSource params,
+            Map<Long, MutableMonthlyMetrics> metricsByFamily,
+            ObjIntConsumer<MutableMonthlyMetrics> countSetter) {
+        jdbcTemplate.queryForList(sql, params)
+                .forEach(
+                        row ->
+                                countSetter.accept(
+                                        metricsByFamily.get(toLong(row.get("family_id"))),
+                                        toInt(row.get(countColumn))));
+    }
+
+    private boolean hasPartialRange(MapSqlParameterSource params) {
+        return params.getValue("leftRangeStart") != null || params.getValue("rightRangeStart") != null;
+    }
+
+    private MapSqlParameterSource buildPartialRangeParams(List<Long> familyIds, LocalDate targetMonth) {
+        List<DateRange> ranges = resolvePartialRanges(targetMonth);
+        MapSqlParameterSource params = new MapSqlParameterSource().addValue("familyIds", familyIds);
+        addTimestamp(params, "leftRangeStart", ranges.size() > 0 ? ranges.get(0).startInclusive() : null);
+        addTimestamp(
+                params,
+                "leftRangeEndExclusive",
+                ranges.size() > 0 ? ranges.get(0).endExclusive() : null);
+        addTimestamp(params, "rightRangeStart", ranges.size() > 1 ? ranges.get(1).startInclusive() : null);
+        addTimestamp(
+                params,
+                "rightRangeEndExclusive",
+                ranges.size() > 1 ? ranges.get(1).endExclusive() : null);
+        return params;
     }
 
     private List<DateRange> resolvePartialRanges(LocalDate targetMonth) {
@@ -451,16 +524,11 @@ public class MonthlyFamilyRecapAggregationRepository {
         LocalDate rightPartialWeekStart =
                 monthEndExclusiveDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
 
-        // 월 바깥으로 걸친 구간만 보강 대상으로 잡음
         List<DateRange> ranges = new ArrayList<>();
         if (monthStartDate.isBefore(firstFullWeekStart)) {
-            // 좌측 partial 구간을 추가함
-            ranges.add(
-                    new DateRange(
-                            monthStartDate.atStartOfDay(), firstFullWeekStart.atStartOfDay()));
+            ranges.add(new DateRange(monthStartDate.atStartOfDay(), firstFullWeekStart.atStartOfDay()));
         }
         if (rightPartialWeekStart.isBefore(monthEndExclusiveDate)) {
-            // 우측 partial 구간을 추가함
             ranges.add(
                     new DateRange(
                             rightPartialWeekStart.atStartOfDay(),
@@ -469,236 +537,29 @@ public class MonthlyFamilyRecapAggregationRepository {
         return ranges;
     }
 
-    private MonthlyMissionSummary readMissionSummary(
-            Long familyId,
-            LocalDate targetMonth,
-            List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots) {
-        // 월 경계 partial만 raw 집계로 보강함
-        MonthlyMissionSummary partialMissionSummary =
-                readPartialMissionSummary(familyId, targetMonth);
-
-        int totalMissionCount = partialMissionSummary.totalMissionCount();
-        int completedMissionCount = partialMissionSummary.completedMissionCount();
-        int rejectedRequestCount = partialMissionSummary.rejectedRequestCount();
-
-        // 월 내부 전체 주간은 주간 스냅샷을 재사용함
-        for (MonthlyWeeklyRecapSnapshot snapshot : fullWeekSnapshots) {
-            totalMissionCount += snapshot.missionCreatedCount();
-            completedMissionCount += snapshot.missionCompletedCount();
-            rejectedRequestCount += snapshot.missionRejectedCount();
-        }
-
-        return new MonthlyMissionSummary(
-                totalMissionCount, completedMissionCount, rejectedRequestCount);
+    private void addTimestamp(MapSqlParameterSource params, String key, LocalDateTime value) {
+        params.addValue(key, value == null ? null : Timestamp.valueOf(value), Types.TIMESTAMP);
     }
 
-    private MonthlyAppealSummary readAppealSummary(
-            Long familyId,
-            LocalDate targetMonth,
-            List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots) {
-        // 월 경계 partial만 raw 집계로 보강함
-        MonthlyAppealSummary partialAppealSummary = readPartialAppealSummary(familyId, targetMonth);
-
-        int totalAppeals = partialAppealSummary.totalAppeals();
-        int approvedAppeals = partialAppealSummary.approvedAppeals();
-        int rejectedAppeals = partialAppealSummary.rejectedAppeals();
-
-        // 월 내부 전체 주간은 주간 스냅샷을 재사용함
-        for (MonthlyWeeklyRecapSnapshot snapshot : fullWeekSnapshots) {
-            totalAppeals += snapshot.totalAppealCount();
-            approvedAppeals += snapshot.approvedAppealCount();
-            rejectedAppeals += snapshot.rejectedAppealCount();
-        }
-
-        return new MonthlyAppealSummary(totalAppeals, approvedAppeals, rejectedAppeals);
+    private String resolveWeekdayKey(int dayOfWeek) {
+        return switch (dayOfWeek) {
+            case 1 -> "sunday";
+            case 2 -> "monday";
+            case 3 -> "tuesday";
+            case 4 -> "wednesday";
+            case 5 -> "thursday";
+            case 6 -> "friday";
+            case 7 -> "saturday";
+            default -> throw new IllegalArgumentException("Unexpected day_of_week: " + dayOfWeek);
+        };
     }
 
-    private MonthlyMissionSummary readPartialMissionSummary(Long familyId, LocalDate targetMonth) {
-        List<DateRange> partialRanges = resolvePartialRanges(targetMonth);
-        if (partialRanges.isEmpty()) {
-            // 전체 주간만으로 월 집계가 가능하면 빈 부분 결과를 반환함
-            return MonthlyMissionSummary.empty();
-        }
-
-        int totalMissionCount = 0;
-        int completedMissionCount = 0;
-        int rejectedRequestCount = 0;
-
-        for (DateRange range : partialRanges) {
-            MapSqlParameterSource rangeParams = buildRangeParams(familyId, range);
-            totalMissionCount += readInt(READ_MISSION_CREATED_COUNT_IN_RANGE_SQL, rangeParams);
-            completedMissionCount +=
-                    readInt(READ_MISSION_COMPLETED_COUNT_IN_RANGE_SQL, rangeParams);
-            rejectedRequestCount += readInt(READ_MISSION_REJECTED_COUNT_IN_RANGE_SQL, rangeParams);
-        }
-
-        return new MonthlyMissionSummary(
-                totalMissionCount, completedMissionCount, rejectedRequestCount);
-    }
-
-    private MonthlyAppealSummary readPartialAppealSummary(Long familyId, LocalDate targetMonth) {
-        List<DateRange> partialRanges = resolvePartialRanges(targetMonth);
-        if (partialRanges.isEmpty()) {
-            // 전체 주간만으로 월 집계가 가능하면 빈 부분 결과를 반환함
-            return MonthlyAppealSummary.empty();
-        }
-
-        int totalAppeals = 0;
-        int approvedAppeals = 0;
-        int rejectedAppeals = 0;
-
-        for (DateRange range : partialRanges) {
-            MapSqlParameterSource rangeParams = buildRangeParams(familyId, range);
-            totalAppeals += readInt(READ_TOTAL_APPEAL_COUNT_IN_RANGE_SQL, rangeParams);
-            approvedAppeals += readInt(READ_APPROVED_APPEAL_COUNT_IN_RANGE_SQL, rangeParams);
-            rejectedAppeals += readInt(READ_REJECTED_APPEAL_COUNT_IN_RANGE_SQL, rangeParams);
-        }
-
-        return new MonthlyAppealSummary(totalAppeals, approvedAppeals, rejectedAppeals);
-    }
-
-    private int readMissionCarryInCount(MapSqlParameterSource params) {
-        // 월초 시점 미완료 미션 수를 반환함
-        return readInt(READ_MISSION_CARRY_IN_COUNT_SQL, params);
-    }
-
-    private int readAppealCarryInCount(MapSqlParameterSource params) {
-        // 월초 시점 미해결 NORMAL 이의제기 수를 반환함
-        return readInt(READ_APPEAL_CARRY_IN_COUNT_SQL, params);
-    }
-
-    private MonthlyAppealHighlights readAppealHighlights(MapSqlParameterSource params) {
-        MonthlyAppealHighlights.TopSuccessfulRequester topSuccessfulRequester =
-                readTopSuccessfulRequester(params);
-        MonthlyAppealHighlights.TopAcceptedApprover topAcceptedApprover =
-                readTopAcceptedApprover(params);
-        return new MonthlyAppealHighlights(topSuccessfulRequester, topAcceptedApprover);
-    }
-
-    private MonthlyAppealHighlights.TopSuccessfulRequester readTopSuccessfulRequester(
-            MapSqlParameterSource params) {
-        try {
-            Map<String, Object> row =
-                    jdbcTemplate.queryForMap(READ_TOP_SUCCESSFUL_REQUESTER_SQL, params);
-            Long requesterId = toLongObject(row.get("requester_id"));
-
-            // 대표 requester를 고른 뒤 최신 승인 이력 3건을 requestedAt 기준으로 붙임
-            // 정렬은 resolvedAt 기준
-            MapSqlParameterSource recentParams = copyParams(params);
-            recentParams.addValue("requesterId", requesterId);
-            List<MonthlyAppealHighlights.RecentApprovedAppeal> recentApprovedAppeals =
-                    jdbcTemplate
-                            .queryForList(READ_RECENT_APPROVED_APPEALS_SQL, recentParams)
-                            .stream()
-                            .map(
-                                    recentRow ->
-                                            new MonthlyAppealHighlights.RecentApprovedAppeal(
-                                                    toLongObject(recentRow.get("appeal_id")),
-                                                    toLongObject(recentRow.get("approver_id")),
-                                                    toNullableString(
-                                                            recentRow.get("approver_name")),
-                                                    toNullableString(
-                                                            recentRow.get("request_reason")),
-                                                    toIsoDateTime(recentRow.get("requested_at"))))
-                            .toList();
-
-            return new MonthlyAppealHighlights.TopSuccessfulRequester(
-                    requesterId,
-                    toNullableString(row.get("requester_name")),
-                    toInt(row.get(APPROVED_APPEAL_COUNT)),
-                    recentApprovedAppeals);
-        } catch (EmptyResultDataAccessException exception) {
-            return MonthlyAppealHighlights.TopSuccessfulRequester.empty();
-        }
-    }
-
-    private MonthlyAppealHighlights.TopAcceptedApprover readTopAcceptedApprover(
-            MapSqlParameterSource params) {
-        try {
-            Map<String, Object> row =
-                    jdbcTemplate.queryForMap(READ_TOP_ACCEPTED_APPROVER_SQL, params);
-            Long approverId = toLongObject(row.get("approver_id"));
-
-            // 대표 approver를 고른 뒤 최신 수락 이력 3건을 resolvedAt 기준으로 붙임
-            MapSqlParameterSource recentParams = copyParams(params);
-            recentParams.addValue("approverId", approverId);
-            List<MonthlyAppealHighlights.RecentAcceptedAppeal> recentAcceptedAppeals =
-                    jdbcTemplate
-                            .queryForList(READ_RECENT_ACCEPTED_APPEALS_SQL, recentParams)
-                            .stream()
-                            .map(
-                                    recentRow ->
-                                            new MonthlyAppealHighlights.RecentAcceptedAppeal(
-                                                    toLongObject(recentRow.get("appeal_id")),
-                                                    toLongObject(recentRow.get("requester_id")),
-                                                    toNullableString(
-                                                            recentRow.get("requester_name")),
-                                                    toNullableString(
-                                                            recentRow.get("request_reason")),
-                                                    toIsoDateTime(recentRow.get("resolved_at"))))
-                            .toList();
-
-            return new MonthlyAppealHighlights.TopAcceptedApprover(
-                    approverId,
-                    toNullableString(row.get("approver_name")),
-                    toInt(row.get(APPROVED_APPEAL_COUNT)),
-                    recentAcceptedAppeals);
-        } catch (EmptyResultDataAccessException exception) {
-            return MonthlyAppealHighlights.TopAcceptedApprover.empty();
-        }
-    }
-
-    private MapSqlParameterSource copyParams(MapSqlParameterSource params) {
-        MapSqlParameterSource copied = new MapSqlParameterSource();
-        for (String name : params.getParameterNames()) {
-            copied.addValue(name, params.getValue(name));
-        }
-        return copied;
-    }
-
-    private MapSqlParameterSource buildRangeParams(Long familyId, DateRange range) {
-        return new MapSqlParameterSource()
-                .addValue("familyId", familyId)
-                .addValue("rangeStart", Timestamp.valueOf(range.startInclusive()))
-                .addValue("rangeEndExclusive", Timestamp.valueOf(range.endExclusive()));
-    }
-
-    private Map<String, Long> initWeekdayUsageMap() {
-        Map<String, Long> usageByWeekday = new LinkedHashMap<>();
-        usageByWeekday.put("monday", 0L);
-        usageByWeekday.put("tuesday", 0L);
-        usageByWeekday.put("wednesday", 0L);
-        usageByWeekday.put("thursday", 0L);
-        usageByWeekday.put("friday", 0L);
-        usageByWeekday.put("saturday", 0L);
-        usageByWeekday.put("sunday", 0L);
-        return usageByWeekday;
-    }
-
-    private long readLong(String sql, MapSqlParameterSource params) {
-        try {
-            Long value = jdbcTemplate.queryForObject(sql, params, Long.class);
-            return value == null ? 0L : value;
-        } catch (EmptyResultDataAccessException exception) {
-            return 0L;
-        }
-    }
-
-    private int readInt(String sql, MapSqlParameterSource params) {
-        try {
-            Integer value = jdbcTemplate.queryForObject(sql, params, Integer.class);
-            return value == null ? 0 : value;
-        } catch (EmptyResultDataAccessException exception) {
-            return 0;
-        }
-    }
-
-    private Long readNullableLong(String sql, MapSqlParameterSource params) {
-        try {
-            return jdbcTemplate.queryForObject(sql, params, Long.class);
-        } catch (EmptyResultDataAccessException exception) {
-            return null;
-        }
+    private static String buildPartialRangeCondition(String column) {
+        return """
+               ((:leftRangeStart IS NOT NULL AND %1$s >= :leftRangeStart AND %1$s < :leftRangeEndExclusive)
+                 OR (:rightRangeStart IS NOT NULL AND %1$s >= :rightRangeStart AND %1$s < :rightRangeEndExclusive))
+               """
+                .formatted(column);
     }
 
     private LocalDate toLocalDate(Object value) {
@@ -709,6 +570,16 @@ public class MonthlyFamilyRecapAggregationRepository {
             return timestampValue.toLocalDateTime().toLocalDate();
         }
         return LocalDate.parse(String.valueOf(value));
+    }
+
+    private Timestamp toTimestamp(Object value) {
+        if (value instanceof Timestamp timestampValue) {
+            return timestampValue;
+        }
+        if (value instanceof Date dateValue) {
+            return Timestamp.valueOf(dateValue.toLocalDate().atStartOfDay());
+        }
+        return value == null ? null : Timestamp.valueOf(String.valueOf(value));
     }
 
     private String toJsonString(Object value) {
@@ -732,27 +603,263 @@ public class MonthlyFamilyRecapAggregationRepository {
     }
 
     private String toIsoDateTime(Object value) {
-        if (value instanceof Timestamp timestampValue) {
-            return timestampValue.toLocalDateTime().format(ISO_DATE_TIME);
-        }
-        if (value instanceof Date dateValue) {
-            return dateValue.toLocalDate().atStartOfDay().format(ISO_DATE_TIME);
-        }
-        return value == null ? null : String.valueOf(value);
-    }
-
-    private String resolveWeekdayKey(int dayOfWeek) {
-        return switch (dayOfWeek) {
-            case 1 -> "sunday";
-            case 2 -> "monday";
-            case 3 -> "tuesday";
-            case 4 -> "wednesday";
-            case 5 -> "thursday";
-            case 6 -> "friday";
-            case 7 -> "saturday";
-            default -> throw new IllegalArgumentException("Unexpected day_of_week: " + dayOfWeek);
-        };
+        Timestamp timestamp = toTimestamp(value);
+        return timestamp == null ? null : timestamp.toLocalDateTime().format(ISO_DATE_TIME);
     }
 
     private record DateRange(LocalDateTime startInclusive, LocalDateTime endExclusive) {}
+
+    private record ApprovedAppealEvent(
+            Long appealId,
+            Long requesterId,
+            String requesterName,
+            Long approverId,
+            String approverName,
+            String requestReason,
+            String requestedAt,
+            Timestamp resolvedAt) {}
+
+    private static final class MutableMonthlyMetrics {
+
+        private final List<MonthlyWeeklyRecapSnapshot> fullWeekSnapshots = new ArrayList<>();
+        private final Map<String, Long> partialUsageByWeekday = initWeekdayUsageMap();
+        private final Map<Integer, Long> partialUsageByHour = new HashMap<>();
+        private final List<ApprovedAppealEvent> approvedAppealEvents = new ArrayList<>();
+
+        private long totalQuotaBytes;
+        private boolean quotaResolved;
+        private long partialTotalUsedBytes;
+        private int partialMissionCreatedCount;
+        private int partialMissionCompletedCount;
+        private int partialMissionRejectedCount;
+        private int partialTotalAppeals;
+        private int partialApprovedAppeals;
+        private int partialRejectedAppeals;
+        private int missionCarryInCount;
+        private int appealCarryInCount;
+
+        private void setPartialMissionCreatedCount(int value) {
+            partialMissionCreatedCount = value;
+        }
+
+        private void setPartialMissionCompletedCount(int value) {
+            partialMissionCompletedCount = value;
+        }
+
+        private void setPartialMissionRejectedCount(int value) {
+            partialMissionRejectedCount = value;
+        }
+
+        private void setPartialTotalAppeals(int value) {
+            partialTotalAppeals = value;
+        }
+
+        private void setPartialApprovedAppeals(int value) {
+            partialApprovedAppeals = value;
+        }
+
+        private void setPartialRejectedAppeals(int value) {
+            partialRejectedAppeals = value;
+        }
+
+        private void setMissionCarryInCount(int value) {
+            missionCarryInCount = value;
+        }
+
+        private void setAppealCarryInCount(int value) {
+            appealCarryInCount = value;
+        }
+
+        private MonthlyUsageSupplementMetrics toPartialUsageMetrics() {
+            MonthlyUsagePeakCandidate peakCandidate = MonthlyUsagePeakCandidate.empty();
+            for (Map.Entry<Integer, Long> entry : partialUsageByHour.entrySet()) {
+                MonthlyUsagePeakCandidate candidate =
+                        new MonthlyUsagePeakCandidate(entry.getKey(), entry.getKey() + 1, entry.getValue());
+                if (candidate.isBetterThan(peakCandidate)) {
+                    peakCandidate = candidate;
+                }
+            }
+            return new MonthlyUsageSupplementMetrics(
+                    partialTotalUsedBytes,
+                    new LinkedHashMap<>(partialUsageByWeekday),
+                    peakCandidate);
+        }
+
+        private MonthlyMissionSummary toMissionSummary() {
+            int totalMissionCount = partialMissionCreatedCount;
+            int completedMissionCount = partialMissionCompletedCount;
+            int rejectedRequestCount = partialMissionRejectedCount;
+            for (MonthlyWeeklyRecapSnapshot snapshot : fullWeekSnapshots) {
+                totalMissionCount += snapshot.missionCreatedCount();
+                completedMissionCount += snapshot.missionCompletedCount();
+                rejectedRequestCount += snapshot.missionRejectedCount();
+            }
+            return new MonthlyMissionSummary(totalMissionCount, completedMissionCount, rejectedRequestCount);
+        }
+
+        private MonthlyAppealSummary toAppealSummary() {
+            int totalAppeals = partialTotalAppeals;
+            int approvedAppeals = partialApprovedAppeals;
+            int rejectedAppeals = partialRejectedAppeals;
+            for (MonthlyWeeklyRecapSnapshot snapshot : fullWeekSnapshots) {
+                totalAppeals += snapshot.totalAppealCount();
+                approvedAppeals += snapshot.approvedAppealCount();
+                rejectedAppeals += snapshot.rejectedAppealCount();
+            }
+            return new MonthlyAppealSummary(totalAppeals, approvedAppeals, rejectedAppeals);
+        }
+
+        private MonthlyAppealHighlights toAppealHighlights() {
+            return new MonthlyAppealHighlights(buildTopSuccessfulRequester(), buildTopAcceptedApprover());
+        }
+
+        private MonthlyAppealHighlights.TopSuccessfulRequester buildTopSuccessfulRequester() {
+            Map<Long, AppealActorSummary> summaries = new HashMap<>();
+            for (ApprovedAppealEvent event : approvedAppealEvents) {
+                if (event.requesterId() == null) {
+                    continue;
+                }
+                summaries.computeIfAbsent(
+                                event.requesterId(),
+                                requesterId ->
+                                        new AppealActorSummary(
+                                                requesterId,
+                                                event.requesterName(),
+                                                new ArrayList<>()))
+                        .add(event);
+            }
+
+            return summaries.values().stream()
+                    .sorted(AppealActorSummary.REQUESTER_COMPARATOR)
+                    .findFirst()
+                    .map(
+                            summary ->
+                                    new MonthlyAppealHighlights.TopSuccessfulRequester(
+                                            summary.actorId,
+                                            summary.actorName,
+                                            summary.events.size(),
+                                            summary.events.stream()
+                                                    .sorted(AppealActorSummary.RECENT_APPROVED_COMPARATOR)
+                                                    .limit(3)
+                                                    .map(
+                                                            event ->
+                                                                    new MonthlyAppealHighlights
+                                                                            .RecentApprovedAppeal(
+                                                                            event.appealId(),
+                                                                            event.approverId(),
+                                                                            event.approverName(),
+                                                                            event.requestReason(),
+                                                                            event.requestedAt()))
+                                                    .toList()))
+                    .orElseGet(MonthlyAppealHighlights.TopSuccessfulRequester::empty);
+        }
+
+        private MonthlyAppealHighlights.TopAcceptedApprover buildTopAcceptedApprover() {
+            Map<Long, AppealActorSummary> summaries = new HashMap<>();
+            for (ApprovedAppealEvent event : approvedAppealEvents) {
+                if (event.approverId() == null) {
+                    continue;
+                }
+                summaries.computeIfAbsent(
+                                event.approverId(),
+                                approverId ->
+                                        new AppealActorSummary(
+                                                approverId,
+                                                event.approverName(),
+                                                new ArrayList<>()))
+                        .add(event);
+            }
+
+            return summaries.values().stream()
+                    .sorted(AppealActorSummary.APPROVER_COMPARATOR)
+                    .findFirst()
+                    .map(
+                            summary ->
+                                    new MonthlyAppealHighlights.TopAcceptedApprover(
+                                            summary.actorId,
+                                            summary.actorName,
+                                            summary.events.size(),
+                                            summary.events.stream()
+                                                    .sorted(AppealActorSummary.RECENT_ACCEPTED_COMPARATOR)
+                                                    .limit(3)
+                                                    .map(
+                                                            event ->
+                                                                    new MonthlyAppealHighlights
+                                                                            .RecentAcceptedAppeal(
+                                                                            event.appealId(),
+                                                                            event.requesterId(),
+                                                                            event.requesterName(),
+                                                                            event.requestReason(),
+                                                                            event.resolvedAt()
+                                                                                    .toLocalDateTime()
+                                                                                    .format(
+                                                                                            ISO_DATE_TIME)))
+                                                    .toList()))
+                    .orElseGet(MonthlyAppealHighlights.TopAcceptedApprover::empty);
+        }
+
+        private static Map<String, Long> initWeekdayUsageMap() {
+            Map<String, Long> usageByWeekday = new LinkedHashMap<>();
+            usageByWeekday.put("monday", 0L);
+            usageByWeekday.put("tuesday", 0L);
+            usageByWeekday.put("wednesday", 0L);
+            usageByWeekday.put("thursday", 0L);
+            usageByWeekday.put("friday", 0L);
+            usageByWeekday.put("saturday", 0L);
+            usageByWeekday.put("sunday", 0L);
+            return usageByWeekday;
+        }
+    }
+
+    private static final class AppealActorSummary {
+
+        private static final Comparator<AppealActorSummary> REQUESTER_COMPARATOR =
+                Comparator.comparingInt(AppealActorSummary::count)
+                        .reversed()
+                        .thenComparing(AppealActorSummary::latestResolvedAt, Comparator.reverseOrder())
+                        .thenComparing(AppealActorSummary::actorId, Comparator.nullsLast(Long::compareTo));
+
+        private static final Comparator<AppealActorSummary> APPROVER_COMPARATOR =
+                Comparator.comparingInt(AppealActorSummary::count)
+                        .reversed()
+                        .thenComparing(AppealActorSummary::latestResolvedAt, Comparator.reverseOrder())
+                        .thenComparing(AppealActorSummary::actorId, Comparator.nullsLast(Long::compareTo));
+
+        private static final Comparator<ApprovedAppealEvent> RECENT_APPROVED_COMPARATOR =
+                Comparator.comparing(ApprovedAppealEvent::resolvedAt, Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(ApprovedAppealEvent::appealId, Comparator.nullsLast(Comparator.reverseOrder()));
+
+        private static final Comparator<ApprovedAppealEvent> RECENT_ACCEPTED_COMPARATOR =
+                Comparator.comparing(ApprovedAppealEvent::resolvedAt, Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(ApprovedAppealEvent::appealId, Comparator.nullsLast(Comparator.reverseOrder()));
+
+        private final Long actorId;
+        private final String actorName;
+        private final List<ApprovedAppealEvent> events;
+
+        private AppealActorSummary(Long actorId, String actorName, List<ApprovedAppealEvent> events) {
+            this.actorId = actorId;
+            this.actorName = actorName;
+            this.events = events;
+        }
+
+        private void add(ApprovedAppealEvent event) {
+            events.add(event);
+        }
+
+        private int count() {
+            return events.size();
+        }
+
+        private Timestamp latestResolvedAt() {
+            return events.stream()
+                    .map(ApprovedAppealEvent::resolvedAt)
+                    .max(Timestamp::compareTo)
+                    .orElse(Timestamp.valueOf(LocalDateTime.MIN));
+        }
+
+        private Long actorId() {
+            return actorId;
+        }
+    }
 }

--- a/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
@@ -753,7 +753,7 @@ public class MonthlyFamilyRecapAggregationRepository {
             }
 
             return summaries.values().stream()
-                    .sorted(AppealActorSummary.REQUESTER_COMPARATOR)
+                    .sorted(AppealActorSummary.TOP_ACTOR_COMPARATOR)
                     .findFirst()
                     .map(
                             summary ->
@@ -797,7 +797,7 @@ public class MonthlyFamilyRecapAggregationRepository {
             }
 
             return summaries.values().stream()
-                    .sorted(AppealActorSummary.APPROVER_COMPARATOR)
+                    .sorted(AppealActorSummary.TOP_ACTOR_COMPARATOR)
                     .findFirst()
                     .map(
                             summary ->
@@ -841,15 +841,7 @@ public class MonthlyFamilyRecapAggregationRepository {
 
     private static final class AppealActorSummary {
 
-        private static final Comparator<AppealActorSummary> REQUESTER_COMPARATOR =
-                Comparator.comparingInt(AppealActorSummary::count)
-                        .reversed()
-                        .thenComparing(
-                                AppealActorSummary::latestResolvedAt, Comparator.reverseOrder())
-                        .thenComparing(
-                                AppealActorSummary::actorId, Comparator.nullsLast(Long::compareTo));
-
-        private static final Comparator<AppealActorSummary> APPROVER_COMPARATOR =
+        private static final Comparator<AppealActorSummary> TOP_ACTOR_COMPARATOR =
                 Comparator.comparingInt(AppealActorSummary::count)
                         .reversed()
                         .thenComparing(

--- a/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepository.java
@@ -36,18 +36,6 @@ public class MonthlyFamilyRecapAggregationRepository {
 
     private static final DateTimeFormatter ISO_DATE_TIME = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
     private static final String APPROVED_APPEAL_COUNT = "approved_appeal_count";
-    private static final String PARTIAL_EVENT_TIME_CONDITION =
-            buildPartialRangeCondition("event_time");
-    private static final String PARTIAL_CREATED_AT_CONDITION =
-            buildPartialRangeCondition("created_at");
-    private static final String PARTIAL_COMPLETED_AT_CONDITION =
-            buildPartialRangeCondition("completed_at");
-    private static final String PARTIAL_MR_RESOLVED_AT_CONDITION =
-            buildPartialRangeCondition("mr.resolved_at");
-    private static final String PARTIAL_APPEAL_CREATED_AT_CONDITION =
-            buildPartialRangeCondition("pa.created_at");
-    private static final String PARTIAL_APPEAL_RESOLVED_AT_CONDITION =
-            buildPartialRangeCondition("pa.resolved_at");
 
     private static final String READ_FULL_WEEKLY_RECAP_ROWS_SQL =
             """
@@ -86,9 +74,10 @@ public class MonthlyFamilyRecapAggregationRepository {
             SELECT family_id, COALESCE(SUM(bytes_used), 0) AS total_used_bytes
             FROM usage_record
             WHERE family_id IN (:familyIds)
-              AND """
-                    + PARTIAL_EVENT_TIME_CONDITION
-                    + """
+              AND (
+                    (:leftRangeStart IS NOT NULL AND event_time >= :leftRangeStart AND event_time < :leftRangeEndExclusive)
+                 OR (:rightRangeStart IS NOT NULL AND event_time >= :rightRangeStart AND event_time < :rightRangeEndExclusive)
+              )
               AND deleted_at IS NULL
             GROUP BY family_id
             """;
@@ -98,9 +87,10 @@ public class MonthlyFamilyRecapAggregationRepository {
             SELECT family_id, DAYOFWEEK(event_time) AS day_of_week, COALESCE(SUM(bytes_used), 0) AS total_bytes
             FROM usage_record
             WHERE family_id IN (:familyIds)
-              AND """
-                    + PARTIAL_EVENT_TIME_CONDITION
-                    + """
+              AND (
+                    (:leftRangeStart IS NOT NULL AND event_time >= :leftRangeStart AND event_time < :leftRangeEndExclusive)
+                 OR (:rightRangeStart IS NOT NULL AND event_time >= :rightRangeStart AND event_time < :rightRangeEndExclusive)
+              )
               AND deleted_at IS NULL
             GROUP BY family_id, DAYOFWEEK(event_time)
             """;
@@ -110,9 +100,10 @@ public class MonthlyFamilyRecapAggregationRepository {
             SELECT family_id, HOUR(event_time) AS start_hour, COALESCE(SUM(bytes_used), 0) AS total_bytes
             FROM usage_record
             WHERE family_id IN (:familyIds)
-              AND """
-                    + PARTIAL_EVENT_TIME_CONDITION
-                    + """
+              AND (
+                    (:leftRangeStart IS NOT NULL AND event_time >= :leftRangeStart AND event_time < :leftRangeEndExclusive)
+                 OR (:rightRangeStart IS NOT NULL AND event_time >= :rightRangeStart AND event_time < :rightRangeEndExclusive)
+              )
               AND deleted_at IS NULL
             GROUP BY family_id, HOUR(event_time)
             """;
@@ -122,9 +113,10 @@ public class MonthlyFamilyRecapAggregationRepository {
             SELECT family_id, COUNT(*) AS mission_created_count
             FROM mission_item
             WHERE family_id IN (:familyIds)
-              AND """
-                    + PARTIAL_CREATED_AT_CONDITION
-                    + """
+              AND (
+                    (:leftRangeStart IS NOT NULL AND created_at >= :leftRangeStart AND created_at < :leftRangeEndExclusive)
+                 OR (:rightRangeStart IS NOT NULL AND created_at >= :rightRangeStart AND created_at < :rightRangeEndExclusive)
+              )
               AND deleted_at IS NULL
             GROUP BY family_id
             """;
@@ -135,9 +127,10 @@ public class MonthlyFamilyRecapAggregationRepository {
             FROM mission_item
             WHERE family_id IN (:familyIds)
               AND status = 'COMPLETED'
-              AND """
-                    + PARTIAL_COMPLETED_AT_CONDITION
-                    + """
+              AND (
+                    (:leftRangeStart IS NOT NULL AND completed_at >= :leftRangeStart AND completed_at < :leftRangeEndExclusive)
+                 OR (:rightRangeStart IS NOT NULL AND completed_at >= :rightRangeStart AND completed_at < :rightRangeEndExclusive)
+              )
               AND deleted_at IS NULL
             GROUP BY family_id
             """;
@@ -149,9 +142,10 @@ public class MonthlyFamilyRecapAggregationRepository {
             JOIN mission_item mi ON mr.mission_item_id = mi.id
             WHERE mi.family_id IN (:familyIds)
               AND mr.status = 'REJECTED'
-              AND """
-                    + PARTIAL_MR_RESOLVED_AT_CONDITION
-                    + """
+              AND (
+                    (:leftRangeStart IS NOT NULL AND mr.resolved_at >= :leftRangeStart AND mr.resolved_at < :leftRangeEndExclusive)
+                 OR (:rightRangeStart IS NOT NULL AND mr.resolved_at >= :rightRangeStart AND mr.resolved_at < :rightRangeEndExclusive)
+              )
               AND mr.deleted_at IS NULL
               AND mi.deleted_at IS NULL
             GROUP BY mi.family_id
@@ -182,9 +176,10 @@ public class MonthlyFamilyRecapAggregationRepository {
             JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
             WHERE pas.family_id IN (:familyIds)
               AND pa.type = 'NORMAL'
-              AND """
-                    + PARTIAL_APPEAL_CREATED_AT_CONDITION
-                    + """
+              AND (
+                    (:leftRangeStart IS NOT NULL AND pa.created_at >= :leftRangeStart AND pa.created_at < :leftRangeEndExclusive)
+                 OR (:rightRangeStart IS NOT NULL AND pa.created_at >= :rightRangeStart AND pa.created_at < :rightRangeEndExclusive)
+              )
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
             GROUP BY pas.family_id
@@ -198,9 +193,10 @@ public class MonthlyFamilyRecapAggregationRepository {
             WHERE pas.family_id IN (:familyIds)
               AND pa.type = 'NORMAL'
               AND pa.status = 'APPROVED'
-              AND """
-                    + PARTIAL_APPEAL_RESOLVED_AT_CONDITION
-                    + """
+              AND (
+                    (:leftRangeStart IS NOT NULL AND pa.resolved_at >= :leftRangeStart AND pa.resolved_at < :leftRangeEndExclusive)
+                 OR (:rightRangeStart IS NOT NULL AND pa.resolved_at >= :rightRangeStart AND pa.resolved_at < :rightRangeEndExclusive)
+              )
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
             GROUP BY pas.family_id
@@ -214,9 +210,10 @@ public class MonthlyFamilyRecapAggregationRepository {
             WHERE pas.family_id IN (:familyIds)
               AND pa.type = 'NORMAL'
               AND pa.status = 'REJECTED'
-              AND """
-                    + PARTIAL_APPEAL_RESOLVED_AT_CONDITION
-                    + """
+              AND (
+                    (:leftRangeStart IS NOT NULL AND pa.resolved_at >= :leftRangeStart AND pa.resolved_at < :leftRangeEndExclusive)
+                 OR (:rightRangeStart IS NOT NULL AND pa.resolved_at >= :rightRangeStart AND pa.resolved_at < :rightRangeEndExclusive)
+              )
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
             GROUP BY pas.family_id
@@ -571,14 +568,6 @@ public class MonthlyFamilyRecapAggregationRepository {
             case 7 -> "saturday";
             default -> throw new IllegalArgumentException("Unexpected day_of_week: " + dayOfWeek);
         };
-    }
-
-    private static String buildPartialRangeCondition(String column) {
-        return """
-               ((:leftRangeStart IS NOT NULL AND %1$s >= :leftRangeStart AND %1$s < :leftRangeEndExclusive)
-                 OR (:rightRangeStart IS NOT NULL AND %1$s >= :rightRangeStart AND %1$s < :rightRangeEndExclusive))
-               """
-                .formatted(column);
     }
 
     private LocalDate toLocalDate(Object value) {

--- a/src/main/java/com/template/worker/jobs/recap/monthly/step/ProcessMonthlyFamilyRecapStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/step/ProcessMonthlyFamilyRecapStepConfig.java
@@ -34,8 +34,7 @@ public class ProcessMonthlyFamilyRecapStepConfig {
                         new StepBuilder(
                                         MonthlyFamilyRecapJobConstants.STEP_PROCESS_MONTHLY_RECAP,
                                         jobRepository)
-                                .<Long, Long>chunk(
-                                        properties.getChunkSize(), transactionManager)
+                                .<Long, Long>chunk(properties.getChunkSize(), transactionManager)
                                 .reader(reader)
                                 .writer(writer)
                                 .listener(writer)

--- a/src/main/java/com/template/worker/jobs/recap/monthly/step/ProcessMonthlyFamilyRecapStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/step/ProcessMonthlyFamilyRecapStepConfig.java
@@ -8,8 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import com.template.worker.common.retry.BatchRetrySupport;
-import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapRow;
-import com.template.worker.jobs.recap.monthly.processor.MonthlyFamilyRecapProcessor;
 import com.template.worker.jobs.recap.monthly.reader.MonthlyFamilyRecapFamilyReader;
 import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapJobConstants;
 import com.template.worker.jobs.recap.monthly.support.MonthlyFamilyRecapProperties;
@@ -24,7 +22,6 @@ public class ProcessMonthlyFamilyRecapStepConfig {
     private final JobRepository jobRepository;
     private final PlatformTransactionManager transactionManager;
     private final MonthlyFamilyRecapFamilyReader reader;
-    private final MonthlyFamilyRecapProcessor processor;
     private final MonthlyFamilyRecapUpsertWriter writer;
     private final MonthlyFamilyRecapProperties properties;
     private final BatchRetrySupport batchRetrySupport;
@@ -37,11 +34,11 @@ public class ProcessMonthlyFamilyRecapStepConfig {
                         new StepBuilder(
                                         MonthlyFamilyRecapJobConstants.STEP_PROCESS_MONTHLY_RECAP,
                                         jobRepository)
-                                .<Long, MonthlyFamilyRecapRow>chunk(
+                                .<Long, Long>chunk(
                                         properties.getChunkSize(), transactionManager)
                                 .reader(reader)
-                                .processor(processor)
                                 .writer(writer)
+                                .listener(writer)
                                 .faultTolerant())
                 .build();
     }

--- a/src/main/java/com/template/worker/jobs/recap/monthly/writer/MonthlyFamilyRecapUpsertWriter.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/writer/MonthlyFamilyRecapUpsertWriter.java
@@ -1,7 +1,10 @@
 package com.template.worker.jobs.recap.monthly.writer;
 
 import java.sql.Date;
+import java.util.List;
 
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -10,12 +13,14 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Component;
 
 import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapRow;
+import com.template.worker.jobs.recap.monthly.processor.MonthlyFamilyRecapProcessor;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class MonthlyFamilyRecapUpsertWriter implements ItemWriter<MonthlyFamilyRecapRow> {
+public class MonthlyFamilyRecapUpsertWriter
+        implements ItemWriter<Long>, StepExecutionListener {
 
     // 월간 recap 결과를 family_id와 report_month 기준으로 업서트
     private static final String UPSERT_MONTHLY_RECAP_SQL =
@@ -64,16 +69,24 @@ public class MonthlyFamilyRecapUpsertWriter implements ItemWriter<MonthlyFamilyR
             """;
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final MonthlyFamilyRecapProcessor processor;
 
     @Override
-    public void write(Chunk<? extends MonthlyFamilyRecapRow> chunk) {
+    public void beforeStep(StepExecution stepExecution) {
+        processor.beforeStep(stepExecution);
+    }
+
+    @Override
+    public void write(Chunk<? extends Long> chunk) {
         if (chunk.isEmpty()) {
             return;
         }
 
+        List<MonthlyFamilyRecapRow> rows = processor.processAll(List.copyOf(chunk.getItems()));
+
         // 청크 아이템을 배치 파라미터로 변환
         SqlParameterSource[] batchParams =
-                chunk.getItems().stream()
+                rows.stream()
                         .map(this::toSqlParameterSource)
                         .toArray(SqlParameterSource[]::new);
 

--- a/src/main/java/com/template/worker/jobs/recap/monthly/writer/MonthlyFamilyRecapUpsertWriter.java
+++ b/src/main/java/com/template/worker/jobs/recap/monthly/writer/MonthlyFamilyRecapUpsertWriter.java
@@ -19,8 +19,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class MonthlyFamilyRecapUpsertWriter
-        implements ItemWriter<Long>, StepExecutionListener {
+public class MonthlyFamilyRecapUpsertWriter implements ItemWriter<Long>, StepExecutionListener {
 
     // 월간 recap 결과를 family_id와 report_month 기준으로 업서트
     private static final String UPSERT_MONTHLY_RECAP_SQL =
@@ -86,9 +85,7 @@ public class MonthlyFamilyRecapUpsertWriter
 
         // 청크 아이템을 배치 파라미터로 변환
         SqlParameterSource[] batchParams =
-                rows.stream()
-                        .map(this::toSqlParameterSource)
-                        .toArray(SqlParameterSource[]::new);
+                rows.stream().map(this::toSqlParameterSource).toArray(SqlParameterSource[]::new);
 
         // UNIQUE(family_id, report_month) 기준 멱등 업서트 실행
         jdbcTemplate.batchUpdate(UPSERT_MONTHLY_RECAP_SQL, batchParams);

--- a/src/main/java/com/template/worker/jobs/recap/weekly/processor/WeeklyFamilyRecapProcessor.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/processor/WeeklyFamilyRecapProcessor.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.StepExecutionListener;
@@ -45,10 +46,19 @@ public class WeeklyFamilyRecapProcessor
 
     @Override
     public WeeklyFamilyRecapRow process(Long familyId) {
-        // 가족별 원본 집계값을 조회
-        WeeklyFamilyRecapSourceMetrics sourceMetrics =
-                aggregationRepository.aggregate(familyId, weekStartDate);
+        return toRow(familyId, aggregationRepository.aggregate(familyId, weekStartDate));
+    }
 
+    public List<WeeklyFamilyRecapRow> processAll(List<Long> familyIds) {
+        Map<Long, WeeklyFamilyRecapSourceMetrics> sourceMetricsByFamily =
+                aggregationRepository.aggregate(familyIds, weekStartDate);
+
+        return familyIds.stream()
+                .map(familyId -> toRow(familyId, sourceMetricsByFamily.get(familyId)))
+                .collect(Collectors.toList());
+    }
+
+    private WeeklyFamilyRecapRow toRow(Long familyId, WeeklyFamilyRecapSourceMetrics sourceMetrics) {
         // writer 진입 전에 집계값 검증
         validateSourceMetrics(familyId, sourceMetrics);
 

--- a/src/main/java/com/template/worker/jobs/recap/weekly/processor/WeeklyFamilyRecapProcessor.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/processor/WeeklyFamilyRecapProcessor.java
@@ -7,7 +7,6 @@ import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.StepExecutionListener;
@@ -55,7 +54,7 @@ public class WeeklyFamilyRecapProcessor
 
         return familyIds.stream()
                 .map(familyId -> toRow(familyId, sourceMetricsByFamily.get(familyId)))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private WeeklyFamilyRecapRow toRow(

--- a/src/main/java/com/template/worker/jobs/recap/weekly/processor/WeeklyFamilyRecapProcessor.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/processor/WeeklyFamilyRecapProcessor.java
@@ -58,7 +58,8 @@ public class WeeklyFamilyRecapProcessor
                 .collect(Collectors.toList());
     }
 
-    private WeeklyFamilyRecapRow toRow(Long familyId, WeeklyFamilyRecapSourceMetrics sourceMetrics) {
+    private WeeklyFamilyRecapRow toRow(
+            Long familyId, WeeklyFamilyRecapSourceMetrics sourceMetrics) {
         // writer 진입 전에 집계값 검증
         validateSourceMetrics(familyId, sourceMetrics);
 

--- a/src/main/java/com/template/worker/jobs/recap/weekly/query/WeeklyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/query/WeeklyFamilyRecapAggregationRepository.java
@@ -176,7 +176,11 @@ public class WeeklyFamilyRecapAggregationRepository {
         applyUsageByWeekday(params, metricsByFamily);
         applyPeakUsage(params, metricsByFamily);
         applyQuota(params, metricsByFamily);
-        applyCount(READ_MISSION_CREATED_COUNT_SQL, "mission_created_count", params, metricsByFamily,
+        applyCount(
+                READ_MISSION_CREATED_COUNT_SQL,
+                "mission_created_count",
+                params,
+                metricsByFamily,
                 MutableWeeklyMetrics::setMissionCreatedCount);
         applyCount(
                 READ_MISSION_COMPLETED_COUNT_SQL,
@@ -239,7 +243,8 @@ public class WeeklyFamilyRecapAggregationRepository {
 
     private void applyTotalUsedBytes(
             MapSqlParameterSource params, Map<Long, MutableWeeklyMetrics> metricsByFamily) {
-        jdbcTemplate.queryForList(READ_TOTAL_USED_BYTES_SQL, params)
+        jdbcTemplate
+                .queryForList(READ_TOTAL_USED_BYTES_SQL, params)
                 .forEach(
                         row ->
                                 metricsByFamily
@@ -249,10 +254,12 @@ public class WeeklyFamilyRecapAggregationRepository {
 
     private void applyUsageByWeekday(
             MapSqlParameterSource params, Map<Long, MutableWeeklyMetrics> metricsByFamily) {
-        jdbcTemplate.queryForList(READ_USAGE_BY_WEEKDAY_SQL, params)
+        jdbcTemplate
+                .queryForList(READ_USAGE_BY_WEEKDAY_SQL, params)
                 .forEach(
                         row -> {
-                            MutableWeeklyMetrics metrics = metricsByFamily.get(toLong(row.get("family_id")));
+                            MutableWeeklyMetrics metrics =
+                                    metricsByFamily.get(toLong(row.get("family_id")));
                             metrics.usageBytesByWeekday.put(
                                     resolveWeekdayKey(toInt(row.get("day_of_week"))),
                                     toLong(row.get("total_bytes")));
@@ -261,23 +268,27 @@ public class WeeklyFamilyRecapAggregationRepository {
 
     private void applyPeakUsage(
             MapSqlParameterSource params, Map<Long, MutableWeeklyMetrics> metricsByFamily) {
-        jdbcTemplate.queryForList(READ_USAGE_BY_HOUR_SQL, params)
+        jdbcTemplate
+                .queryForList(READ_USAGE_BY_HOUR_SQL, params)
                 .forEach(
                         row -> {
-                            MutableWeeklyMetrics metrics = metricsByFamily.get(toLong(row.get("family_id")));
+                            MutableWeeklyMetrics metrics =
+                                    metricsByFamily.get(toLong(row.get("family_id")));
                             int startHour = toInt(row.get("start_hour"));
                             long peakBytes = toLong(row.get("peak_bytes"));
                             if (peakBytes > metrics.peakUsage.peakBytes()
                                     || (peakBytes == metrics.peakUsage.peakBytes()
                                             && startHour < metrics.peakUsage.startHour())) {
-                                metrics.peakUsage = new WeeklyPeakUsage(startHour, startHour + 1, peakBytes);
+                                metrics.peakUsage =
+                                        new WeeklyPeakUsage(startHour, startHour + 1, peakBytes);
                             }
                         });
     }
 
     private void applyQuota(
             MapSqlParameterSource params, Map<Long, MutableWeeklyMetrics> metricsByFamily) {
-        jdbcTemplate.queryForList(READ_TOTAL_QUOTA_BYTES_SQL, params)
+        jdbcTemplate
+                .queryForList(READ_TOTAL_QUOTA_BYTES_SQL, params)
                 .forEach(
                         row ->
                                 metricsByFamily
@@ -291,7 +302,8 @@ public class WeeklyFamilyRecapAggregationRepository {
             MapSqlParameterSource params,
             Map<Long, MutableWeeklyMetrics> metricsByFamily,
             CountApplier countApplier) {
-        jdbcTemplate.queryForList(sql, params)
+        jdbcTemplate
+                .queryForList(sql, params)
                 .forEach(
                         row ->
                                 countApplier.apply(

--- a/src/main/java/com/template/worker/jobs/recap/weekly/query/WeeklyFamilyRecapAggregationRepository.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/query/WeeklyFamilyRecapAggregationRepository.java
@@ -8,7 +8,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
@@ -22,231 +21,285 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WeeklyFamilyRecapAggregationRepository {
 
-    // 대상 주간의 총 사용량을 합산
     private static final String READ_TOTAL_USED_BYTES_SQL =
             """
-            SELECT COALESCE(SUM(bytes_used), 0)
+            SELECT family_id, COALESCE(SUM(bytes_used), 0) AS total_used_bytes
             FROM usage_record
-            WHERE family_id = :familyId
+            WHERE family_id IN (:familyIds)
               AND event_time >= :weekStart
               AND event_time < :weekEndExclusive
               AND deleted_at IS NULL
+            GROUP BY family_id
             """;
 
-    // 대상 주간의 요일별 사용량을 집계
     private static final String READ_USAGE_BY_WEEKDAY_SQL =
             """
-            SELECT DAYOFWEEK(event_time) AS day_of_week,
+            SELECT family_id,
+                   DAYOFWEEK(event_time) AS day_of_week,
                    COALESCE(SUM(bytes_used), 0) AS total_bytes
             FROM usage_record
-            WHERE family_id = :familyId
+            WHERE family_id IN (:familyIds)
               AND event_time >= :weekStart
               AND event_time < :weekEndExclusive
               AND deleted_at IS NULL
-            GROUP BY DAYOFWEEK(event_time)
+            GROUP BY family_id, DAYOFWEEK(event_time)
             """;
 
-    // 대상 주간에서 사용량이 가장 큰 시간대를 조회
-    private static final String READ_PEAK_USAGE_SQL =
+    private static final String READ_USAGE_BY_HOUR_SQL =
             """
-            SELECT HOUR(event_time) AS start_hour,
+            SELECT family_id,
+                   HOUR(event_time) AS start_hour,
                    COALESCE(SUM(bytes_used), 0) AS peak_bytes
             FROM usage_record
-            WHERE family_id = :familyId
+            WHERE family_id IN (:familyIds)
               AND event_time >= :weekStart
               AND event_time < :weekEndExclusive
               AND deleted_at IS NULL
-            GROUP BY HOUR(event_time)
-            ORDER BY peak_bytes DESC, start_hour ASC
-            LIMIT 1
+            GROUP BY family_id, HOUR(event_time)
             """;
 
-    // 대상 주가 속한 월의 family_quota 총량을 조회
     private static final String READ_TOTAL_QUOTA_BYTES_SQL =
             """
-            SELECT total_quota_bytes
+            SELECT family_id, total_quota_bytes
             FROM family_quota
-            WHERE family_id = :familyId
+            WHERE family_id IN (:familyIds)
               AND current_month = :quotaMonth
               AND deleted_at IS NULL
             """;
 
-    // 대상 주간에 생성된 미션 수를 집계
     private static final String READ_MISSION_CREATED_COUNT_SQL =
             """
-            SELECT COUNT(*)
+            SELECT family_id, COUNT(*) AS mission_created_count
             FROM mission_item
-            WHERE family_id = :familyId
+            WHERE family_id IN (:familyIds)
               AND created_at >= :weekStart
               AND created_at < :weekEndExclusive
               AND deleted_at IS NULL
+            GROUP BY family_id
             """;
 
-    // 대상 주간에 완료된 미션 수를 집계
     private static final String READ_MISSION_COMPLETED_COUNT_SQL =
             """
-            SELECT COUNT(*)
+            SELECT family_id, COUNT(*) AS mission_completed_count
             FROM mission_item
-            WHERE family_id = :familyId
+            WHERE family_id IN (:familyIds)
               AND status = 'COMPLETED'
               AND completed_at >= :weekStart
               AND completed_at < :weekEndExclusive
               AND deleted_at IS NULL
+            GROUP BY family_id
             """;
 
-    // 대상 주간에 반려된 미션 요청 수를 집계
     private static final String READ_MISSION_REJECTED_COUNT_SQL =
             """
-            SELECT COUNT(*)
+            SELECT mi.family_id, COUNT(*) AS mission_rejected_count
             FROM mission_request mr
             JOIN mission_item mi ON mr.mission_item_id = mi.id
-            WHERE mi.family_id = :familyId
+            WHERE mi.family_id IN (:familyIds)
               AND mr.status = 'REJECTED'
               AND mr.resolved_at >= :weekStart
               AND mr.resolved_at < :weekEndExclusive
               AND mr.deleted_at IS NULL
               AND mi.deleted_at IS NULL
+            GROUP BY mi.family_id
             """;
 
-    // 대상 주간에 생성된 NORMAL 이의제기 수를 집계
     private static final String READ_TOTAL_APPEAL_COUNT_SQL =
             """
-            SELECT COUNT(*)
+            SELECT pas.family_id, COUNT(*) AS total_appeal_count
             FROM policy_appeal pa
             JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
-            WHERE pas.family_id = :familyId
+            WHERE pas.family_id IN (:familyIds)
               AND pa.type = 'NORMAL'
               AND pa.created_at >= :weekStart
               AND pa.created_at < :weekEndExclusive
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
+            GROUP BY pas.family_id
             """;
 
-    // 대상 주간에 승인된 NORMAL 이의제기 수를 집계
     private static final String READ_APPROVED_APPEAL_COUNT_SQL =
             """
-            SELECT COUNT(*)
+            SELECT pas.family_id, COUNT(*) AS approved_appeal_count
             FROM policy_appeal pa
             JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
-            WHERE pas.family_id = :familyId
+            WHERE pas.family_id IN (:familyIds)
               AND pa.type = 'NORMAL'
               AND pa.status = 'APPROVED'
               AND pa.resolved_at >= :weekStart
               AND pa.resolved_at < :weekEndExclusive
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
+            GROUP BY pas.family_id
             """;
 
-    // 대상 주간에 반려된 NORMAL 이의제기 수를 집계
     private static final String READ_REJECTED_APPEAL_COUNT_SQL =
             """
-            SELECT COUNT(*)
+            SELECT pas.family_id, COUNT(*) AS rejected_appeal_count
             FROM policy_appeal pa
             JOIN policy_assignment pas ON pa.policy_assignment_id = pas.id
-            WHERE pas.family_id = :familyId
+            WHERE pas.family_id IN (:familyIds)
               AND pa.type = 'NORMAL'
               AND pa.status = 'REJECTED'
               AND pa.resolved_at >= :weekStart
               AND pa.resolved_at < :weekEndExclusive
               AND pa.deleted_at IS NULL
               AND pas.deleted_at IS NULL
+            GROUP BY pas.family_id
             """;
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
     public WeeklyFamilyRecapSourceMetrics aggregate(Long familyId, LocalDate weekStartDate) {
-        // 주간 집계 구간 고정
+        return aggregate(List.of(familyId), weekStartDate).get(familyId);
+    }
+
+    public Map<Long, WeeklyFamilyRecapSourceMetrics> aggregate(
+            List<Long> familyIds, LocalDate weekStartDate) {
+        if (familyIds.isEmpty()) {
+            return Map.of();
+        }
+
         LocalDateTime weekStart = weekStartDate.atStartOfDay();
         LocalDateTime weekEndExclusive = weekStart.plusDays(7);
 
         MapSqlParameterSource params =
                 new MapSqlParameterSource()
-                        .addValue("familyId", familyId)
+                        .addValue("familyIds", familyIds)
                         .addValue("quotaMonth", Date.valueOf(weekStartDate.withDayOfMonth(1)))
                         .addValue("weekStart", Timestamp.valueOf(weekStart))
                         .addValue("weekEndExclusive", Timestamp.valueOf(weekEndExclusive));
 
-        long totalUsedBytes = readLong(READ_TOTAL_USED_BYTES_SQL, params);
-        long totalQuotaBytes = readLong(READ_TOTAL_QUOTA_BYTES_SQL, params);
-        Map<String, Long> usageBytesByWeekday = readUsageByWeekday(params);
-        WeeklyPeakUsage peakUsage = readPeakUsage(params);
+        Map<Long, MutableWeeklyMetrics> metricsByFamily = initMetrics(familyIds);
 
-        int missionCreatedCount = readInt(READ_MISSION_CREATED_COUNT_SQL, params);
-        int missionCompletedCount = readInt(READ_MISSION_COMPLETED_COUNT_SQL, params);
-        int missionRejectedCount = readInt(READ_MISSION_REJECTED_COUNT_SQL, params);
-        int totalAppealCount = readInt(READ_TOTAL_APPEAL_COUNT_SQL, params);
-        int approvedAppealCount = readInt(READ_APPROVED_APPEAL_COUNT_SQL, params);
-        int rejectedAppealCount = readInt(READ_REJECTED_APPEAL_COUNT_SQL, params);
+        applyTotalUsedBytes(params, metricsByFamily);
+        applyUsageByWeekday(params, metricsByFamily);
+        applyPeakUsage(params, metricsByFamily);
+        applyQuota(params, metricsByFamily);
+        applyCount(READ_MISSION_CREATED_COUNT_SQL, "mission_created_count", params, metricsByFamily,
+                MutableWeeklyMetrics::setMissionCreatedCount);
+        applyCount(
+                READ_MISSION_COMPLETED_COUNT_SQL,
+                "mission_completed_count",
+                params,
+                metricsByFamily,
+                MutableWeeklyMetrics::setMissionCompletedCount);
+        applyCount(
+                READ_MISSION_REJECTED_COUNT_SQL,
+                "mission_rejected_count",
+                params,
+                metricsByFamily,
+                MutableWeeklyMetrics::setMissionRejectedCount);
+        applyCount(
+                READ_TOTAL_APPEAL_COUNT_SQL,
+                "total_appeal_count",
+                params,
+                metricsByFamily,
+                MutableWeeklyMetrics::setTotalAppealCount);
+        applyCount(
+                READ_APPROVED_APPEAL_COUNT_SQL,
+                "approved_appeal_count",
+                params,
+                metricsByFamily,
+                MutableWeeklyMetrics::setApprovedAppealCount);
+        applyCount(
+                READ_REJECTED_APPEAL_COUNT_SQL,
+                "rejected_appeal_count",
+                params,
+                metricsByFamily,
+                MutableWeeklyMetrics::setRejectedAppealCount);
 
-        return new WeeklyFamilyRecapSourceMetrics(
-                totalUsedBytes,
-                totalQuotaBytes,
-                usageBytesByWeekday,
-                peakUsage,
-                missionCreatedCount,
-                missionCompletedCount,
-                missionRejectedCount,
-                totalAppealCount,
-                approvedAppealCount,
-                rejectedAppealCount);
+        Map<Long, WeeklyFamilyRecapSourceMetrics> result = new LinkedHashMap<>();
+        for (Long familyId : familyIds) {
+            MutableWeeklyMetrics metrics = metricsByFamily.get(familyId);
+            result.put(
+                    familyId,
+                    new WeeklyFamilyRecapSourceMetrics(
+                            metrics.totalUsedBytes,
+                            metrics.totalQuotaBytes,
+                            metrics.usageBytesByWeekday,
+                            metrics.peakUsage,
+                            metrics.missionCreatedCount,
+                            metrics.missionCompletedCount,
+                            metrics.missionRejectedCount,
+                            metrics.totalAppealCount,
+                            metrics.approvedAppealCount,
+                            metrics.rejectedAppealCount));
+        }
+        return result;
     }
 
-    private long readLong(String sql, MapSqlParameterSource params) {
-        try {
-            Long value = jdbcTemplate.queryForObject(sql, params, Long.class);
-            return value == null ? 0L : value;
-        } catch (EmptyResultDataAccessException e) {
-            return 0L;
+    private Map<Long, MutableWeeklyMetrics> initMetrics(List<Long> familyIds) {
+        Map<Long, MutableWeeklyMetrics> metricsByFamily = new LinkedHashMap<>();
+        for (Long familyId : familyIds) {
+            metricsByFamily.put(familyId, new MutableWeeklyMetrics());
         }
+        return metricsByFamily;
     }
 
-    private int readInt(String sql, MapSqlParameterSource params) {
-        try {
-            Integer value = jdbcTemplate.queryForObject(sql, params, Integer.class);
-            return value == null ? 0 : value;
-        } catch (EmptyResultDataAccessException e) {
-            return 0;
-        }
+    private void applyTotalUsedBytes(
+            MapSqlParameterSource params, Map<Long, MutableWeeklyMetrics> metricsByFamily) {
+        jdbcTemplate.queryForList(READ_TOTAL_USED_BYTES_SQL, params)
+                .forEach(
+                        row ->
+                                metricsByFamily
+                                        .get(toLong(row.get("family_id")))
+                                        .setTotalUsedBytes(toLong(row.get("total_used_bytes"))));
     }
 
-    private Map<String, Long> readUsageByWeekday(MapSqlParameterSource params) {
-        // 요일별 기본값을 0으로 채움
-        Map<String, Long> usageByWeekday = new LinkedHashMap<>();
-        usageByWeekday.put("monday", 0L);
-        usageByWeekday.put("tuesday", 0L);
-        usageByWeekday.put("wednesday", 0L);
-        usageByWeekday.put("thursday", 0L);
-        usageByWeekday.put("friday", 0L);
-        usageByWeekday.put("saturday", 0L);
-        usageByWeekday.put("sunday", 0L);
-
-        List<Map<String, Object>> rows =
-                jdbcTemplate.queryForList(READ_USAGE_BY_WEEKDAY_SQL, params);
-        for (Map<String, Object> row : rows) {
-            int dayOfWeek = ((Number) row.get("day_of_week")).intValue();
-            long totalBytes = ((Number) row.get("total_bytes")).longValue();
-            usageByWeekday.put(resolveWeekdayKey(dayOfWeek), totalBytes);
-        }
-
-        return usageByWeekday;
+    private void applyUsageByWeekday(
+            MapSqlParameterSource params, Map<Long, MutableWeeklyMetrics> metricsByFamily) {
+        jdbcTemplate.queryForList(READ_USAGE_BY_WEEKDAY_SQL, params)
+                .forEach(
+                        row -> {
+                            MutableWeeklyMetrics metrics = metricsByFamily.get(toLong(row.get("family_id")));
+                            metrics.usageBytesByWeekday.put(
+                                    resolveWeekdayKey(toInt(row.get("day_of_week"))),
+                                    toLong(row.get("total_bytes")));
+                        });
     }
 
-    private WeeklyPeakUsage readPeakUsage(MapSqlParameterSource params) {
-        // 사용량이 가장 큰 시간대 1건만 선택
-        List<Map<String, Object>> rows = jdbcTemplate.queryForList(READ_PEAK_USAGE_SQL, params);
-        if (rows.isEmpty()) {
-            return new WeeklyPeakUsage(0, 1, 0L);
-        }
+    private void applyPeakUsage(
+            MapSqlParameterSource params, Map<Long, MutableWeeklyMetrics> metricsByFamily) {
+        jdbcTemplate.queryForList(READ_USAGE_BY_HOUR_SQL, params)
+                .forEach(
+                        row -> {
+                            MutableWeeklyMetrics metrics = metricsByFamily.get(toLong(row.get("family_id")));
+                            int startHour = toInt(row.get("start_hour"));
+                            long peakBytes = toLong(row.get("peak_bytes"));
+                            if (peakBytes > metrics.peakUsage.peakBytes()
+                                    || (peakBytes == metrics.peakUsage.peakBytes()
+                                            && startHour < metrics.peakUsage.startHour())) {
+                                metrics.peakUsage = new WeeklyPeakUsage(startHour, startHour + 1, peakBytes);
+                            }
+                        });
+    }
 
-        Map<String, Object> first = rows.get(0);
-        int startHour = ((Number) first.get("start_hour")).intValue();
-        long peakBytes = ((Number) first.get("peak_bytes")).longValue();
-        int endHour = startHour + 1;
-        return new WeeklyPeakUsage(startHour, endHour, peakBytes);
+    private void applyQuota(
+            MapSqlParameterSource params, Map<Long, MutableWeeklyMetrics> metricsByFamily) {
+        jdbcTemplate.queryForList(READ_TOTAL_QUOTA_BYTES_SQL, params)
+                .forEach(
+                        row ->
+                                metricsByFamily
+                                        .get(toLong(row.get("family_id")))
+                                        .setTotalQuotaBytes(toLong(row.get("total_quota_bytes"))));
+    }
+
+    private void applyCount(
+            String sql,
+            String countColumn,
+            MapSqlParameterSource params,
+            Map<Long, MutableWeeklyMetrics> metricsByFamily,
+            CountApplier countApplier) {
+        jdbcTemplate.queryForList(sql, params)
+                .forEach(
+                        row ->
+                                countApplier.apply(
+                                        metricsByFamily.get(toLong(row.get("family_id"))),
+                                        toInt(row.get(countColumn))));
     }
 
     private String resolveWeekdayKey(int dayOfWeek) {
-        // MySQL 요일 값을 응답용 키로 변환
         return switch (dayOfWeek) {
             case 1 -> "sunday";
             case 2 -> "monday";
@@ -257,5 +310,77 @@ public class WeeklyFamilyRecapAggregationRepository {
             case 7 -> "saturday";
             default -> throw new IllegalArgumentException("Unexpected day_of_week: " + dayOfWeek);
         };
+    }
+
+    private int toInt(Object value) {
+        return value instanceof Number numberValue ? numberValue.intValue() : 0;
+    }
+
+    private long toLong(Object value) {
+        return value instanceof Number numberValue ? numberValue.longValue() : 0L;
+    }
+
+    @FunctionalInterface
+    private interface CountApplier {
+        void apply(MutableWeeklyMetrics metrics, int value);
+    }
+
+    private static final class MutableWeeklyMetrics {
+
+        private final Map<String, Long> usageBytesByWeekday = initWeekdayUsageMap();
+
+        private long totalUsedBytes;
+        private long totalQuotaBytes;
+        private WeeklyPeakUsage peakUsage = new WeeklyPeakUsage(0, 1, 0L);
+        private int missionCreatedCount;
+        private int missionCompletedCount;
+        private int missionRejectedCount;
+        private int totalAppealCount;
+        private int approvedAppealCount;
+        private int rejectedAppealCount;
+
+        private void setTotalUsedBytes(long totalUsedBytes) {
+            this.totalUsedBytes = totalUsedBytes;
+        }
+
+        private void setTotalQuotaBytes(long totalQuotaBytes) {
+            this.totalQuotaBytes = totalQuotaBytes;
+        }
+
+        private void setMissionCreatedCount(int missionCreatedCount) {
+            this.missionCreatedCount = missionCreatedCount;
+        }
+
+        private void setMissionCompletedCount(int missionCompletedCount) {
+            this.missionCompletedCount = missionCompletedCount;
+        }
+
+        private void setMissionRejectedCount(int missionRejectedCount) {
+            this.missionRejectedCount = missionRejectedCount;
+        }
+
+        private void setTotalAppealCount(int totalAppealCount) {
+            this.totalAppealCount = totalAppealCount;
+        }
+
+        private void setApprovedAppealCount(int approvedAppealCount) {
+            this.approvedAppealCount = approvedAppealCount;
+        }
+
+        private void setRejectedAppealCount(int rejectedAppealCount) {
+            this.rejectedAppealCount = rejectedAppealCount;
+        }
+
+        private static Map<String, Long> initWeekdayUsageMap() {
+            Map<String, Long> usageByWeekday = new LinkedHashMap<>();
+            usageByWeekday.put("monday", 0L);
+            usageByWeekday.put("tuesday", 0L);
+            usageByWeekday.put("wednesday", 0L);
+            usageByWeekday.put("thursday", 0L);
+            usageByWeekday.put("friday", 0L);
+            usageByWeekday.put("saturday", 0L);
+            usageByWeekday.put("sunday", 0L);
+            return usageByWeekday;
+        }
     }
 }

--- a/src/main/java/com/template/worker/jobs/recap/weekly/step/ProcessWeeklyFamilyRecapStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/step/ProcessWeeklyFamilyRecapStepConfig.java
@@ -8,8 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import com.template.worker.common.retry.BatchRetrySupport;
-import com.template.worker.jobs.recap.weekly.model.WeeklyFamilyRecapRow;
-import com.template.worker.jobs.recap.weekly.processor.WeeklyFamilyRecapProcessor;
 import com.template.worker.jobs.recap.weekly.reader.WeeklyFamilyRecapFamilyReader;
 import com.template.worker.jobs.recap.weekly.support.WeeklyFamilyRecapJobConstants;
 import com.template.worker.jobs.recap.weekly.support.WeeklyFamilyRecapProperties;
@@ -24,7 +22,6 @@ public class ProcessWeeklyFamilyRecapStepConfig {
     private final JobRepository jobRepository;
     private final PlatformTransactionManager transactionManager;
     private final WeeklyFamilyRecapFamilyReader reader;
-    private final WeeklyFamilyRecapProcessor processor;
     private final WeeklyFamilyRecapUpsertWriter writer;
     private final WeeklyFamilyRecapProperties properties;
     private final BatchRetrySupport batchRetrySupport;
@@ -37,11 +34,11 @@ public class ProcessWeeklyFamilyRecapStepConfig {
                         new StepBuilder(
                                         WeeklyFamilyRecapJobConstants.STEP_PROCESS_WEEKLY_RECAP,
                                         jobRepository)
-                                .<Long, WeeklyFamilyRecapRow>chunk(
+                                .<Long, Long>chunk(
                                         properties.getChunkSize(), transactionManager)
                                 .reader(reader)
-                                .processor(processor)
                                 .writer(writer)
+                                .listener(writer)
                                 .faultTolerant())
                 .build();
     }

--- a/src/main/java/com/template/worker/jobs/recap/weekly/step/ProcessWeeklyFamilyRecapStepConfig.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/step/ProcessWeeklyFamilyRecapStepConfig.java
@@ -34,8 +34,7 @@ public class ProcessWeeklyFamilyRecapStepConfig {
                         new StepBuilder(
                                         WeeklyFamilyRecapJobConstants.STEP_PROCESS_WEEKLY_RECAP,
                                         jobRepository)
-                                .<Long, Long>chunk(
-                                        properties.getChunkSize(), transactionManager)
+                                .<Long, Long>chunk(properties.getChunkSize(), transactionManager)
                                 .reader(reader)
                                 .writer(writer)
                                 .listener(writer)

--- a/src/main/java/com/template/worker/jobs/recap/weekly/writer/WeeklyFamilyRecapUpsertWriter.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/writer/WeeklyFamilyRecapUpsertWriter.java
@@ -12,15 +12,14 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Component;
 
-import com.template.worker.jobs.recap.weekly.processor.WeeklyFamilyRecapProcessor;
 import com.template.worker.jobs.recap.weekly.model.WeeklyFamilyRecapRow;
+import com.template.worker.jobs.recap.weekly.processor.WeeklyFamilyRecapProcessor;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class WeeklyFamilyRecapUpsertWriter
-        implements ItemWriter<Long>, StepExecutionListener {
+public class WeeklyFamilyRecapUpsertWriter implements ItemWriter<Long>, StepExecutionListener {
 
     // 주간 recap 결과를 family_id와 week_start_date 기준으로 업서트
     private static final String UPSERT_WEEKLY_RECAP_SQL =
@@ -92,9 +91,7 @@ public class WeeklyFamilyRecapUpsertWriter
 
         // 청크 아이템을 배치 파라미터로 변환
         SqlParameterSource[] batchParams =
-                rows.stream()
-                        .map(this::toSqlParameterSource)
-                        .toArray(SqlParameterSource[]::new);
+                rows.stream().map(this::toSqlParameterSource).toArray(SqlParameterSource[]::new);
 
         // UNIQUE(family_id, week_start_date) 기준 멱등 업서트 실행
         jdbcTemplate.batchUpdate(UPSERT_WEEKLY_RECAP_SQL, batchParams);

--- a/src/main/java/com/template/worker/jobs/recap/weekly/writer/WeeklyFamilyRecapUpsertWriter.java
+++ b/src/main/java/com/template/worker/jobs/recap/weekly/writer/WeeklyFamilyRecapUpsertWriter.java
@@ -1,7 +1,10 @@
 package com.template.worker.jobs.recap.weekly.writer;
 
 import java.sql.Date;
+import java.util.List;
 
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -9,13 +12,15 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Component;
 
+import com.template.worker.jobs.recap.weekly.processor.WeeklyFamilyRecapProcessor;
 import com.template.worker.jobs.recap.weekly.model.WeeklyFamilyRecapRow;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class WeeklyFamilyRecapUpsertWriter implements ItemWriter<WeeklyFamilyRecapRow> {
+public class WeeklyFamilyRecapUpsertWriter
+        implements ItemWriter<Long>, StepExecutionListener {
 
     // 주간 recap 결과를 family_id와 week_start_date 기준으로 업서트
     private static final String UPSERT_WEEKLY_RECAP_SQL =
@@ -70,16 +75,24 @@ public class WeeklyFamilyRecapUpsertWriter implements ItemWriter<WeeklyFamilyRec
             """;
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final WeeklyFamilyRecapProcessor processor;
 
     @Override
-    public void write(Chunk<? extends WeeklyFamilyRecapRow> chunk) {
+    public void beforeStep(StepExecution stepExecution) {
+        processor.beforeStep(stepExecution);
+    }
+
+    @Override
+    public void write(Chunk<? extends Long> chunk) {
         if (chunk.isEmpty()) {
             return;
         }
 
+        List<WeeklyFamilyRecapRow> rows = processor.processAll(List.copyOf(chunk.getItems()));
+
         // 청크 아이템을 배치 파라미터로 변환
         SqlParameterSource[] batchParams =
-                chunk.getItems().stream()
+                rows.stream()
                         .map(this::toSqlParameterSource)
                         .toArray(SqlParameterSource[]::new);
 

--- a/src/main/resources/batch.yml
+++ b/src/main/resources/batch.yml
@@ -34,12 +34,12 @@ batch:
   jobs:
     weekly-family-recap:
       lock-ttl: ${BATCH_WEEKLY_FAMILY_RECAP_LOCK_TTL:PT1H}
-      chunk-size: ${BATCH_WEEKLY_FAMILY_RECAP_CHUNK_SIZE:500}
-      db-fetch-size: ${BATCH_WEEKLY_FAMILY_RECAP_DB_FETCH_SIZE:1000}
+      chunk-size: ${BATCH_WEEKLY_FAMILY_RECAP_CHUNK_SIZE:1000}
+      db-fetch-size: ${BATCH_WEEKLY_FAMILY_RECAP_DB_FETCH_SIZE:4000}
     monthly-family-recap:
       lock-ttl: ${BATCH_MONTHLY_FAMILY_RECAP_LOCK_TTL:PT1H}
-      chunk-size: ${BATCH_MONTHLY_FAMILY_RECAP_CHUNK_SIZE:500}
-      db-fetch-size: ${BATCH_MONTHLY_FAMILY_RECAP_DB_FETCH_SIZE:1000}
+      chunk-size: ${BATCH_MONTHLY_FAMILY_RECAP_CHUNK_SIZE:1000}
+      db-fetch-size: ${BATCH_MONTHLY_FAMILY_RECAP_DB_FETCH_SIZE:4000}
     monthly-usage-precreate:
       lock-ttl: ${BATCH_MONTHLY_USAGE_PRECREATE_LOCK_TTL:PT1H}
       db-fetch-size: ${BATCH_MONTHLY_USAGE_PRECREATE_DB_FETCH_SIZE:4000}

--- a/src/test/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepositoryTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepositoryTest.java
@@ -172,37 +172,41 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
         assertThat(result.partialUsageMetrics().usageBytesByWeekday())
                 .containsEntry("sunday", 300L)
                 .containsEntry("tuesday", 300L);
-        assertThat(result.partialUsageMetrics().peakUsageCandidate().startHour()).isEqualTo(22);
-        assertThat(result.partialUsageMetrics().peakUsageCandidate().peakBytes()).isEqualTo(500L);
+        assertThat(result.partialUsageMetrics().peakUsageCandidate())
+                .extracting("startHour", "peakBytes")
+                .containsExactly(22, 500L);
 
-        assertThat(result.missionSummary().totalMissionCount()).isEqualTo(3);
-        assertThat(result.missionSummary().completedMissionCount()).isEqualTo(2);
-        assertThat(result.missionSummary().rejectedRequestCount()).isEqualTo(1);
+        assertThat(result.missionSummary())
+                .extracting("totalMissionCount", "completedMissionCount", "rejectedRequestCount")
+                .containsExactly(3, 2, 1);
         assertThat(result.missionCarryInCount()).isEqualTo(1);
 
-        assertThat(result.appealSummary().totalAppeals()).isEqualTo(4);
-        assertThat(result.appealSummary().approvedAppeals()).isEqualTo(3);
-        assertThat(result.appealSummary().rejectedAppeals()).isEqualTo(1);
+        assertThat(result.appealSummary())
+                .extracting("totalAppeals", "approvedAppeals", "rejectedAppeals")
+                .containsExactly(4, 3, 1);
         assertThat(result.appealCarryInCount()).isEqualTo(1);
 
         MonthlyAppealHighlights.TopSuccessfulRequester topRequester =
                 result.appealHighlights().topSuccessfulRequester();
-        assertThat(topRequester.requesterId()).isEqualTo(101L);
-        assertThat(topRequester.requesterName()).isEqualTo("김민지");
-        assertThat(topRequester.approvedAppealCount()).isEqualTo(3);
+        assertThat(topRequester)
+                .extracting("requesterId", "requesterName", "approvedAppealCount")
+                .containsExactly(101L, "김민지", 3);
         assertThat(topRequester.recentApprovedAppeals())
                 .extracting(MonthlyAppealHighlights.RecentApprovedAppeal::appealId)
                 .containsExactly(87L, 83L, 70L);
 
         MonthlyAppealHighlights.TopAcceptedApprover topApprover =
                 result.appealHighlights().topAcceptedApprover();
-        assertThat(topApprover.approverId()).isEqualTo(201L);
-        assertThat(topApprover.approvedAppealCount()).isEqualTo(3);
+        assertThat(topApprover)
+                .extracting("approverId", "approvedAppealCount")
+                .containsExactly(201L, 3);
         assertThat(topApprover.recentAcceptedAppeals())
                 .extracting(MonthlyAppealHighlights.RecentAcceptedAppeal::appealId)
                 .containsExactly(87L, 83L, 70L);
         assertThat(bulkResult).containsKey(1L);
-        assertThat(bulkResult.get(1L).partialUsageMetrics().totalUsedBytes()).isEqualTo(600L);
+        assertThat(bulkResult.get(1L))
+                .extracting(metrics -> metrics.partialUsageMetrics().totalUsedBytes())
+                .isEqualTo(600L);
     }
 
     @Test

--- a/src/test/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepositoryTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/monthly/query/MonthlyFamilyRecapAggregationRepositoryTest.java
@@ -3,6 +3,8 @@ package com.template.worker.jobs.recap.monthly.query;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 
 import javax.sql.DataSource;
 
@@ -160,6 +162,8 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
                     + " 11:00:00', NULL)");
 
         MonthlyFamilyRecapSourceMetrics result = repository.aggregate(1L, LocalDate.of(2026, 3, 1));
+        Map<Long, MonthlyFamilyRecapSourceMetrics> bulkResult =
+                repository.aggregate(List.of(1L), LocalDate.of(2026, 3, 1));
 
         assertThat(result.fullWeekSnapshots()).hasSize(2);
         assertThat(result.fullWeekSnapshots().get(0).approvedAppealCount()).isEqualTo(2);
@@ -197,6 +201,8 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
         assertThat(topApprover.recentAcceptedAppeals())
                 .extracting(MonthlyAppealHighlights.RecentAcceptedAppeal::appealId)
                 .containsExactly(87L, 83L, 70L);
+        assertThat(bulkResult).containsKey(1L);
+        assertThat(bulkResult.get(1L).partialUsageMetrics().totalUsedBytes()).isEqualTo(600L);
     }
 
     @Test
@@ -210,6 +216,8 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
                     + " used_bytes, deleted_at) VALUES (2, 2, DATE '2026-03-01', 7000, 0, NULL)");
 
         MonthlyFamilyRecapSourceMetrics result = repository.aggregate(2L, LocalDate.of(2026, 3, 1));
+        Map<Long, MonthlyFamilyRecapSourceMetrics> bulkResult =
+                repository.aggregate(List.of(2L), LocalDate.of(2026, 3, 1));
 
         assertThat(result.fullWeekSnapshots()).isEmpty();
         assertThat(result.totalQuotaBytes()).isEqualTo(7000L);
@@ -218,6 +226,7 @@ class MonthlyFamilyRecapAggregationRepositoryTest {
         assertThat(result.appealCarryInCount()).isZero();
         assertThat(result.appealHighlights().topSuccessfulRequester().requesterId()).isNull();
         assertThat(result.appealHighlights().topAcceptedApprover().approverId()).isNull();
+        assertThat(bulkResult.get(2L).totalQuotaBytes()).isEqualTo(7000L);
     }
 
     private DataSource createDataSource() {

--- a/src/test/java/com/template/worker/jobs/recap/monthly/writer/MonthlyFamilyRecapUpsertWriterTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/monthly/writer/MonthlyFamilyRecapUpsertWriterTest.java
@@ -1,6 +1,8 @@
 package com.template.worker.jobs.recap.monthly.writer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -15,11 +17,13 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
 import com.template.worker.jobs.recap.monthly.model.MonthlyFamilyRecapRow;
+import com.template.worker.jobs.recap.monthly.processor.MonthlyFamilyRecapProcessor;
 
 class MonthlyFamilyRecapUpsertWriterTest {
 
     private JdbcTemplate jdbcTemplate;
     private MonthlyFamilyRecapUpsertWriter writer;
+    private MonthlyFamilyRecapProcessor processor;
 
     @BeforeEach
     void setUp() {
@@ -30,7 +34,8 @@ class MonthlyFamilyRecapUpsertWriterTest {
         dataSource.setPassword("");
 
         jdbcTemplate = new JdbcTemplate(dataSource);
-        writer = new MonthlyFamilyRecapUpsertWriter(new NamedParameterJdbcTemplate(dataSource));
+        processor = mock(MonthlyFamilyRecapProcessor.class);
+        writer = new MonthlyFamilyRecapUpsertWriter(new NamedParameterJdbcTemplate(dataSource), processor);
 
         jdbcTemplate.execute("DROP TABLE IF EXISTS family_recap_monthly");
         jdbcTemplate.execute(
@@ -86,8 +91,10 @@ class MonthlyFamilyRecapUpsertWriterTest {
                         "{\"topSuccessfulRequester\":{},\"topAcceptedApprover\":{}}",
                         new BigDecimal("88.88"));
 
-        writer.write(new Chunk<>(List.of(firstRow)));
-        writer.write(new Chunk<>(List.of(secondRow)));
+        when(processor.processAll(List.of(10L))).thenReturn(List.of(firstRow), List.of(secondRow));
+
+        writer.write(new Chunk<>(List.of(10L)));
+        writer.write(new Chunk<>(List.of(10L)));
 
         Integer rowCount =
                 jdbcTemplate.queryForObject(

--- a/src/test/java/com/template/worker/jobs/recap/monthly/writer/MonthlyFamilyRecapUpsertWriterTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/monthly/writer/MonthlyFamilyRecapUpsertWriterTest.java
@@ -35,7 +35,9 @@ class MonthlyFamilyRecapUpsertWriterTest {
 
         jdbcTemplate = new JdbcTemplate(dataSource);
         processor = mock(MonthlyFamilyRecapProcessor.class);
-        writer = new MonthlyFamilyRecapUpsertWriter(new NamedParameterJdbcTemplate(dataSource), processor);
+        writer =
+                new MonthlyFamilyRecapUpsertWriter(
+                        new NamedParameterJdbcTemplate(dataSource), processor);
 
         jdbcTemplate.execute("DROP TABLE IF EXISTS family_recap_monthly");
         jdbcTemplate.execute(

--- a/src/test/java/com/template/worker/jobs/recap/weekly/query/WeeklyFamilyRecapAggregationRepositoryTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/weekly/query/WeeklyFamilyRecapAggregationRepositoryTest.java
@@ -3,6 +3,8 @@ package com.template.worker.jobs.recap.weekly.query;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 
 import javax.sql.DataSource;
 
@@ -94,6 +96,8 @@ class WeeklyFamilyRecapAggregationRepositoryTest {
                     + " NULL, TIMESTAMP '2026-03-10 11:00:00', NULL)");
 
         WeeklyFamilyRecapSourceMetrics result = repository.aggregate(1L, LocalDate.of(2026, 3, 9));
+        Map<Long, WeeklyFamilyRecapSourceMetrics> bulkResult =
+                repository.aggregate(List.of(1L), LocalDate.of(2026, 3, 9));
 
         assertThat(result.totalUsedBytes()).isEqualTo(100L);
         assertThat(result.totalQuotaBytes()).isEqualTo(5000L);
@@ -103,6 +107,8 @@ class WeeklyFamilyRecapAggregationRepositoryTest {
         assertThat(result.totalAppealCount()).isEqualTo(4);
         assertThat(result.approvedAppealCount()).isEqualTo(2);
         assertThat(result.rejectedAppealCount()).isEqualTo(1);
+        assertThat(bulkResult).containsKey(1L);
+        assertThat(bulkResult.get(1L).missionRejectedCount()).isEqualTo(1);
     }
 
     private DataSource createDataSource() {

--- a/src/test/java/com/template/worker/jobs/recap/weekly/step/ProcessWeeklyFamilyRecapStepConfigTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/weekly/step/ProcessWeeklyFamilyRecapStepConfigTest.java
@@ -99,6 +99,7 @@ class ProcessWeeklyFamilyRecapStepConfigTest {
 
         assertThat(stepExecution.getStatus()).isEqualTo(BatchStatus.FAILED);
     }
+
     private StepExecution createStepExecution(String stepName) {
         JobExecution jobExecution =
                 new JobExecution(

--- a/src/test/java/com/template/worker/jobs/recap/weekly/step/ProcessWeeklyFamilyRecapStepConfigTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/weekly/step/ProcessWeeklyFamilyRecapStepConfigTest.java
@@ -7,8 +7,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.DisplayName;
@@ -25,8 +23,6 @@ import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.transaction.PlatformTransactionManager;
 
 import com.template.worker.common.retry.BatchRetrySupport;
-import com.template.worker.jobs.recap.weekly.model.WeeklyFamilyRecapRow;
-import com.template.worker.jobs.recap.weekly.processor.WeeklyFamilyRecapProcessor;
 import com.template.worker.jobs.recap.weekly.reader.WeeklyFamilyRecapFamilyReader;
 import com.template.worker.jobs.recap.weekly.support.WeeklyFamilyRecapProperties;
 import com.template.worker.jobs.recap.weekly.writer.WeeklyFamilyRecapUpsertWriter;
@@ -39,7 +35,6 @@ class ProcessWeeklyFamilyRecapStepConfigTest {
         JobRepository jobRepository = mock(JobRepository.class);
         PlatformTransactionManager transactionManager = new ResourcelessTransactionManager();
         WeeklyFamilyRecapFamilyReader reader = mock(WeeklyFamilyRecapFamilyReader.class);
-        WeeklyFamilyRecapProcessor processor = mock(WeeklyFamilyRecapProcessor.class);
         WeeklyFamilyRecapUpsertWriter writer = mock(WeeklyFamilyRecapUpsertWriter.class);
         WeeklyFamilyRecapProperties properties = new WeeklyFamilyRecapProperties();
         properties.setChunkSize(2);
@@ -49,13 +44,11 @@ class ProcessWeeklyFamilyRecapStepConfigTest {
                         jobRepository,
                         transactionManager,
                         reader,
-                        processor,
                         writer,
                         properties,
                         new BatchRetrySupport(3, 0L));
 
         when(reader.read()).thenReturn(10L, (Long) null);
-        when(processor.process(10L)).thenReturn(createRow());
 
         AtomicInteger attempts = new AtomicInteger();
         doAnswer(
@@ -83,7 +76,6 @@ class ProcessWeeklyFamilyRecapStepConfigTest {
         JobRepository jobRepository = mock(JobRepository.class);
         PlatformTransactionManager transactionManager = new ResourcelessTransactionManager();
         WeeklyFamilyRecapFamilyReader reader = mock(WeeklyFamilyRecapFamilyReader.class);
-        WeeklyFamilyRecapProcessor processor = mock(WeeklyFamilyRecapProcessor.class);
         WeeklyFamilyRecapUpsertWriter writer = mock(WeeklyFamilyRecapUpsertWriter.class);
         WeeklyFamilyRecapProperties properties = new WeeklyFamilyRecapProperties();
         properties.setChunkSize(2);
@@ -93,13 +85,11 @@ class ProcessWeeklyFamilyRecapStepConfigTest {
                         jobRepository,
                         transactionManager,
                         reader,
-                        processor,
                         writer,
                         properties,
                         new BatchRetrySupport(3, 0L));
 
         when(reader.read()).thenReturn(10L, (Long) null);
-        when(processor.process(10L)).thenReturn(createRow());
         doThrow(new PessimisticLockingFailureException("deadlock", null)).when(writer).write(any());
 
         Step step = stepConfig.processWeeklyFamilyRecapStep();
@@ -109,24 +99,6 @@ class ProcessWeeklyFamilyRecapStepConfigTest {
 
         assertThat(stepExecution.getStatus()).isEqualTo(BatchStatus.FAILED);
     }
-
-    private WeeklyFamilyRecapRow createRow() {
-        return new WeeklyFamilyRecapRow(
-                10L,
-                LocalDate.of(2026, 3, 9),
-                100L,
-                1000L,
-                new BigDecimal("10.00"),
-                "{}",
-                "{}",
-                1,
-                1,
-                0,
-                1,
-                1,
-                0);
-    }
-
     private StepExecution createStepExecution(String stepName) {
         JobExecution jobExecution =
                 new JobExecution(

--- a/src/test/java/com/template/worker/jobs/recap/weekly/writer/WeeklyFamilyRecapUpsertWriterTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/weekly/writer/WeeklyFamilyRecapUpsertWriterTest.java
@@ -35,7 +35,9 @@ class WeeklyFamilyRecapUpsertWriterTest {
 
         jdbcTemplate = new JdbcTemplate(dataSource);
         processor = mock(WeeklyFamilyRecapProcessor.class);
-        writer = new WeeklyFamilyRecapUpsertWriter(new NamedParameterJdbcTemplate(dataSource), processor);
+        writer =
+                new WeeklyFamilyRecapUpsertWriter(
+                        new NamedParameterJdbcTemplate(dataSource), processor);
 
         jdbcTemplate.execute("DROP TABLE IF EXISTS family_recap_weekly");
         jdbcTemplate.execute(

--- a/src/test/java/com/template/worker/jobs/recap/weekly/writer/WeeklyFamilyRecapUpsertWriterTest.java
+++ b/src/test/java/com/template/worker/jobs/recap/weekly/writer/WeeklyFamilyRecapUpsertWriterTest.java
@@ -1,6 +1,8 @@
 package com.template.worker.jobs.recap.weekly.writer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -15,11 +17,13 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
 import com.template.worker.jobs.recap.weekly.model.WeeklyFamilyRecapRow;
+import com.template.worker.jobs.recap.weekly.processor.WeeklyFamilyRecapProcessor;
 
 class WeeklyFamilyRecapUpsertWriterTest {
 
     private JdbcTemplate jdbcTemplate;
     private WeeklyFamilyRecapUpsertWriter writer;
+    private WeeklyFamilyRecapProcessor processor;
 
     @BeforeEach
     void setUp() {
@@ -30,7 +34,8 @@ class WeeklyFamilyRecapUpsertWriterTest {
         dataSource.setPassword("");
 
         jdbcTemplate = new JdbcTemplate(dataSource);
-        writer = new WeeklyFamilyRecapUpsertWriter(new NamedParameterJdbcTemplate(dataSource));
+        processor = mock(WeeklyFamilyRecapProcessor.class);
+        writer = new WeeklyFamilyRecapUpsertWriter(new NamedParameterJdbcTemplate(dataSource), processor);
 
         jdbcTemplate.execute("DROP TABLE IF EXISTS family_recap_weekly");
         jdbcTemplate.execute(
@@ -96,8 +101,10 @@ class WeeklyFamilyRecapUpsertWriterTest {
                         2,
                         1);
 
-        writer.write(new Chunk<>(List.of(firstRow)));
-        writer.write(new Chunk<>(List.of(secondRow)));
+        when(processor.processAll(List.of(10L))).thenReturn(List.of(firstRow), List.of(secondRow));
+
+        writer.write(new Chunk<>(List.of(10L)));
+        writer.write(new Chunk<>(List.of(10L)));
 
         Integer rowCount =
                 jdbcTemplate.queryForObject(


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

<!-- 이슈 넘버와 티켓 넘버를 작성해주세요. 이슈가 닫히는 것을 원치 않으면 closed:를 지워주세요 -->

- closed: #28 
- jira: DABOM-514

---

## 🎯 목적

<!-- 왜 이 변경이 필요한지 배경과 목적을 작성해주세요. -->
`weekly-family-recap-job`과 `monthly-family-recap-job`의 병목은 `familyId` 1건마다 집계 SQL을 반복 호출하는 구조였다.  
이번 변경은 `batch-core` 기준으로 리캡 집계를 chunk 단위 벌크 조회로 전환해, 운영 데이터 스케일에서 배치 처리 시간을 줄이기 위한 목적이다.

## 📝 변경 사항

<!-- 무엇을 변경했는지 리스트로 작성해주세요. -->

- `weekly-family-recap-job`
  - `WeeklyFamilyRecapAggregationRepository`에 `aggregate(List<Long>, weekStartDate)` 벌크 집계 추가
  - step에서 `processor` 단건 처리 대신 writer가 chunk 전체 `familyIds`를 받아 벌크 집계 후 batch upsert 하도록 변경
  - `WeeklyFamilyRecapProcessor`는 기존 단건 `process()`를 유지하면서 `processAll()` 벌크 조립 메서드 추가
- `monthly-family-recap-job`
  - `MonthlyFamilyRecapAggregationRepository`를 `familyIds` 기준 벌크 집계 구조로 리팩터링
  - full weekly snapshot, partial raw usage/mission/appeal, carry-in, appeal highlights를 chunk 단위로 한 번에 조회하도록 변경
  - `MonthlyFamilyRecapProcessor`에 `processAll()` 벌크 조립 메서드 추가
  - writer가 chunk 전체를 받아 벌크 집계 후 batch upsert 하도록 변경
- 배치 설정 조정
  - `batch.yml`에서 weekly/monthly recap의 `chunk-size`, `db-fetch-size` 기본값 상향
- 테스트 갱신
  - writer 테스트를 chunk `familyIds` 입력 구조에 맞게 수정
  - repository 테스트에 벌크 집계 경로 검증 추가


## 📂 변경 범위

<!-- 변경된 레이어를 표시해주세요. 해당 항목에 [x]로 체크해주세요. -->

| Job | api (controller/service/dto) | job config | step config | reader | processor | writer | global (config/launcher/listener) |
| :-: | :--------------------------: | :--------: | :---------: | :----: | :-------: | :----: | :-------------------------------: |
| weekly-family-recap / monthly-family-recap | | | [x] | | [x] | [x] | [x] |

---

## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. 단순 변경이면 섹션을 지워도 됩니다. -->

```java
@Override
public void write(Chunk<? extends Long> chunk) {
    if (chunk.isEmpty()) {
        return;
    }

    List<MonthlyFamilyRecapRow> rows = processor.processAll(List.copyOf(chunk.getItems()));
    SqlParameterSource[] batchParams =
            rows.stream().map(this::toSqlParameterSource).toArray(SqlParameterSource[]::new);

    jdbcTemplate.batchUpdate(UPSERT_MONTHLY_RECAP_SQL, batchParams);
}
```

기존에는 `familyId` 1건마다 `processor -> repository.aggregate(familyId, ...)` 구조로 반복 집계했다.  
변경 후에는 writer가 chunk 전체 `familyIds`를 받아 `processAll()`로 벌크 집계 결과를 조립하고, upsert만 한 번에 수행한다.

## 💬 리뷰어에게

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- writer가 chunk 단위 집계 조립까지 담당하게 되면서 책임 경계가 기존보다 두꺼워졌습니다. 리캡 배치 성능 개선을 우선한 구조 변경이라, 이 부분을 특히 봐주시면 됩니다.
- 월간 리캡의 appeal highlights는 per-family 쿼리 반복 대신 월간 승인 appeal 원본을 한 번에 읽어 메모리에서 가족별로 조립하도록 바꿨습니다.
---

## 📋 체크리스트

<!-- PR 제출 전 확인해주세요. 해당 항목에 [x]로 체크해주세요. -->

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [ ] 전체 변경사항이 500줄을 넘지 않는가?

**배치 코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → BatchJobLauncher → Job → Step → Reader/Processor/Writer`)
- [x] 모든 Job에 `JobResultListener`를 등록했는가?
- [x] Reader/Processor/Writer가 각각 단일 책임만 수행하는가?
- [x] Job/Step 이름이 kebab-case인가?
- [x] 하나의 Config 파일에 하나의 Job/Step만 정의했는가?

**테스트**
- [x] 신규 배치 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

<!-- 추가로 공유할 내용이 있으면 작성해주세요. (관련 문서 링크, 후속 작업 등) -->
